### PR TITLE
Improve error handling in RSS parser

### DIFF
--- a/src/local_newsifier/tools/rss_parser.py
+++ b/src/local_newsifier/tools/rss_parser.py
@@ -4,16 +4,39 @@ RSS Parser Tool for extracting URLs and titles from RSS feeds.
 
 import json
 import logging
+import time
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Tuple
 from xml.etree import ElementTree
+from xml.etree.ElementTree import ParseError
 
 import requests
 from dateutil import parser as date_parser
 from pydantic import BaseModel
+from requests.exceptions import RequestException, Timeout, HTTPError, ConnectionError
 
 logger = logging.getLogger(__name__)
+
+
+class RSSParsingError(Exception):
+    """Exception raised for RSS parsing errors."""
+    
+    def __init__(self, message: str, feed_url: str, error_type: str, original_error: Optional[Exception] = None):
+        """
+        Initialize with error context.
+        
+        Args:
+            message: Error message
+            feed_url: URL of the RSS feed that failed
+            error_type: Type of error (network, parsing, etc.)
+            original_error: Original exception that caused this error
+        """
+        self.feed_url = feed_url
+        self.error_type = error_type
+        self.original_error = original_error
+        self.timestamp = datetime.now()
+        super().__init__(message)
 
 
 class RSSItem(BaseModel):
@@ -28,14 +51,16 @@ class RSSItem(BaseModel):
 class RSSParser:
     """Tool for parsing RSS feeds and extracting content."""
 
-    def __init__(self, cache_file: Optional[str] = None):
+    def __init__(self, cache_file: Optional[str] = None, max_retries: int = 3):
         """
         Initialize the RSS parser.
 
         Args:
             cache_file: Optional path to a JSON file to cache processed URLs
+            max_retries: Maximum number of retry attempts for network errors
         """
         self.cache_file = cache_file
+        self.max_retries = max_retries
         self.processed_urls = self._load_cache() if cache_file else set()
 
     def _load_cache(self) -> set:
@@ -75,6 +100,94 @@ class RSSParser:
                 return elem.text
         return None
 
+    def _fetch_feed_with_retry(self, feed_url: str) -> Tuple[bytes, bool]:
+        """
+        Fetch the feed with retry logic for transient errors.
+        
+        Args:
+            feed_url: URL of the feed to fetch
+            
+        Returns:
+            Tuple of (content, success_flag)
+            
+        Raises:
+            RSSParsingError: If the feed couldn't be fetched after retries
+        """
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                response = requests.get(feed_url, timeout=30)
+                response.raise_for_status()
+                return response.content, True
+            except Timeout as e:
+                logger.warning(f"Timeout fetching feed {feed_url} (attempt {attempt}/{self.max_retries}): {e}")
+                if attempt < self.max_retries:
+                    # Exponential backoff
+                    wait_time = 2 ** attempt
+                    logger.info(f"Retrying in {wait_time} seconds...")
+                    time.sleep(wait_time)
+                else:
+                    raise RSSParsingError(
+                        f"Timeout fetching feed after {self.max_retries} attempts", 
+                        feed_url=feed_url,
+                        error_type="network_timeout",
+                        original_error=e
+                    )
+            except HTTPError as e:
+                status_code = e.response.status_code if hasattr(e, 'response') else "unknown"
+                # Don't retry client errors (4xx) except for 429 (Too Many Requests)
+                if 400 <= status_code < 500 and status_code != 429:
+                    raise RSSParsingError(
+                        f"HTTP error {status_code} fetching feed", 
+                        feed_url=feed_url,
+                        error_type=f"http_{status_code}",
+                        original_error=e
+                    )
+                logger.warning(f"HTTP error fetching feed {feed_url} (attempt {attempt}/{self.max_retries}): {e}")
+                if attempt < self.max_retries:
+                    wait_time = 2 ** attempt
+                    logger.info(f"Retrying in {wait_time} seconds...")
+                    time.sleep(wait_time)
+                else:
+                    raise RSSParsingError(
+                        f"HTTP error fetching feed after {self.max_retries} attempts", 
+                        feed_url=feed_url,
+                        error_type="network_http_error",
+                        original_error=e
+                    )
+            except ConnectionError as e:
+                logger.warning(f"Connection error fetching feed {feed_url} (attempt {attempt}/{self.max_retries}): {e}")
+                if attempt < self.max_retries:
+                    wait_time = 2 ** attempt
+                    logger.info(f"Retrying in {wait_time} seconds...")
+                    time.sleep(wait_time)
+                else:
+                    raise RSSParsingError(
+                        f"Connection error fetching feed after {self.max_retries} attempts", 
+                        feed_url=feed_url,
+                        error_type="network_connection_error",
+                        original_error=e
+                    )
+            except RequestException as e:
+                logger.warning(f"Request error fetching feed {feed_url} (attempt {attempt}/{self.max_retries}): {e}")
+                if attempt < self.max_retries:
+                    wait_time = 2 ** attempt
+                    logger.info(f"Retrying in {wait_time} seconds...")
+                    time.sleep(wait_time)
+                else:
+                    raise RSSParsingError(
+                        f"Request error fetching feed after {self.max_retries} attempts", 
+                        feed_url=feed_url,
+                        error_type="network_request_error",
+                        original_error=e
+                    )
+        
+        # Should never reach here due to the raises above, but just in case
+        raise RSSParsingError(
+            f"Failed to fetch feed after {self.max_retries} attempts for unknown reason", 
+            feed_url=feed_url,
+            error_type="network_unknown_error"
+        )
+
     def parse_feed(self, feed_url: str) -> List[RSSItem]:
         """
         Parse an RSS feed and extract items.
@@ -84,14 +197,27 @@ class RSSParser:
 
         Returns:
             List of RSSItem objects containing the feed content
+            
+        Raises:
+            RSSParsingError: If the feed couldn't be parsed
         """
         try:
