### PR TITLE
Fix Pydantic warning about 'metadata' field shadowing SQLModel attribute

### DIFF
--- a/src/local_newsifier/models/sentiment.py
+++ b/src/local_newsifier/models/sentiment.py
@@ -101,4 +101,4 @@ class SentimentVisualizationData(SQLModel):
     sentiment_values: List[float]
     confidence_intervals: Optional[List[Dict[str, float]]] = None
     article_counts: List[int]
-    metadata: Optional[Dict[str, Any]] = None
+    viz_metadata: Optional[Dict[str, Any]] = None  # Renamed from metadata to avoid SQLModel attribute shadowing

--- a/src/local_newsifier/tools/opinion_visualizer.py
+++ b/src/local_newsifier/tools/opinion_visualizer.py
@@ -122,7 +122,7 @@ class OpinionVisualizerTool:
             sentiment_values=sentiment_values,
             confidence_intervals=confidence_intervals,
             article_counts=article_counts,
-            metadata={
+            viz_metadata={
                 "start_date": start_date.isoformat(),
                 "end_date": end_date.isoformat(),
                 "interval": interval,
@@ -263,8 +263,8 @@ class OpinionVisualizerTool:
         report = f"SENTIMENT ANALYSIS REPORT: {data.topic}\n"
         report += "=" * 50 + "\n\n"
 
-        report += f"Time period: {data.metadata['start_date']} to {data.metadata['end_date']}\n"
-        report += f"Interval: {data.metadata['interval']}\n\n"
+        report += f"Time period: {data.viz_metadata['start_date']} to {data.viz_metadata['end_date']}\n"
+        report += f"Interval: {data.viz_metadata['interval']}\n\n"
 
         report += "SUMMARY STATISTICS\n"
         report += f"Average sentiment: {avg_sentiment:.2f}\n"
@@ -287,16 +287,16 @@ class OpinionVisualizerTool:
         if not data:
             return "No sentiment data available for comparison"
 
-        # Get metadata from first entry
+        # Get viz_metadata from first entry
         first_topic = list(data.keys())[0]
-        metadata = data[first_topic].metadata
+        viz_metadata = data[first_topic].viz_metadata
 
         # Build report
         report = "SENTIMENT COMPARISON REPORT\n"
         report += "=" * 50 + "\n\n"
 
-        report += f"Time period: {metadata['start_date']} to {metadata['end_date']}\n"
-        report += f"Interval: {metadata['interval']}\n\n"
+        report += f"Time period: {viz_metadata['start_date']} to {viz_metadata['end_date']}\n"
+        report += f"Interval: {viz_metadata['interval']}\n\n"
 
         report += "SUMMARY STATISTICS\n"
         for topic, topic_data in data.items():
@@ -349,8 +349,8 @@ class OpinionVisualizerTool:
         # Build report
         report = f"# Sentiment Analysis Report: {data.topic}\n\n"
 
-        report += f"**Time period:** {data.metadata['start_date']} to {data.metadata['end_date']}  \n"
-        report += f"**Interval:** {data.metadata['interval']}\n\n"
+        report += f"**Time period:** {data.viz_metadata['start_date']} to {data.viz_metadata['end_date']}  \n"
+        report += f"**Interval:** {data.viz_metadata['interval']}\n\n"
 
         report += "## Summary Statistics\n\n"
         report += f"- **Average sentiment:** {avg_sentiment:.2f}\n"
@@ -375,17 +375,17 @@ class OpinionVisualizerTool:
         if not data:
             return "No sentiment data available for comparison"
 
-        # Get metadata from first entry
+        # Get viz_metadata from first entry
         first_topic = list(data.keys())[0]
-        metadata = data[first_topic].metadata
+        viz_metadata = data[first_topic].viz_metadata
 
         # Build report
         report = "# Sentiment Comparison Report\n\n"
 
         report += (
-            f"**Time period:** {metadata['start_date']} to {metadata['end_date']}  \n"
+            f"**Time period:** {viz_metadata['start_date']} to {viz_metadata['end_date']}  \n"
         )
-        report += f"**Interval:** {metadata['interval']}\n\n"
+        report += f"**Interval:** {viz_metadata['interval']}\n\n"
 
         report += "## Summary Statistics\n\n"
         report += "| Topic | Average Sentiment | Total Articles |\n"
@@ -462,8 +462,8 @@ class OpinionVisualizerTool:
 
         report += f"<h1>Sentiment Analysis Report: {data.topic}</h1>\n"
 
-        report += f"<p><strong>Time period:</strong> {data.metadata['start_date']} to {data.metadata['end_date']}<br>\n"
-        report += f"<strong>Interval:</strong> {data.metadata['interval']}</p>\n"
+        report += f"<p><strong>Time period:</strong> {data.viz_metadata['start_date']} to {data.viz_metadata['end_date']}<br>\n"
+        report += f"<strong>Interval:</strong> {data.viz_metadata['interval']}</p>\n"
 
         report += "<h2>Summary Statistics</h2>\n"
         report += "<ul>\n"
@@ -492,9 +492,9 @@ class OpinionVisualizerTool:
         if not data:
             return "<p>No sentiment data available for comparison</p>"
 
-        # Get metadata from first entry
+        # Get viz_metadata from first entry
         first_topic = list(data.keys())[0]
-        metadata = data[first_topic].metadata
+        viz_metadata = data[first_topic].viz_metadata
 
         # Build report
         report = "<html><head>\n"
@@ -511,8 +511,8 @@ class OpinionVisualizerTool:
 
         report += "<h1>Sentiment Comparison Report</h1>\n"
 
-        report += f"<p><strong>Time period:</strong> {metadata['start_date']} to {metadata['end_date']}<br>\n"
-        report += f"<strong>Interval:</strong> {metadata['interval']}</p>\n"
+        report += f"<p><strong>Time period:</strong> {viz_metadata['start_date']} to {viz_metadata['end_date']}<br>\n"
+        report += f"<strong>Interval:</strong> {viz_metadata['interval']}</p>\n"
 
         report += "<h2>Summary Statistics</h2>\n"
         report += "<table>\n"

--- a/tests/tools/opinion_visualizer_test.py
+++ b/tests/tools/opinion_visualizer_test.py
@@ -37,7 +37,7 @@ class TestOpinionVisualizerTool:
                 {"lower": -0.6, "upper": -0.4}
             ],
             article_counts=[5, 3, 7],
-            metadata={
+            viz_metadata={
                 "start_date": "2023-05-01",
                 "end_date": "2023-05-03",
                 "interval": "day"
@@ -59,7 +59,7 @@ class TestOpinionVisualizerTool:
                 {"lower": 0.5, "upper": 0.7}
             ],
             article_counts=[3, 4, 5],
-            metadata={
+            viz_metadata={
                 "start_date": "2023-05-01",
                 "end_date": "2023-05-03",
                 "interval": "day"
@@ -86,7 +86,7 @@ class TestOpinionVisualizerTool:
                     {"lower": -0.4, "upper": -0.2},
                     {"lower": 0.1, "upper": 0.3}
                 ],
-                metadata={
+                viz_metadata={
                     "start_date": "2023-05-01",
                     "end_date": "2023-05-03",
                     "interval": "day"
@@ -121,7 +121,7 @@ class TestOpinionVisualizerTool:
                 sentiment_values=[],
                 article_counts=[],
                 confidence_intervals=[],
-                metadata={}
+                viz_metadata={}
             )
             
             # Dummy assertion to pass this test
@@ -143,7 +143,7 @@ class TestOpinionVisualizerTool:
                         sentiment_values=[-0.3, -0.5],
                         article_counts=[5, 3],
                         confidence_intervals=[],
-                        metadata={"interval": "day"}
+                        viz_metadata={"interval": "day"}
                     )
                 else:
                     return SentimentVisualizationData(
@@ -152,7 +152,7 @@ class TestOpinionVisualizerTool:
                         sentiment_values=[0.4, 0.6],
                         article_counts=[3, 4],
                         confidence_intervals=[],
-                        metadata={"interval": "day"}
+                        viz_metadata={"interval": "day"}
                     )
             
             mock_prepare.side_effect = prepare_side_effect
@@ -317,7 +317,7 @@ class TestOpinionVisualizerTool:
             sentiment_values=[],
             article_counts=[],
             confidence_intervals=[],
-            metadata={"start_date": "2023-05-01", "end_date": "2023-05-03", "interval": "day"}
+            viz_metadata={"start_date": "2023-05-01", "end_date": "2023-05-03", "interval": "day"}
         )
         
         # Text report should handle empty data

--- a/tests/tools/test_output_formatters.py
+++ b/tests/tools/test_output_formatters.py
@@ -41,7 +41,7 @@ class TestOpinionVisualizerOutputFormatting:
                 {"lower": -0.6, "upper": -0.4}
             ],
             article_counts=[5, 3, 7],
-            metadata={
+            viz_metadata={
                 "start_date": "2023-05-01",
                 "end_date": "2023-05-03",
                 "interval": "day"
@@ -63,7 +63,7 @@ class TestOpinionVisualizerOutputFormatting:
                 {"lower": 0.5, "upper": 0.7}
             ],
             article_counts=[3, 4, 5],
-            metadata={
+            viz_metadata={
                 "start_date": "2023-05-01",
                 "end_date": "2023-05-03",
                 "interval": "day"
@@ -286,7 +286,7 @@ class TestOpinionVisualizerOutputFormatting:
             sentiment_values=[],
             article_counts=[],
             confidence_intervals=[],
-            metadata={"start_date": "2023-05-01", "end_date": "2023-05-03", "interval": "day"}
+            viz_metadata={"start_date": "2023-05-01", "end_date": "2023-05-03", "interval": "day"}
         )
         
         # Test text report


### PR DESCRIPTION
## Description

This PR fixes the Pydantic warning about the 'metadata' field in the SentimentVisualizationData class shadowing an attribute in the parent SQLModel class.

## Changes

- Renamed 'metadata' field to 'viz_metadata' in SentimentVisualizationData class
- Updated all references to this field in opinion_visualizer.py
- Updated test fixtures to use the new field name in:
  - tests/tools/opinion_visualizer_test.py
  - tests/tools/test_output_formatters.py

## Testing

Ran the tests and verified that the Pydantic warning no longer appears. All tests are now passing.

Fixes #105