### PR TITLE
Refactor SQLModel Query Patterns for Consistency and Simplicity

### DIFF
--- a/src/local_newsifier/crud/analysis_result.py
+++ b/src/local_newsifier/crud/analysis_result.py
@@ -23,8 +23,9 @@ class CRUDAnalysisResult(CRUDBase[AnalysisResult]):
         Returns:
             List of analysis results for the article
         """
-        statement = select(AnalysisResult).where(AnalysisResult.article_id == article_id)
-        results = db.execute(statement).all()
+        results = db.execute(select(AnalysisResult).where(
+            AnalysisResult.article_id == article_id
+        )).all()
         return [row[0] for row in results]
 
     def get_by_article_and_type(
@@ -40,12 +41,10 @@ class CRUDAnalysisResult(CRUDBase[AnalysisResult]):
         Returns:
             Analysis result if found, None otherwise
         """
-        statement = select(AnalysisResult).where(
+        result = db.execute(select(AnalysisResult).where(
             AnalysisResult.article_id == article_id,
             AnalysisResult.analysis_type == analysis_type
-        )
-        results = db.execute(statement)
-        result = results.first()
+        )).first()
         return result[0] if result else None
 
 

--- a/src/local_newsifier/crud/article.py
+++ b/src/local_newsifier/crud/article.py
@@ -67,8 +67,7 @@ class CRUDArticle(CRUDBase[Article]):
         Returns:
             Updated article if found, None otherwise
         """
-        statement = select(Article).where(Article.id == article_id)
-        db_article = db.exec(statement).first()
+        db_article = db.exec(select(Article).where(Article.id == article_id)).first()
         
         if db_article:
             db_article.status = status
@@ -88,8 +87,7 @@ class CRUDArticle(CRUDBase[Article]):
         Returns:
             List of articles with the specified status
         """
