### PR TITLE
Register all tool classes in DI container

### DIFF
--- a/docs/dependency_injection_tools.md
+++ b/docs/dependency_injection_tools.md
@@ -1,0 +1,338 @@
+# Tool Registration in Dependency Injection Container
+
+This document provides guidelines for registering tool classes in the dependency injection container and using them consistently throughout the application.
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Naming Conventions](#naming-conventions)
+3. [Registration Patterns](#registration-patterns)
+4. [Using Container-Provided Tools](#using-container-provided-tools)
+5. [Testing](#testing)
+
+## Overview
+
+All tool classes are now registered in the dependency injection container to provide:
+- Centralized management of tool instances
+- Consistent access patterns
+- Configurable initialization
+- Clear dependency relationships
+- Improved testability
+
+Tools are organized into three main categories:
+1. **Core Tools** - Basic utilities like web scraping and file handling
+2. **Analysis Tools** - Specialized analysis functionality like trend analysis and sentiment analysis
+3. **Entity Tools** - Entity extraction, resolution, and tracking
+
+## Naming Conventions
+
+### Standard Tool Names
+
+Tools registered in the container follow this naming pattern:
+
+- Standard name: `{tool_name}_tool`
+- Example: `web_scraper_tool`, `rss_parser_tool`, `trend_analyzer_tool`
+
+### Backward Compatibility
+
+For backward compatibility with existing code, each tool is also registered with a legacy name:
+
+- Legacy name: `{tool_name}` (without the _tool suffix)
+- Example: `web_scraper`, `rss_parser`, `trend_analyzer`
+
+This dual registration allows gradual migration to the new naming scheme without breaking existing code.
+
+## Registration Patterns
+
+Tool registration is handled in the `container.py` module, which initializes the DI container and registers all services and dependencies. Tools are registered in three dedicated functions:
+
+### 1. Core Tools Registration
+
+```python
+def register_core_tools(container):
+    """Register core tool classes in the container."""
+    try:
+        from local_newsifier.tools.web_scraper import WebScraperTool
+        from local_newsifier.tools.rss_parser import RSSParser
+        from local_newsifier.tools.file_writer import FileWriterTool
+        
+        # Register tools with standard names and configurable parameters
+        container.register_factory_with_params(
+            "web_scraper_tool", 
+            lambda c, **kwargs: WebScraperTool(
+                user_agent=kwargs.get("user_agent")
+            )
+        )
+        
+        # Backward compatibility registration
+        container.register_factory(
+            "web_scraper", 
+            lambda c: c.get("web_scraper_tool")
+        )
+        
+        # More tool registrations...
+    except ImportError as e:
+        # Log error but continue initialization
+        print(f"Error registering core tools: {e}")
+```
+
+### 2. Analysis Tools Registration
+
+```python
+def register_analysis_tools(container):
+    """Register analysis tools in the container."""
+    try:
+        # Import and register trend analysis, sentiment analysis, and other tools
+        from local_newsifier.tools.analysis.trend_analyzer import TrendAnalyzer
+        # More imports...
+        
+        container.register_factory(
+            "trend_analyzer_tool", 
+            lambda c: TrendAnalyzer()
+        )
+        
+        # Tools with session dependency
+        container.register_factory_with_params(
+            "sentiment_analyzer_tool", 
+            lambda c, **kwargs: SentimentAnalysisTool(
+                session=kwargs.get("session")
+            )
+        )
+        
+        # Backward compatibility...
+    except ImportError as e:
+        # Log error but continue initialization
+        print(f"Error registering analysis tools: {e}")
+```
+
+### 3. Entity Tools Registration
+
+```python
+def register_entity_tools(container):
+    """Register entity-related tools in the container."""
+    try:
+        # Import and register entity extraction, resolution, and tracking tools
+        from local_newsifier.tools.extraction.entity_extractor import EntityExtractor
+        # More imports...
+        
+        container.register_factory(
+            "entity_extractor_tool", 
+            lambda c: EntityExtractor()
+        )
+        
+        # Backward compatibility...
+    except ImportError as e:
+        # Log error but continue initialization
+        print(f"Error registering entity tools: {e}")
+```
+
+## Tool Registration Strategies
+
+### Simple Factory Registration
+
+For tools without dependencies or configuration options:
+
+```python
+container.register_factory(
+    "tool_name_tool", 
+    lambda c: ToolClass()
+)
+```
+
+### Parameterized Factory Registration
+
+For tools with configuration options or dependencies:
+
+```python
+container.register_factory_with_params(
+    "tool_name_tool", 
+    lambda c, **kwargs: ToolClass(
+        param1=kwargs.get("param1", default_value),
+        param2=kwargs.get("param2")
+    )
+)
+```
+
+### Dependency Injection Configuration
+
+For tools that require other services:
+
+```python
+container.register_factory(
+    "tool_name_tool", 
+    lambda c: ToolClass(
+        dependency1=c.get("other_service"),
+        dependency2=c.get("another_service")
+    )
+)
+```
+
+## Using Container-Provided Tools
+
+### Direct Access Pattern
+
+For simple tool access without parameters:
+
+```python
+from local_newsifier.container import container
+
+def some_function():
+    # Get a tool instance
+    web_scraper = container.get("web_scraper_tool")
+    
+    # Use the tool
+    result = web_scraper.scrape_url("https://example.com")
+```
+
+### Parameterized Access Pattern
+
+For tools that need runtime configuration:
+
+```python
+from local_newsifier.container import container
+
+def some_function():
+    # Get a tool instance with specific parameters
+    file_writer = container.get("file_writer_tool", output_dir="custom_output")
+    
+    # Use the tool
+    file_writer.save(state)
+```
+
+### Service Constructor Injection Pattern
+
+The preferred pattern is to accept dependencies in service constructors:
+
+```python
+class NewsService:
+    def __init__(
+        self, 
+        web_scraper=None, 
+        rss_parser=None,
+        container=None
+    ):
+        self.container = container
+        
+        # Prefer passed dependencies
+        self.web_scraper = web_scraper
+        self.rss_parser = rss_parser
+        
+    def _ensure_dependencies(self):
+        """Ensure all dependencies are available."""
+        if self.web_scraper is None and self.container:
+            self.web_scraper = self.container.get("web_scraper_tool")
+            
+        if self.rss_parser is None and self.container:
+            self.rss_parser = self.container.get("rss_parser_tool")
+```
+
+### Constructor Registration Pattern
+
+When registering services that use tools:
+
+```python
+# Register a service that uses tools
+container.register_factory(
+    "news_service", 
+    lambda c: NewsService(
+        web_scraper=c.get("web_scraper_tool"),
+        rss_parser=c.get("rss_parser_tool"),
+        container=c  # For lazy resolution of other dependencies
+    )
+)
+```
+
+## Testing
+
+### Mocking Container-Provided Tools
+
+When testing code that uses container-provided tools:
+
+```python
+@patch("local_newsifier.container.container.get")
+def test_function_with_container_tools(mock_container_get):
+    # Setup the mock
+    mock_tool = Mock()
+    mock_tool.some_method.return_value = expected_result
+    
+    # Configure the mock to return our mock tool when requested
+    mock_container_get.side_effect = lambda name, **kwargs: {
+        "tool_name_tool": mock_tool
+    }.get(name)
+    
+    # Call the function under test
+    result = function_to_test()
+    
+    # Assertions
+    mock_container_get.assert_called_with("tool_name_tool")
+    mock_tool.some_method.assert_called_once()
+    assert result == expected_result
+```
+
+### Testing Services with Container Injection
+
+When testing services that use the container:
+
+```python
+def test_service_with_container():
+    # Create a mock container
+    mock_container = Mock()
+    mock_tool = Mock()
+    
+    # Configure the mock container
+    mock_container.get.side_effect = lambda name, **kwargs: {
+        "tool_name_tool": mock_tool
+    }.get(name)
+    
+    # Create the service with the mock container
+    service = MyService(container=mock_container)
+    
+    # Call method that uses a tool
+    service.method_that_needs_tool()
+    
+    # Verify
+    mock_container.get.assert_called_with("tool_name_tool")
+    mock_tool.some_method.assert_called_once()
+```
+
+## Guidelines for Adding New Tools
+
+When adding a new tool to the system:
+
+1. Implement the tool class with a clear, focused responsibility
+2. Follow the naming convention (verb + noun + Tool)
+3. Register the tool in the appropriate function in container.py
+4. Add both standard (_tool suffix) and backward compatibility registrations
+5. Add appropriate tests for tool registration
+6. Update documentation if the tool introduces new patterns or concepts
+
+Example of adding a new tool:
+
+```python
+# 1. Implement the tool
+# in local_newsifier/tools/text_summarizer.py
+class TextSummarizerTool:
+    def __init__(self, max_length=100):
+        self.max_length = max_length
+        
+    def summarize(self, text):
+        # Implementation...
+        return summary
+
+# 2. Register the tool in container.py
+from local_newsifier.tools.text_summarizer import TextSummarizerTool
+
+# In register_analysis_tools function:
+container.register_factory_with_params(
+    "text_summarizer_tool",
+    lambda c, **kwargs: TextSummarizerTool(
+        max_length=kwargs.get("max_length", 100)
+    )
+)
+
+# Backward compatibility
+container.register_factory(
+    "text_summarizer",
+    lambda c: c.get("text_summarizer_tool")
+)
+
+# 3. Add tests in tests/utils/test_tool_registration.py

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -6,8 +6,17 @@
 - Database schema management with Alembic
 - SQLAlchemy session management in asynchronous tasks
 - Resolving circular dependencies with dependency injection
+- Standardizing all tool registrations in the dependency injection container
 
 ## Recent Changes
+- Registered all tool classes in the dependency injection container
+  - Created standardized organization with dedicated registration functions
+  - Implemented consistent naming conventions with *_tool suffix
+  - Added backward compatibility registrations to maintain existing code
+  - Used factory methods for configurable tool initialization
+  - Added comprehensive tests for tool registration in tests/utils/test_tool_registration.py
+  - Created documentation for tool registration patterns in docs/dependency_injection_tools.md
+
 - Implemented dependency injection container pattern
   - Created DIContainer class with service registration and resolution
   - Added container initialization module that registers all services

--- a/src/local_newsifier/container.py
+++ b/src/local_newsifier/container.py
@@ -25,25 +25,6 @@ from local_newsifier.crud import (
 from local_newsifier.services.article_service import ArticleService
 from local_newsifier.services.rss_feed_service import RSSFeedService
 
-# Import flow classes if they exist
-try:
-    from local_newsifier.flows.entity_tracking_flow import EntityTrackingFlow
-    from local_newsifier.flows.news_pipeline import NewsPipelineFlow
-    from local_newsifier.flows.trend_analysis_flow import TrendAnalysisFlow
-    from local_newsifier.flows.public_opinion_flow import PublicOpinionFlow
-    from local_newsifier.flows.rss_scraping_flow import RSSScrapingFlow
-    FLOWS_AVAILABLE = True
-except ImportError:
-    FLOWS_AVAILABLE = False
-
-# Import tool classes if they exist 
-try:
-    from local_newsifier.tools.rss_parser import RSSParser
-    from local_newsifier.tools.web_scraper import WebScraper
-    TOOLS_AVAILABLE = True
-except ImportError:
-    TOOLS_AVAILABLE = False
-
 
 def init_container(environment="production"):
     """Initialize and configure the dependency injection container.
@@ -79,15 +60,214 @@ def init_container(environment="production"):
         container.register_factory("session_factory", 
                                 lambda c: SessionManager)
     
-    # Register tools if available
-    if TOOLS_AVAILABLE:
-        container.register_factory("rss_parser", 
-                                 lambda c: RSSParser())
-        container.register_factory("web_scraper", 
-                                 lambda c: WebScraper())
+    # Register Core Tools
+    register_core_tools(container)
+    
+    # Register Analysis Tools
+    register_analysis_tools(container)
+    
+    # Register Entity Tools
+    register_entity_tools(container)
     
     # Register services - use factories to handle circular dependencies
+    register_services(container)
     
+    # Register flow services
+    register_flows(container)
+    
+    # Register parameterized factories
+    container.register_factory_with_params("entity_service_with_params",
+        lambda c, **kwargs: kwargs.get("entity_service") or c.get("entity_service")
+    )
+    
+    container.register_factory_with_params("article_service_with_params",
+        lambda c, **kwargs: kwargs.get("article_service") or c.get("article_service")
+    )
+    
+    # Environment-specific configurations
+    if environment == "development":
+        # Development-specific registrations
+        pass
+    elif environment == "testing":
+        # Testing-specific registrations
+        pass
+    
+    return container
+
+
+def register_core_tools(container):
+    """Register core tool classes in the container.
+    
+    Args:
+        container: The DI container instance
+    """
+    # Import core tools
+    try:
+        from local_newsifier.tools.web_scraper import WebScraperTool
+        from local_newsifier.tools.rss_parser import RSSParser
+        from local_newsifier.tools.file_writer import FileWriterTool
+        
+        # Register web_scraper_tool with configurable user_agent
+        container.register_factory_with_params(
+            "web_scraper_tool", 
+            lambda c, **kwargs: WebScraperTool(
+                user_agent=kwargs.get("user_agent")
+            )
+        )
+        
+        # Register rss_parser_tool with configurable cache_file
+        container.register_factory_with_params(
+            "rss_parser_tool", 
+            lambda c, **kwargs: RSSParser(
+                cache_file=kwargs.get("cache_file")
+            )
+        )
+        
+        # Register file_writer_tool with configurable output_dir
+        container.register_factory_with_params(
+            "file_writer_tool", 
+            lambda c, **kwargs: FileWriterTool(
+                output_dir=kwargs.get("output_dir", "output")
+            )
+        )
+        
+        # Backward compatibility registrations
+        container.register_factory("web_scraper", lambda c: c.get("web_scraper_tool"))
+        container.register_factory("rss_parser", lambda c: c.get("rss_parser_tool"))
+        container.register_factory("file_writer", lambda c: c.get("file_writer_tool"))
+        
+    except ImportError as e:
+        # Log error but continue initialization
+        print(f"Error registering core tools: {e}")
+
+
+def register_analysis_tools(container):
+    """Register analysis tools in the container.
+    
+    Args:
+        container: The DI container instance
+    """
+    try:
+        # Import analysis tools
+        from local_newsifier.tools.analysis.trend_analyzer import TrendAnalyzer
+        from local_newsifier.tools.analysis.context_analyzer import ContextAnalyzer
+        from local_newsifier.tools.sentiment_analyzer import SentimentAnalysisTool
+        from local_newsifier.tools.sentiment_tracker import SentimentTracker
+        from local_newsifier.tools.opinion_visualizer import OpinionVisualizerTool
+        from local_newsifier.tools.trend_reporter import TrendReporter
+        from local_newsifier.services.analysis_service import AnalysisService
+        
+        # Register trend_analyzer_tool
+        container.register_factory(
+            "trend_analyzer_tool", 
+            lambda c: TrendAnalyzer()
+        )
+        
+        # Register context_analyzer_tool
+        container.register_factory(
+            "context_analyzer_tool", 
+            lambda c: ContextAnalyzer()
+        )
+        
+        # Register sentiment_analyzer_tool with configurable session
+        container.register_factory_with_params(
+            "sentiment_analyzer_tool", 
+            lambda c, **kwargs: SentimentAnalysisTool(
+                session=kwargs.get("session")
+            )
+        )
+        
+        # Register sentiment_tracker_tool with configurable session
+        container.register_factory_with_params(
+            "sentiment_tracker_tool", 
+            lambda c, **kwargs: SentimentTracker(
+                session=kwargs.get("session")
+            )
+        )
+        
+        # Register opinion_visualizer_tool with configurable session
+        container.register_factory_with_params(
+            "opinion_visualizer_tool", 
+            lambda c, **kwargs: OpinionVisualizerTool(
+                session=kwargs.get("session")
+            )
+        )
+        
+        # Register trend_reporter_tool with configurable output_dir
+        container.register_factory_with_params(
+            "trend_reporter_tool", 
+            lambda c, **kwargs: TrendReporter(
+                output_dir=kwargs.get("output_dir", "trend_output")
+            )
+        )
+        
+        # Register analysis_service
+        container.register_factory_with_params(
+            "analysis_service", 
+            lambda c, **kwargs: AnalysisService(
+                session=kwargs.get("session")
+            )
+        )
+        
+        # Backward compatibility registrations
+        container.register_factory("trend_analyzer", lambda c: c.get("trend_analyzer_tool"))
+        container.register_factory("context_analyzer", lambda c: c.get("context_analyzer_tool"))
+        container.register_factory("sentiment_analyzer", lambda c: c.get("sentiment_analyzer_tool"))
+        container.register_factory("sentiment_tracker", lambda c: c.get("sentiment_tracker_tool"))
+        container.register_factory("opinion_visualizer", lambda c: c.get("opinion_visualizer_tool"))
+        container.register_factory("trend_reporter", lambda c: c.get("trend_reporter_tool"))
+        
+    except ImportError as e:
+        # Log error but continue initialization
+        print(f"Error registering analysis tools: {e}")
+
+
+def register_entity_tools(container):
+    """Register entity-related tools in the container.
+    
+    Args:
+        container: The DI container instance
+    """
+    try:
+        # Import entity tools
+        from local_newsifier.tools.extraction.entity_extractor import EntityExtractor
+        from local_newsifier.tools.resolution.entity_resolver import EntityResolver
+        from local_newsifier.tools.entity_tracker_service import EntityTracker
+        
+        # Register entity_extractor_tool
+        container.register_factory(
+            "entity_extractor_tool", 
+            lambda c: EntityExtractor()
+        )
+        
+        # Register entity_resolver_tool
+        container.register_factory(
+            "entity_resolver_tool", 
+            lambda c: EntityResolver()
+        )
+        
+        # Register entity_tracker_tool
+        container.register_factory(
+            "entity_tracker_tool", 
+            lambda c: EntityTracker()
+        )
+        
+        # Backward compatibility registrations
+        container.register_factory("entity_extractor", lambda c: c.get("entity_extractor_tool"))
+        container.register_factory("entity_resolver", lambda c: c.get("entity_resolver_tool"))
+        container.register_factory("entity_tracker", lambda c: c.get("entity_tracker_tool"))
+        
+    except ImportError as e:
+        # Log error but continue initialization
+        print(f"Error registering entity tools: {e}")
+
+
+def register_services(container):
+    """Register service classes in the container.
+    
+    Args:
+        container: The DI container instance
+    """
     # ArticleService 
     container.register_factory("article_service", 
         lambda c: ArticleService(
@@ -109,56 +289,30 @@ def init_container(environment="production"):
             container=c  # Inject the container itself
         )
     )
+
+
+def register_flows(container):
+    """Register flow classes in the container.
     
-    # Register tools if available (expanded)
-    if TOOLS_AVAILABLE:
-        container.register_factory("rss_parser", 
-                               lambda c: RSSParser())
-        container.register_factory("web_scraper", 
-                               lambda c: WebScraper())
+    Args:
+        container: The DI container instance
+    """
+    try:
+        # Import flow classes
+        from local_newsifier.flows.entity_tracking_flow import EntityTrackingFlow
+        from local_newsifier.flows.news_pipeline import NewsPipelineFlow
+        from local_newsifier.flows.trend_analysis_flow import TrendAnalysisFlow
+        from local_newsifier.flows.public_opinion_flow import PublicOpinionFlow
+        from local_newsifier.flows.rss_scraping_flow import RSSScrapingFlow
         
-        # Register analysis tools
-        try:
-            from local_newsifier.tools.extraction.entity_extractor import EntityExtractor
-            from local_newsifier.tools.analysis.context_analyzer import ContextAnalyzer
-            from local_newsifier.tools.resolution.entity_resolver import EntityResolver
-            from local_newsifier.tools.entity_tracker_service import EntityTracker
-            from local_newsifier.tools.file_writer import FileWriterTool
-            
-            # Additional analysis tools
-            from local_newsifier.services.analysis_service import AnalysisService
-            from local_newsifier.tools.sentiment_analyzer import SentimentAnalysisTool
-            from local_newsifier.tools.sentiment_tracker import SentimentTracker
-            from local_newsifier.tools.opinion_visualizer import OpinionVisualizerTool
-            from local_newsifier.tools.trend_reporter import TrendReporter
-            
-            # Register entity analysis tools
-            container.register_factory("entity_extractor", lambda c: EntityExtractor())
-            container.register_factory("context_analyzer", lambda c: ContextAnalyzer())
-            container.register_factory("entity_resolver", lambda c: EntityResolver())
-            container.register_factory("entity_tracker", lambda c: EntityTracker())
-            container.register_factory("file_writer", lambda c: FileWriterTool(output_dir="output"))
-            
-            # Register sentiment and trend analysis tools
-            container.register_factory("analysis_service", lambda c: AnalysisService())
-            container.register_factory("sentiment_analyzer", lambda c: SentimentAnalysisTool(session=None))
-            container.register_factory("sentiment_tracker", lambda c: SentimentTracker(session=None))
-            container.register_factory("opinion_visualizer", lambda c: OpinionVisualizerTool(session=None))
-            container.register_factory("trend_reporter", lambda c: TrendReporter(output_dir="trend_output"))
-        except ImportError:
-            # These tools are optional
-            pass
-    
-    # Register flow services if available
-    if FLOWS_AVAILABLE:
         # EntityTrackingFlow with proper dependencies
         container.register_factory("entity_tracking_flow",
             lambda c: EntityTrackingFlow(
                 entity_service=c.get("entity_service"),
-                entity_tracker=c.get("entity_tracker"),
-                entity_extractor=c.get("entity_extractor"),
-                context_analyzer=c.get("context_analyzer"),
-                entity_resolver=c.get("entity_resolver"),
+                entity_tracker=c.get("entity_tracker_tool"),
+                entity_extractor=c.get("entity_extractor_tool"),
+                context_analyzer=c.get("context_analyzer_tool"),
+                entity_resolver=c.get("entity_resolver_tool"),
                 session_factory=c.get("session_factory")
             ))
         
@@ -167,11 +321,11 @@ def init_container(environment="production"):
             lambda c: NewsPipelineFlow(
                 article_service=c.get("article_service"),
                 entity_service=c.get("entity_service"),
-                web_scraper=c.get("web_scraper"),
-                file_writer=c.get("file_writer"),
-                entity_extractor=c.get("entity_extractor"),
-                context_analyzer=c.get("context_analyzer"),
-                entity_resolver=c.get("entity_resolver"),
+                web_scraper=c.get("web_scraper_tool"),
+                file_writer=c.get("file_writer_tool"),
+                entity_extractor=c.get("entity_extractor_tool"),
+                context_analyzer=c.get("context_analyzer_tool"),
+                entity_resolver=c.get("entity_resolver_tool"),
                 session_factory=c.get("session_factory")
             ))
         
@@ -179,16 +333,16 @@ def init_container(environment="production"):
         container.register_factory("trend_analysis_flow",
             lambda c: TrendAnalysisFlow(
                 analysis_service=c.get("analysis_service"),
-                trend_reporter=c.get("trend_reporter"),
+                trend_reporter=c.get("trend_reporter_tool"),
                 output_dir="trend_output"
             ))
         
         # PublicOpinionFlow with proper dependencies
         container.register_factory("public_opinion_flow",
             lambda c: PublicOpinionFlow(
-                sentiment_analyzer=c.get("sentiment_analyzer"),
-                sentiment_tracker=c.get("sentiment_tracker"),
-                opinion_visualizer=c.get("opinion_visualizer"),
+                sentiment_analyzer=c.get("sentiment_analyzer_tool"),
+                sentiment_tracker=c.get("sentiment_tracker_tool"),
+                opinion_visualizer=c.get("opinion_visualizer_tool"),
                 session_factory=c.get("session_factory")
             ))
         
@@ -198,25 +352,9 @@ def init_container(environment="production"):
                 rss_feed_service=c.get("rss_feed_service"),
                 article_service=c.get("article_service")
             ))
-    
-    # Register parameterized factories
-    container.register_factory_with_params("entity_service_with_params",
-        lambda c, **kwargs: kwargs.get("entity_service") or c.get("entity_service")
-    )
-    
-    container.register_factory_with_params("article_service_with_params",
-        lambda c, **kwargs: kwargs.get("article_service") or c.get("article_service")
-    )
-    
-    # Environment-specific configurations
-    if environment == "development":
-        # Development-specific registrations
+    except ImportError:
+        # These flows are optional
         pass
-    elif environment == "testing":
-        # Testing-specific registrations
-        pass
-    
-    return container
 
 
 # Create the singleton container instance

--- a/tests/utils/test_tool_registration.py
+++ b/tests/utils/test_tool_registration.py
@@ -1,0 +1,194 @@
+"""
+Tests for tool registration in the DI container.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from local_newsifier.container import (
+    register_core_tools,
+    register_analysis_tools,
+    register_entity_tools,
+    init_container
+)
+
+
+@pytest.fixture
+def mock_container():
+    """Fixture for a mock DI container."""
+    container = MagicMock()
+    container.register_factory.return_value = container
+    container.register_factory_with_params.return_value = container
+    container.get.return_value = MagicMock()
+    return container
+
+
+class TestCoreToolRegistration:
+    """Tests for core tool registration in container."""
+    
+    def test_register_core_tools(self, mock_container, monkeypatch):
+        """Test that core tools are registered correctly."""
+        # Mock the imports
+        mock_web_scraper = MagicMock()
+        mock_rss_parser = MagicMock()
+        mock_file_writer = MagicMock()
+        
+        monkeypatch.setattr("local_newsifier.tools.web_scraper.WebScraperTool", mock_web_scraper)
+        monkeypatch.setattr("local_newsifier.tools.rss_parser.RSSParser", mock_rss_parser)
+        monkeypatch.setattr("local_newsifier.tools.file_writer.FileWriterTool", mock_file_writer)
+        
+        # Register the tools
+        register_core_tools(mock_container)
+        
+        # Verify tool registrations
+        assert mock_container.register_factory_with_params.call_count == 3
+        assert mock_container.register_factory.call_count == 3
+        
+        # Check specific tool registrations
+        registration_names = []
+        for call in mock_container.register_factory_with_params.call_args_list:
+            registration_names.append(call[0][0])
+        
+        assert "web_scraper_tool" in registration_names
+        assert "rss_parser_tool" in registration_names
+        assert "file_writer_tool" in registration_names
+        
+        # Check backward compatibility registrations
+        compatibility_names = []
+        for call in mock_container.register_factory.call_args_list:
+            compatibility_names.append(call[0][0])
+            
+        assert "web_scraper" in compatibility_names
+        assert "rss_parser" in compatibility_names
+        assert "file_writer" in compatibility_names
+
+
+class TestAnalysisToolRegistration:
+    """Tests for analysis tool registration in container."""
+    
+    def test_register_analysis_tools(self, mock_container, monkeypatch):
+        """Test that analysis tools are registered correctly."""
+        # Mock the imports
+        mock_trend_analyzer = MagicMock()
+        mock_context_analyzer = MagicMock()
+        mock_sentiment_analyzer = MagicMock()
+        mock_sentiment_tracker = MagicMock()
+        mock_opinion_visualizer = MagicMock()
+        mock_trend_reporter = MagicMock()
+        mock_analysis_service = MagicMock()
+        
+        monkeypatch.setattr("local_newsifier.tools.analysis.trend_analyzer.TrendAnalyzer", mock_trend_analyzer)
+        monkeypatch.setattr("local_newsifier.tools.analysis.context_analyzer.ContextAnalyzer", mock_context_analyzer)
+        monkeypatch.setattr("local_newsifier.tools.sentiment_analyzer.SentimentAnalysisTool", mock_sentiment_analyzer)
+        monkeypatch.setattr("local_newsifier.tools.sentiment_tracker.SentimentTracker", mock_sentiment_tracker)
+        monkeypatch.setattr("local_newsifier.tools.opinion_visualizer.OpinionVisualizerTool", mock_opinion_visualizer)
+        monkeypatch.setattr("local_newsifier.tools.trend_reporter.TrendReporter", mock_trend_reporter)
+        monkeypatch.setattr("local_newsifier.services.analysis_service.AnalysisService", mock_analysis_service)
+        
+        # Register the tools
+        register_analysis_tools(mock_container)
+        
+        # Verify registrations
+        factory_calls = mock_container.register_factory.call_count
+        factory_params_calls = mock_container.register_factory_with_params.call_count
+        
+        assert factory_calls >= 2  # At least trend_analyzer and context_analyzer
+        assert factory_params_calls >= 5  # At least the parameterized tools
+        
+        # Check specific tool registrations
+        all_registrations = []
+        for call in mock_container.register_factory.call_args_list:
+            all_registrations.append(call[0][0])
+        for call in mock_container.register_factory_with_params.call_args_list:
+            all_registrations.append(call[0][0])
+            
+        # Check that all tools are registered
+        assert "trend_analyzer_tool" in all_registrations
+        assert "context_analyzer_tool" in all_registrations
+        assert "sentiment_analyzer_tool" in all_registrations
+        assert "sentiment_tracker_tool" in all_registrations
+        assert "opinion_visualizer_tool" in all_registrations
+        assert "trend_reporter_tool" in all_registrations
+        assert "analysis_service" in all_registrations
+        
+        # Check backward compatibility
+        compatibility_names = []
+        for call in mock_container.register_factory.call_args_list:
+            compatibility_names.append(call[0][0])
+            
+        assert "trend_analyzer" in compatibility_names
+        assert "context_analyzer" in compatibility_names
+        assert "sentiment_analyzer" in compatibility_names
+        assert "sentiment_tracker" in compatibility_names
+        assert "opinion_visualizer" in compatibility_names
+        assert "trend_reporter" in compatibility_names
+
+
+class TestEntityToolRegistration:
+    """Tests for entity tool registration in container."""
+    
+    def test_register_entity_tools(self, mock_container, monkeypatch):
+        """Test that entity tools are registered correctly."""
+        # Mock the imports
+        mock_entity_extractor = MagicMock()
+        mock_entity_resolver = MagicMock()
+        mock_entity_tracker = MagicMock()
+        
+        monkeypatch.setattr("local_newsifier.tools.extraction.entity_extractor.EntityExtractor", mock_entity_extractor)
+        monkeypatch.setattr("local_newsifier.tools.resolution.entity_resolver.EntityResolver", mock_entity_resolver)
+        monkeypatch.setattr("local_newsifier.tools.entity_tracker_service.EntityTracker", mock_entity_tracker)
+        
+        # Register the tools
+        register_entity_tools(mock_container)
+        
+        # Verify registrations
+        assert mock_container.register_factory.call_count == 6  # 3 tools + 3 backward compatibility
+        
+        # Check specific tool registrations
+        registration_names = []
+        for call in mock_container.register_factory.call_args_list:
+            registration_names.append(call[0][0])
+            
+        assert "entity_extractor_tool" in registration_names
+        assert "entity_resolver_tool" in registration_names
+        assert "entity_tracker_tool" in registration_names
+        
+        # Check backward compatibility
+        assert "entity_extractor" in registration_names
+        assert "entity_resolver" in registration_names
+        assert "entity_tracker" in registration_names
+
+
+class TestContainerInitialization:
+    """Tests for container initialization."""
+    
+    def test_init_container(self, monkeypatch):
+        """Test that the container is properly initialized with all tools registered."""
+        # Mock the registration functions
+        mock_register_core = MagicMock()
+        mock_register_analysis = MagicMock()
+        mock_register_entity = MagicMock()
+        mock_register_services = MagicMock()
+        mock_register_flows = MagicMock()
+        
+        monkeypatch.setattr("local_newsifier.container.register_core_tools", mock_register_core)
+        monkeypatch.setattr("local_newsifier.container.register_analysis_tools", mock_register_analysis)
+        monkeypatch.setattr("local_newsifier.container.register_entity_tools", mock_register_entity)
+        monkeypatch.setattr("local_newsifier.container.register_services", mock_register_services)
+        monkeypatch.setattr("local_newsifier.container.register_flows", mock_register_flows)
+        
+        # Initialize the container
+        container = init_container()
+        
+        # Verify that all registration functions were called
+        assert mock_register_core.call_count == 1
+        assert mock_register_analysis.call_count == 1
+        assert mock_register_entity.call_count == 1
+        assert mock_register_services.call_count == 1
+        assert mock_register_flows.call_count == 1
+        
+        # Verify container object
+        assert container is not None
+        
+        # Verify CRUD modules and other essentials were registered
+        assert len(container._services) > 0 or len(container._factories) > 0


### PR DESCRIPTION
## Summary

This PR implements issue #132 by registering all tool classes in the dependency injection container. This creates a standardized way to access all tools through the container.

## Implementation

1. Structured the container.py file with organized section functions:
   - `register_core_tools()` for web_scraper, rss_parser, and file_writer tools
   - `register_analysis_tools()` for trend analysis, sentiment analysis, and visualization tools
   - `register_entity_tools()` for entity extraction, resolution, and tracking tools

2. Used consistent naming conventions:
   - Standardized on *_tool suffix for all tool service names
   - Added backward compatibility registrations to maintain existing code

3. Provided factory methods that enable configuration:
   - Used register_factory_with_params for tools that need configuration
   - Organized tool initialization with appropriate parameters

4. Added comprehensive tests:
   - Created test_tool_registration.py to validate tool registration
   - Tests verify all tools are registered with proper naming conventions
   - Tests ensure backward compatibility is maintained

## Testing

All tests pass, confirming the changes work correctly.

Closes #132
