### PR TITLE
feat: add Apify SQLModels and Alembic migration

### DIFF
--- a/alembic/versions/a6b9cd123456_add_apify_models.py
+++ b/alembic/versions/a6b9cd123456_add_apify_models.py
@@ -1,0 +1,128 @@
+"""Add Apify models
+
+Revision ID: a6b9cd123456
+Revises: rename_tables_to_plural
+Create Date: 2025-04-29 04:23:30.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'a6b9cd123456'
+down_revision: Union[str, None] = 'rename_tables_to_plural'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Create apify_source_configs table
+    op.create_table('apify_source_configs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('actor_id', sa.String(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False, default=True),
+        sa.Column('schedule', sa.String(), nullable=True),
+        sa.Column('source_type', sa.String(), nullable=False),
+        sa.Column('source_url', sa.String(), nullable=True),
+        sa.Column('input_configuration', postgresql.JSON(astext_type=sa.Text()), nullable=True),
+        sa.Column('last_run_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_apify_source_configs_name'), 'apify_source_configs', ['name'], unique=False)
+    
+    # Create apify_jobs table
+    op.create_table('apify_jobs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('source_config_id', sa.Integer(), nullable=True),
+        sa.Column('run_id', sa.String(), nullable=False),
+        sa.Column('actor_id', sa.String(), nullable=False),
+        sa.Column('status', sa.String(), nullable=False),
+        sa.Column('started_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('finished_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('duration_seconds', sa.Integer(), nullable=True),
+        sa.Column('dataset_id', sa.String(), nullable=True),
+        sa.Column('item_count', sa.Integer(), nullable=True),
+        sa.Column('error_message', sa.String(), nullable=True),
+        sa.Column('processed', sa.Boolean(), nullable=False, default=False),
+        sa.Column('articles_created', sa.Integer(), nullable=True),
+        sa.Column('processed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['source_config_id'], ['apify_source_configs.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_apify_jobs_source_config_id'), 'apify_jobs', ['source_config_id'], unique=False)
+    op.create_index(op.f('ix_apify_jobs_run_id'), 'apify_jobs', ['run_id'], unique=False)
+    
+    # Create apify_dataset_items table
+    op.create_table('apify_dataset_items',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('job_id', sa.Integer(), nullable=False),
+        sa.Column('apify_id', sa.String(), nullable=False),
+        sa.Column('raw_data', postgresql.JSON(astext_type=sa.Text()), nullable=True),
+        sa.Column('transformed', sa.Boolean(), nullable=False, default=False),
+        sa.Column('article_id', sa.Integer(), nullable=True),
+        sa.Column('error_message', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['article_id'], ['articles.id'], ),
+        sa.ForeignKeyConstraint(['job_id'], ['apify_jobs.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_apify_dataset_items_job_id'), 'apify_dataset_items', ['job_id'], unique=False)
+    op.create_index(op.f('ix_apify_dataset_items_article_id'), 'apify_dataset_items', ['article_id'], unique=False)
+    
+    # Create apify_credentials table
+    op.create_table('apify_credentials',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('api_token', sa.String(), nullable=False),
+        sa.Column('label', sa.String(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False, default=True),
+        sa.Column('rate_limit_remaining', sa.Integer(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_apify_credentials_label'), 'apify_credentials', ['label'], unique=False)
+    
+    # Create apify_webhooks table
+    op.create_table('apify_webhooks',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('webhook_id', sa.String(), nullable=False),
+        sa.Column('actor_id', sa.String(), nullable=True),
+        sa.Column('event_types', postgresql.JSON(astext_type=sa.Text()), nullable=True),
+        sa.Column('payload_template', sa.String(), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False, default=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_apify_webhooks_webhook_id'), 'apify_webhooks', ['webhook_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop tables in reverse order of creation to avoid foreign key constraints
+    op.drop_index(op.f('ix_apify_webhooks_webhook_id'), table_name='apify_webhooks')
+    op.drop_table('apify_webhooks')
+    
+    op.drop_index(op.f('ix_apify_credentials_label'), table_name='apify_credentials')
+    op.drop_table('apify_credentials')
+    
+    op.drop_index(op.f('ix_apify_dataset_items_article_id'), table_name='apify_dataset_items')
+    op.drop_index(op.f('ix_apify_dataset_items_job_id'), table_name='apify_dataset_items')
+    op.drop_table('apify_dataset_items')
+    
+    op.drop_index(op.f('ix_apify_jobs_run_id'), table_name='apify_jobs')
+    op.drop_index(op.f('ix_apify_jobs_source_config_id'), table_name='apify_jobs')
+    op.drop_table('apify_jobs')
+    
+    op.drop_index(op.f('ix_apify_source_configs_name'), table_name='apify_source_configs')
+    op.drop_table('apify_source_configs')

--- a/src/local_newsifier/models/__init__.py
+++ b/src/local_newsifier/models/__init__.py
@@ -24,6 +24,13 @@ from local_newsifier.models.sentiment import (
     OpinionTrend,
     SentimentShift,
 )
+from local_newsifier.models.apify import (
+    ApifySourceConfig,
+    ApifyJob,
+    ApifyDatasetItem,
+    ApifyCredentials,
+    ApifyWebhook,
+)
 
 # Export only the class names, not the actual classes
 __all__ = [
@@ -44,4 +51,10 @@ __all__ = [
     "SentimentAnalysis",
     "OpinionTrend",
     "SentimentShift",
+    # Apify models
+    "ApifySourceConfig",
+    "ApifyJob", 
+    "ApifyDatasetItem",
+    "ApifyCredentials",
+    "ApifyWebhook",
 ]

--- a/src/local_newsifier/models/apify.py
+++ b/src/local_newsifier/models/apify.py
@@ -1,0 +1,123 @@
+"""Apify integration models for the Local Newsifier system."""
+
+from datetime import datetime, timezone
+from typing import Dict, Any, Optional, List, TYPE_CHECKING
+
+from sqlmodel import Field, Relationship, JSON, SQLModel
+
+from local_newsifier.models.base import TableBase
+
+# Handle circular imports
+if TYPE_CHECKING:
+    from local_newsifier.models.article import Article
+
+
+class ApifySourceConfig(TableBase, table=True):
+    """SQLModel for storing Apify scraper configurations."""
+
+    __tablename__ = "apify_source_configs"
+    
+    # Handle multiple imports during test collection
+    __table_args__ = {"extend_existing": True}
+
+    name: str = Field(index=True)  # Human-readable name for this source
+    actor_id: str  # Apify actor ID
+    is_active: bool = Field(default=True)
+    schedule: Optional[str] = None  # Cron expression for scheduling
+    source_type: str  # e.g., "news", "blog", "social_media"
+    source_url: Optional[str] = None  # Original source URL if applicable
+
+    # Configuration parameters for the actor
+    input_configuration: Dict[str, Any] = Field(default_factory=dict, sa_type=JSON)
+
+    # Metadata and timestamps
+    last_run_at: Optional[datetime] = None
+
+    # Relationships
+    jobs: List["ApifyJob"] = Relationship(back_populates="source_config")
+
+
+class ApifyJob(TableBase, table=True):
+    """SQLModel for tracking Apify job runs."""
+
+    __tablename__ = "apify_jobs"
+    
+    # Handle multiple imports during test collection
+    __table_args__ = {"extend_existing": True}
+
+    source_config_id: Optional[int] = Field(default=None, foreign_key="apify_source_configs.id", index=True)
+    run_id: str = Field(index=True)  # Apify run ID
+    actor_id: str  # Apify actor ID that was run
+    status: str  # e.g., "RUNNING", "SUCCEEDED", "FAILED", "ABORTED"
+
+    # Run statistics
+    started_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    finished_at: Optional[datetime] = None
+    duration_seconds: Optional[int] = None
+
+    # Results metadata
+    dataset_id: Optional[str] = None  # Apify dataset ID with results
+    item_count: Optional[int] = None  # Number of items scraped
+    error_message: Optional[str] = None
+
+    # Processing status
+    processed: bool = Field(default=False)  # Whether results were imported to articles
+    articles_created: Optional[int] = None  # Number of articles created from this job
+    processed_at: Optional[datetime] = None
+
+    # Relationship back to source config
+    source_config: Optional["ApifySourceConfig"] = Relationship(back_populates="jobs")
+    
+    # Relationship to dataset items
+    dataset_items: List["ApifyDatasetItem"] = Relationship(back_populates="job")
+
+
+class ApifyDatasetItem(TableBase, table=True):
+    """SQLModel for storing raw Apify dataset items before transformation."""
+
+    __tablename__ = "apify_dataset_items"
+    
+    # Handle multiple imports during test collection
+    __table_args__ = {"extend_existing": True}
+
+    job_id: int = Field(foreign_key="apify_jobs.id", index=True)
+    apify_id: str  # Original item ID from Apify
+    raw_data: Dict[str, Any] = Field(sa_type=JSON)
+
+    # Processing status
+    transformed: bool = Field(default=False)
+    article_id: Optional[int] = Field(default=None, foreign_key="articles.id", index=True)
+    error_message: Optional[str] = None
+
+    # Relationships
+    job: "ApifyJob" = Relationship(back_populates="dataset_items")
+    article: Optional["local_newsifier.models.article.Article"] = Relationship()
+
+
+class ApifyCredentials(TableBase, table=True):
+    """SQLModel for storing Apify API credentials."""
+
+    __tablename__ = "apify_credentials"
+    
+    # Handle multiple imports during test collection
+    __table_args__ = {"extend_existing": True}
+
+    api_token: str  # Encrypted API token
+    label: str = Field(index=True)  # Descriptive label for this token
+    is_active: bool = Field(default=True)
+    rate_limit_remaining: Optional[int] = None  # For tracking API usage
+
+
+class ApifyWebhook(TableBase, table=True):
+    """SQLModel for managing Apify webhooks."""
+
+    __tablename__ = "apify_webhooks"
+    
+    # Handle multiple imports during test collection
+    __table_args__ = {"extend_existing": True}
+
+    webhook_id: str = Field(index=True)  # Apify webhook ID
+    actor_id: Optional[str] = None  # Actor this webhook is associated with (if any)
+    event_types: List[str] = Field(default_factory=list, sa_type=JSON)  # e.g., ["RUN.SUCCEEDED"]
+    payload_template: Optional[str] = None  # Custom payload template if used
+    is_active: bool = Field(default=True)


### PR DESCRIPTION
Implements comprehensive data models for Apify integration as specified in #109:

- ApifySourceConfig for storing scraper configurations
- ApifyJob for tracking execution runs 
- ApifyDatasetItem for raw data storage before transformation
- ApifyCredentials for API token management
- ApifyWebhook for webhook configurations

All models are implemented as SQLModel classes with proper relationships, and include a complete Alembic migration script.

Closes #109