-        statement = select(Article).where(Article.status == status)
-        return db.exec(statement).all()
+        return db.exec(select(Article).where(Article.status == status)).all()
         
     def get_by_date_range(
         self, 
@@ -110,19 +108,19 @@ class CRUDArticle(CRUDBase[Article]):
         Returns:
             List of articles within the date range
         """
-        statement = select(Article).where(
+        query = select(Article).where(
             Article.published_at >= start_date,
             Article.published_at <= end_date
         )
         
         # Add source filter if provided
         if source:
-            statement = statement.where(Article.source == source)
+            query = query.where(Article.source == source)
             
         # Order by published date
-        statement = statement.order_by(Article.published_at)
+        query = query.order_by(Article.published_at)
         
-        return db.exec(statement).all()
+        return db.exec(query).all()
 
 
 article = CRUDArticle(Article)

--- a/src/local_newsifier/crud/base.py
+++ b/src/local_newsifier/crud/base.py
@@ -29,9 +29,7 @@ class CRUDBase(Generic[ModelType]):
         Returns:
             The item if found, None otherwise
         """
-        statement = select(self.model).where(self.model.id == id)
-        results = db.exec(statement)
-        return results.first()
+        return db.exec(select(self.model).where(self.model.id == id)).first()
 
     def get_multi(
         self, db: Session, *, skip: int = 0, limit: int = 100
@@ -46,8 +44,7 @@ class CRUDBase(Generic[ModelType]):
         Returns:
             List of items
         """
-        statement = select(self.model).offset(skip).limit(limit)
-        return db.exec(statement).all()
+        return db.exec(select(self.model).offset(skip).limit(limit)).all()
 
     def create(
         self, db: Session, *, obj_in: Union[Dict[str, Any], ModelType]
@@ -115,8 +112,7 @@ class CRUDBase(Generic[ModelType]):
         Returns:
             Removed item if found, None otherwise
         """
-        statement = select(self.model).where(self.model.id == id)
-        db_obj = db.exec(statement).first()
+        db_obj = db.exec(select(self.model).where(self.model.id == id)).first()
         if db_obj:
             db.delete(db_obj)
             db.commit()

--- a/src/local_newsifier/crud/canonical_entity.py
+++ b/src/local_newsifier/crud/canonical_entity.py
@@ -26,12 +26,10 @@ class CRUDCanonicalEntity(CRUDBase[CanonicalEntity]):
         Returns:
             Canonical entity if found, None otherwise
         """
-        statement = select(CanonicalEntity).where(
+        result = db.execute(select(CanonicalEntity).where(
             CanonicalEntity.name == name,
             CanonicalEntity.entity_type == entity_type
-        )
-        results = db.execute(statement)
-        result = results.first()
+        )).first()
         return result[0] if result else None
 
     def get_by_type(
@@ -46,10 +44,9 @@ class CRUDCanonicalEntity(CRUDBase[CanonicalEntity]):
         Returns:
             List of canonical entities
         """
-        statement = select(CanonicalEntity).where(
+        results = db.execute(select(CanonicalEntity).where(
             CanonicalEntity.entity_type == entity_type
-        )
-        results = db.execute(statement).all()
+        )).all()
         return [row[0] for row in results]
 
     def get_all(
@@ -64,10 +61,10 @@ class CRUDCanonicalEntity(CRUDBase[CanonicalEntity]):
         Returns:
             List of canonical entities
         """
-        statement = select(CanonicalEntity)
+        query = select(CanonicalEntity)
         if entity_type:
-            statement = statement.where(CanonicalEntity.entity_type == entity_type)
-        results = db.execute(statement).all()
+            query = query.where(CanonicalEntity.entity_type == entity_type)
+        results = db.execute(query).all()
         return [row[0] for row in results]
 
     def get_mentions_count(self, db: Session, *, entity_id: int) -> int:
@@ -149,15 +146,13 @@ class CRUDCanonicalEntity(CRUDBase[CanonicalEntity]):
         Returns:
             List of articles mentioning the entity
         """
-        statement = select(Article).join(
+        results = db.execute(select(Article).join(
             EntityMention, Article.id == EntityMention.article_id
         ).where(
             EntityMention.canonical_entity_id == entity_id,
             Article.published_at >= start_date,
             Article.published_at <= end_date
-        )
-        
-        results = db.execute(statement).all()
+        )).all()
         return [row[0] for row in results]
 
 

--- a/src/local_newsifier/crud/entity.py
+++ b/src/local_newsifier/crud/entity.py
@@ -23,8 +23,7 @@ class CRUDEntity(CRUDBase[Entity]):
         Returns:
             List of entities for the article
         """
-        statement = select(Entity).where(Entity.article_id == article_id)
-        results = db.execute(statement).all()
+        results = db.execute(select(Entity).where(Entity.article_id == article_id)).all()
         return [row[0] for row in results]
 
     def get_by_text_and_article(
@@ -40,11 +39,9 @@ class CRUDEntity(CRUDBase[Entity]):
         Returns:
             Entity if found, None otherwise
         """
-        statement = select(Entity).where(
+        result = db.execute(select(Entity).where(
             Entity.text == text, Entity.article_id == article_id
-        )
-        results = db.execute(statement)
-        result = results.first()
+        )).first()
         return result[0] if result else None
         
     def get_by_date_range_and_types(

--- a/src/local_newsifier/crud/entity_mention_context.py
+++ b/src/local_newsifier/crud/entity_mention_context.py
@@ -26,12 +26,10 @@ class CRUDEntityMentionContext(CRUDBase[EntityMentionContext]):
         Returns:
             Entity mention context if found, None otherwise
         """
-        statement = select(EntityMentionContext).where(
+        result = db.execute(select(EntityMentionContext).where(
             EntityMentionContext.entity_id == entity_id,
             EntityMentionContext.article_id == article_id
-        )
-        results = db.execute(statement)
-        result = results.first()
+        )).first()
         return result[0] if result else None
 
     def get_by_entity(
@@ -46,10 +44,9 @@ class CRUDEntityMentionContext(CRUDBase[EntityMentionContext]):
         Returns:
             List of entity mention contexts
         """
-        statement = select(EntityMentionContext).where(
+        results = db.execute(select(EntityMentionContext).where(
             EntityMentionContext.entity_id == entity_id
-        )
-        results = db.execute(statement).all()
+        )).all()
         return [row[0] for row in results]
 
     def get_sentiment_trend(

--- a/src/local_newsifier/crud/entity_profile.py
+++ b/src/local_newsifier/crud/entity_profile.py
@@ -24,11 +24,9 @@ class CRUDEntityProfile(CRUDBase[EntityProfile]):
         Returns:
             Entity profile if found, None otherwise
         """
-        statement = select(EntityProfile).where(
+        result = db.execute(select(EntityProfile).where(
             EntityProfile.canonical_entity_id == entity_id
-        )
-        results = db.execute(statement)
-        result = results.first()
+        )).first()
         return result[0] if result else None
 
     def get_by_entity_and_type(
@@ -44,12 +42,10 @@ class CRUDEntityProfile(CRUDBase[EntityProfile]):
         Returns:
             Entity profile if found, None otherwise
         """
-        statement = select(EntityProfile).where(
+        result = db.execute(select(EntityProfile).where(
             EntityProfile.canonical_entity_id == entity_id,
             EntityProfile.profile_type == profile_type
-        )
-        results = db.execute(statement)
-        result = results.first()
+        )).first()
         return result[0] if result else None
 
     def create(

--- a/src/local_newsifier/crud/entity_relationship.py
+++ b/src/local_newsifier/crud/entity_relationship.py
@@ -49,10 +49,9 @@ class CRUDEntityRelationship:
         Returns:
             List of entity relationships
         """
-        statement = select(EntityRelationship).where(
+        return db.exec(select(EntityRelationship).where(
             EntityRelationship.source_entity_id == source_entity_id
-        )
-        return db.exec(statement).all()
+        )).all()
 
     def create_or_update(
         self, db: Session, *, obj_in: Union[EntityRelationship, Dict[str, Any]]


### PR DESCRIPTION
## Problem

The current database query code in the CRUD modules was unnecessarily verbose. Many query operations followed this pattern:

```python
statement = select(Model).where(condition)
results = db.exec(statement)
return results.first()  # or .all() for multiple results
```

This created extra variables and made the code harder to read.

## Solution

Refactored all CRUD methods to use the more concise SQLModel pattern:

```python
return db.exec(select(Model).where(condition)).first()  # or .all()
```

## Changes

- Refactored base CRUDBase class to use simplified query pattern
- Updated entity_mention_context.py methods to use chained style
- Updated entity_relationship.py methods for consistency
- Refactored canonical_entity.py query patterns
- Simplified article.py query methods
- Updated entity.py query methods
- Refactored analysis_result.py for consistency
- Updated entity_profile.py methods

## Testing

All tests are passing (313 passed, 1 skipped). No functionality changes made, only code style improvements.

## Benefits

- More readable code
- Fewer variables
- More consistent patterns
- Easier to maintain
- Better align with SQLModel's design principles

Closes #63