-            # Fetch the feed
-            response = requests.get(feed_url)
-            response.raise_for_status()
+            # Fetch the feed with retry logic
+            content, success = self._fetch_feed_with_retry(feed_url)
+            if not success:
+                return []
 
-            # Parse the XML
-            root = ElementTree.fromstring(response.content)
+            try:
+                # Parse the XML
+                root = ElementTree.fromstring(content)
+            except ParseError as e:
+                logger.error(f"XML parsing error in feed {feed_url}: {e}")
+                raise RSSParsingError(
+                    f"XML parsing error: {str(e)}", 
+                    feed_url=feed_url,
+                    error_type="xml_parse_error",
+                    original_error=e
+                )
 
             # Handle both RSS and Atom feeds
             if root.tag.endswith("rss"):
@@ -103,7 +229,11 @@ class RSSParser:
 
             if not entries:
                 logger.error(f"No entries found in feed: {feed_url}")
-                return []
+                raise RSSParsingError(
+                    "No entries found in feed", 
+                    feed_url=feed_url,
+                    error_type="empty_feed"
+                )
 
             items = []
             for entry in entries:
@@ -126,6 +256,7 @@ class RSSParser:
                             url = link_elem.get("href")
 
                     if not url:
+                        logger.debug(f"Skipping entry without URL in feed {feed_url}")
                         continue
 
                     # Extract published date
@@ -140,7 +271,7 @@ class RSSParser:
                         try:
                             published = date_parser.parse(date_text)
                         except Exception as e:
-                            logger.warning(f"Could not parse date: {e}")
+                            logger.warning(f"Could not parse date '{date_text}': {e}")
 
                     # Extract description
                     description = self._get_element_text(
@@ -163,10 +294,22 @@ class RSSParser:
                     logger.error(f"Error parsing entry in feed {feed_url}: {e}")
                     continue
 
+            if not items:
+                logger.warning(f"No valid items found in feed: {feed_url}")
+                
             return items
+            
+        except RSSParsingError:
+            # Re-raise RSSParsingError exceptions
+            raise
         except Exception as e:
-            logger.error(f"Error parsing feed {feed_url}: {e}")
-            return []
+            logger.error(f"Unexpected error parsing feed {feed_url}: {e}")
+            raise RSSParsingError(
+                f"Unexpected error: {str(e)}", 
+                feed_url=feed_url,
+                error_type="unexpected_error",
+                original_error=e
+            )
 
     def get_new_urls(self, feed_url: str) -> List[RSSItem]:
         """
@@ -178,15 +321,22 @@ class RSSParser:
         Returns:
             List of RSSItem objects containing only new content
         """
-        items = self.parse_feed(feed_url)
-        new_items = [item for item in items if item.url not in self.processed_urls]
+        try:
+            items = self.parse_feed(feed_url)
+            new_items = [item for item in items if item.url not in self.processed_urls]
 
-        # Update cache with new URLs
-        self.processed_urls.update(item.url for item in new_items)
-        if self.cache_file:
-            self._save_cache()
+            # Update cache with new URLs
+            self.processed_urls.update(item.url for item in new_items)
+            if self.cache_file:
+                self._save_cache()
 
-        return new_items
+            return new_items
+        except RSSParsingError as e:
+            logger.error(f"Failed to get new URLs from feed {feed_url}: {e}")
+            return []
+        except Exception as e:
+            logger.error(f"Unexpected error getting new URLs from feed {feed_url}: {e}")
+            return []
 
 
 # Global parser instance
@@ -230,11 +380,31 @@ def parse_rss_feed(feed_url: str) -> Dict[str, Any]:
             "feed_url": feed_url,
             "entries": entries,
         }
+    except RSSParsingError as e:
+        # Structured error response for RSS parsing errors
+        logger.error(f"RSS parsing error for {feed_url}: {str(e)}")
+        return {
+            "title": "Error parsing feed",
+            "feed_url": feed_url,
+            "entries": [],
+            "error": {
+                "message": str(e),
+                "type": e.error_type,
+                "timestamp": e.timestamp.isoformat(),
+                "feed_url": e.feed_url
+            }
+        }
     except Exception as e:
+        # Generic error fallback
         logger.error(f"Error parsing RSS feed {feed_url}: {str(e)}")
         return {
             "title": "Error parsing feed",
             "feed_url": feed_url,
             "entries": [],
-            "error": str(e)
+            "error": {
+                "message": str(e),
+                "type": "unknown_error",
+                "timestamp": datetime.now().isoformat(),
+                "feed_url": feed_url
+            }
         }


### PR DESCRIPTION
## Overview

This PR adds improved error handling to the RSS parser module, aligning with the broader effort to standardize error handling (ref: issues #75-80). It focuses specifically on providing more detailed error information and better logging when RSS feeds fail to parse.

## Changes

1. Added a new `RSSParsingError` exception class:
   - Captures feed URL, error type, and original exception
   - Provides timestamp and contextual information 
   - Enables better error handling by callers

2. Added retry logic with exponential backoff for transient network issues:
   - Implementing exponential backoff (wait time doubles with each retry)
   - Adding specific handling for different HTTP error codes
   - Properly logging each retry attempt
   - Configurable max retry attempts

3. Enhanced error details in return value:
   - When a feed fails to parse, providing structured error information
   - Including error type, message, and timestamp in return value
   - Allowing callers to better handle different error types

4. More specific exception handling:
   - Handling XML parsing errors separately from network errors
   - Different handling for client errors (4xx) vs server errors (5xx)
   - Better logging with error context

## Testing

The changes have been tested with several error scenarios:
- Network timeout errors
- XML parsing errors (malformed feeds)
- HTTP error responses (404, 500, etc.)
- Connection failures

All scenarios now provide consistent error information and appropriate logging.

## Related Issues

- Part of the broader error handling standardization effort (#75)
- Addresses inconsistent error handling in RSS parsing mentioned in #96

## Notes

This is an incremental improvement that doesn't yet integrate with the new error hierarchy from PR #69. Once that PR is merged, we can update this code to use the new standard error types.
