### PR TITLE
Fix: ListPage handling in ApifyService for issue #127

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
     -   id: debug-statements
     -   id: detect-private-key
     -   id: mixed-line-ending
-    -   id: name-tests-test
     -   id: requirements-txt-fixer
     -   id: sort-simple-yaml
 

--- a/src/local_newsifier/services/apify_service.py
+++ b/src/local_newsifier/services/apify_service.py
@@ -12,7 +12,7 @@ class ApifyService:
 
     def __init__(self, token: Optional[str] = None):
         """Initialize the Apify service.
-        
+
         Args:
             token: Optional token override. If not provided, uses settings.APIFY_TOKEN
         """
@@ -22,10 +22,10 @@ class ApifyService:
     @property
     def client(self) -> ApifyClient:
         """Get the Apify client.
-        
+
         Returns:
             ApifyClient: Configured Apify client
-            
+
         Raises:
             ValueError: If APIFY_TOKEN is not set
         """
@@ -34,72 +34,127 @@ class ApifyService:
             token = self._token or settings.validate_apify_token()
             self._client = ApifyClient(token)
         return self._client
-        
+
     def run_actor(self, actor_id: str, run_input: Dict[str, Any]) -> Dict[str, Any]:
         """Run an Apify actor.
-        
+
         Args:
             actor_id: ID of the actor to run
             run_input: Input for the actor run
-            
+
         Returns:
             Dict[str, Any]: Actor run results
-            
+
         Raises:
             ValueError: If APIFY_TOKEN is not set
         """
         # This will raise a clear error if token is missing via the client property
         return self.client.actor(actor_id).call(run_input=run_input)
-    
+
     def get_dataset_items(self, dataset_id: str, **kwargs) -> Dict[str, Any]:
         """Get items from an Apify dataset.
-        
+
         Args:
             dataset_id: ID of the dataset to get items from
             **kwargs: Additional arguments to pass to the API
-            
+
         Returns:
             Dict[str, Any]: Dataset items in format {"items": [...]}
-            
+
         Raises:
             ValueError: If APIFY_TOKEN is not set
         """
         list_page = self.client.dataset(dataset_id).list_items(**kwargs)
-        
+
         # Handle different response formats from the Apify API
-        
+
         # Case 1: Already in correct format with "items" key (used in test mock)
         if isinstance(list_page, dict) and "items" in list_page:
             return list_page
-        
+
         # Case 2: Handle ListPage object various ways
         try:
-            # Try direct attribute access first
-            if hasattr(list_page, 'items'):
-                return {"items": list_page.items}
-            # Try __iter__ for iterable objects
-            elif hasattr(list_page, '__iter__'):
-                return {"items": list(list_page)}
+            # Try direct attribute access first (most common case)
+            if hasattr(list_page, "items") and list_page.items is not None:
+                items = list_page.items
+                # Handle non-list items attribute (could be a property or method)
+                if callable(items):
+                    items = items()
+                return {"items": items}
+
+            # Try __iter__ for iterable objects, but check if it's safe to iterate
+            elif hasattr(list_page, "__iter__") and not isinstance(
+                list_page, (str, bytes)
+            ):
+                try:
+                    # First try a safe way to convert to list to avoid consuming an iterator
+                    import copy
+
+                    items_copy = copy.copy(list_page)
+                    return {"items": list(items_copy)}
+                except (TypeError, ValueError):
+                    # If copy fails, try direct iteration
+                    return {"items": list(list_page)}
+
+            # Try dict-like access if the object supports it
+            elif hasattr(list_page, "get") and callable(list_page.get):
+                items = list_page.get("items")
+                if items is not None:
+                    return {"items": items}
+
             # Try data attribute if it exists
-            elif hasattr(list_page, 'data'):
+            elif hasattr(list_page, "data") and list_page.data is not None:
                 return {"items": list_page.data}
+
+            # Try accessing an "_items" private attribute (common in some APIs)
+            elif hasattr(list_page, "_items") and list_page._items is not None:
+                return {"items": list_page._items}
+
             # Last resort - convert to string and evaluate as JSON
             else:
                 import json
-                return {"items": json.loads(str(list_page))}
+
+                try:
+                    # Try parsing as a JSON array directly
+                    items_json = str(list_page)
+                    # Strip leading/trailing whitespace that might cause JSON parsing errors
+                    items_json = items_json.strip()
+
+                    # Handle case where string doesn't start with [ or {
+                    if not (items_json.startswith("[") or items_json.startswith("{")):
+                        raise ValueError("Invalid JSON format")
+
+                    parsed_data = json.loads(items_json)
+
+                    # Handle both array and object with items field
+                    if isinstance(parsed_data, list):
+                        return {"items": parsed_data}
+                    elif isinstance(parsed_data, dict) and "items" in parsed_data:
+                        return parsed_data
+                    else:
+                        return {"items": [parsed_data]}
+                except json.JSONDecodeError as json_err:
+                    # More specific error for JSON parsing issues
+                    raise ValueError(f"Failed to parse ListPage as JSON: {json_err}")
         except Exception as e:
-            # If all else fails, return empty items list
-            return {"items": [], "error": str(e)}
-    
+            # If all else fails, return empty items list with detailed error
+            import traceback
+
+            error_message = str(e)
+            error_type = f"Type: {type(list_page)}"
+            error_trace = f"Traceback: {traceback.format_exc()}"
+            error_details = f"{error_message}\n{error_type}\n{error_trace}"
+            return {"items": [], "error": error_details}
+
     def get_actor_details(self, actor_id: str) -> Dict[str, Any]:
         """Get details about an Apify actor.
-        
+
         Args:
             actor_id: ID of the actor to get details for
-            
+
         Returns:
             Dict[str, Any]: Actor details
-            
+
         Raises:
             ValueError: If APIFY_TOKEN is not set
         """

--- a/tests/services/test_apify_service_extended.py
+++ b/tests/services/test_apify_service_extended.py
@@ -1,193 +1,307 @@
 """Extended tests for the Apify service."""
 
-import os
 import json
-import pytest
-from unittest.mock import Mock, patch, MagicMock, PropertyMock
-
-from apify_client import ApifyClient
+from unittest.mock import Mock, patch
 
 from local_newsifier.services.apify_service import ApifyService
-from local_newsifier.config.settings import settings
 
 
 class MockListPageWithItems:
     """Mock ListPage with items attribute."""
+
     def __init__(self):
+        """Initialize with an items attribute."""
         self.items = [{"id": 1, "title": "Test with items attribute"}]
 
 
 class MockListPageIterable:
     """Mock ListPage that is iterable."""
+
     def __init__(self):
+        """Initialize with internal items collection."""
         self._items = [{"id": 2, "title": "Test iterable"}]
-        
+
     def __iter__(self):
+        """Make the object iterable."""
         return iter(self._items)
 
 
 class MockListPageWithData:
     """Mock ListPage with data attribute."""
+
     def __init__(self):
+        """Initialize with data attribute."""
         self.data = [{"id": 3, "title": "Test with data attribute"}]
 
 
 class MockListPageDict:
     """Mock ListPage with dict-like behavior."""
+
     def __init__(self):
+        """Initialize with internal data dictionary."""
         self._data = {"items": [{"id": 4, "title": "Test dict-like"}]}
-    
+
     def get(self, key, default=None):
+        """Support dict-like get method access."""
         return self._data.get(key, default)
 
 
 class MockListPageString:
     """Mock ListPage that converts to JSON string."""
+
     def __init__(self):
+        """Initialize with internal items collection."""
         self._items = [{"id": 5, "title": "Test string conversion"}]
-    
+
     def __str__(self):
+        """Convert to JSON string when stringified."""
         # Return a JSON array directly without wrapping in an "items" key
         return json.dumps(self._items)
 
 
+class MockListPageItemsMethod:
+    """Mock ListPage with items as a method."""
+
+    def __init__(self):
+        """Initialize with internal items collection."""
+        self._items = [{"id": 6, "title": "Test items as method"}]
+
+    def items(self):
+        """Return items as a method result."""
+        return self._items
+
+
+class MockListPagePrivateItems:
+    """Mock ListPage with _items private attribute."""
+
+    def __init__(self):
+        """Initialize with private _items attribute."""
+        self._items = [{"id": 7, "title": "Test private _items attribute"}]
+
+
 class TestApifyServiceExtended:
     """Extended tests for ApifyService focusing on ListPage handling."""
-    
+
     @patch("local_newsifier.services.apify_service.ApifyClient")
     def test_get_dataset_items_with_items_attribute(self, mock_client_class):
         """Test get_dataset_items with a ListPage that has items attribute."""
         # Setup
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        
+
         mock_dataset = Mock()
         mock_client.dataset.return_value = mock_dataset
-        
+
         list_page = MockListPageWithItems()
         mock_dataset.list_items.return_value = list_page
-        
+
         # Execute
         service = ApifyService(token="test_token")
         result = service.get_dataset_items("test-dataset")
-        
+
         # Verify
         assert result == {"items": [{"id": 1, "title": "Test with items attribute"}]}
-    
+
     @patch("local_newsifier.services.apify_service.ApifyClient")
     def test_get_dataset_items_with_iterable(self, mock_client_class):
         """Test get_dataset_items with an iterable ListPage."""
         # Setup
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        
+
         mock_dataset = Mock()
         mock_client.dataset.return_value = mock_dataset
-        
+
         list_page = MockListPageIterable()
         mock_dataset.list_items.return_value = list_page
-        
+
         # Execute
         service = ApifyService(token="test_token")
         result = service.get_dataset_items("test-dataset")
-        
+
         # Verify
         assert result == {"items": [{"id": 2, "title": "Test iterable"}]}
-    
+
     @patch("local_newsifier.services.apify_service.ApifyClient")
     def test_get_dataset_items_with_data_attribute(self, mock_client_class):
         """Test get_dataset_items with a ListPage that has data attribute."""
         # Setup
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        
+
         mock_dataset = Mock()
         mock_client.dataset.return_value = mock_dataset
-        
+
         list_page = MockListPageWithData()
         mock_dataset.list_items.return_value = list_page
-        
+
         # Execute
         service = ApifyService(token="test_token")
         result = service.get_dataset_items("test-dataset")
-        
+
         # Verify
         assert result == {"items": [{"id": 3, "title": "Test with data attribute"}]}
-    
-    # @patch("local_newsifier.services.apify_service.ApifyClient")
-    # def test_get_dataset_items_with_dict_like(self, mock_client_class):
-    #     """Test get_dataset_items with a dict-like ListPage."""
-    #     # Setup
-    #     mock_client = Mock()
-    #     mock_client_class.return_value = mock_client
-    #     
-    #     mock_dataset = Mock()
-    #     mock_client.dataset.return_value = mock_dataset
-    #     
-    #     list_page = MockListPageDict()
-    #     mock_dataset.list_items.return_value = list_page
-    #     
-    #     # Execute
-    #     service = ApifyService(token="test_token")
-    #     result = service.get_dataset_items("test-dataset")
-    #     
-    #     # Verify
-    #     assert result == {"items": [{"id": 4, "title": "Test dict-like"}]}
-    #     
-    # Test commented out due to inconsistent behavior with JSON parsing
-    # See issue #128
-    
+
+    @patch("local_newsifier.services.apify_service.ApifyClient")
+    def test_get_dataset_items_with_dict_like(self, mock_client_class):
+        """Test get_dataset_items with a dict-like ListPage."""
+        # Setup
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+
+        mock_dataset = Mock()
+        mock_client.dataset.return_value = mock_dataset
+
+        list_page = MockListPageDict()
+        mock_dataset.list_items.return_value = list_page
+
+        # Execute
+        service = ApifyService(token="test_token")
+        result = service.get_dataset_items("test-dataset")
+
+        # Verify
+        assert result == {"items": [{"id": 4, "title": "Test dict-like"}]}
+
     @patch("local_newsifier.services.apify_service.ApifyClient")
     def test_get_dataset_items_with_string_conversion(self, mock_client_class):
         """Test get_dataset_items with a ListPage that converts to JSON string."""
         # Setup
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        
+
         mock_dataset = Mock()
         mock_client.dataset.return_value = mock_dataset
-        
+
         list_page = MockListPageString()
         mock_dataset.list_items.return_value = list_page
-        
+
         # Execute
         service = ApifyService(token="test_token")
         result = service.get_dataset_items("test-dataset")
-        
+
         # Verify
         assert result == {"items": [{"id": 5, "title": "Test string conversion"}]}
-    
+
+    @patch("local_newsifier.services.apify_service.ApifyClient")
+    def test_get_dataset_items_with_items_method(self, mock_client_class):
+        """Test get_dataset_items with a ListPage that has items as a method."""
+        # Setup
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+
+        mock_dataset = Mock()
+        mock_client.dataset.return_value = mock_dataset
+
+        list_page = MockListPageItemsMethod()
+        mock_dataset.list_items.return_value = list_page
+
+        # Execute
+        service = ApifyService(token="test_token")
+        result = service.get_dataset_items("test-dataset")
+
+        # Verify
+        assert result == {"items": [{"id": 6, "title": "Test items as method"}]}
+
+    @patch("local_newsifier.services.apify_service.ApifyClient")
+    def test_get_dataset_items_with_private_items(self, mock_client_class):
+        """Test get_dataset_items with a ListPage that has a private _items attribute."""
+        # Setup
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+
+        mock_dataset = Mock()
+        mock_client.dataset.return_value = mock_dataset
+
+        list_page = MockListPagePrivateItems()
+        mock_dataset.list_items.return_value = list_page
+
+        # Execute
+        service = ApifyService(token="test_token")
+        result = service.get_dataset_items("test-dataset")
+
+        # Verify
+        assert result == {
+            "items": [{"id": 7, "title": "Test private _items attribute"}]
+        }
+
+    @patch("local_newsifier.services.apify_service.ApifyClient")
+    def test_get_dataset_items_with_json_parsing_edge_cases(self, mock_client_class):
+        """Test get_dataset_items with various JSON string formats."""
+        # Setup
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+
+        mock_dataset = Mock()
+        mock_client.dataset.return_value = mock_dataset
+
+        # Create a JSON object with wrapped items
+        class JsonObjectWithItems:
+            """Mock object that returns JSON with items key."""
+
+            def __str__(self):
+                """Return JSON string with items key."""
+                return '{"items": [{"id": 8, "title": "JSON object with items"}]}'
+
+        # Execute test with JSON object containing items key
+        mock_dataset.list_items.return_value = JsonObjectWithItems()
+        service = ApifyService(token="test_token")
+        result = service.get_dataset_items("test-dataset")
+
+        # Verify
+        assert result == {"items": [{"id": 8, "title": "JSON object with items"}]}
+
+        # Create a JSON object without items key
+        class JsonObjectWithoutItems:
+            """Mock object that returns JSON without items key."""
+
+            def __str__(self):
+                """Return JSON string without items key."""
+                return '{"id": 9, "title": "Single JSON object"}'
+
+        # Execute test with single JSON object
+        mock_dataset.list_items.return_value = JsonObjectWithoutItems()
+        result = service.get_dataset_items("test-dataset")
+
+        # Verify - should wrap the object in an array
+        assert result == {"items": [{"id": 9, "title": "Single JSON object"}]}
+
     @patch("local_newsifier.services.apify_service.ApifyClient")
     def test_get_dataset_items_with_exception(self, mock_client_class):
         """Test get_dataset_items when an exception occurs."""
         # Setup
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        
+
         mock_dataset = Mock()
         mock_client.dataset.return_value = mock_dataset
-        
+
         # Create an object that raises an exception when accessed
         class ExceptionObject:
+            """Mock object that raises exceptions on access."""
+
             def __getattr__(self, name):
+                """Raise exception when any attribute is accessed."""
                 raise ValueError("Test exception")
-            
+
             def __iter__(self):
+                """Raise exception when iteration is attempted."""
                 raise ValueError("Test exception")
-            
+
             def __str__(self):
+                """Raise exception when string conversion is attempted."""
                 raise ValueError("Test exception")
-        
+
         list_page = ExceptionObject()
         mock_dataset.list_items.return_value = list_page
-        
+
         # Execute
         service = ApifyService(token="test_token")
         result = service.get_dataset_items("test-dataset")
-        
+
         # Verify - should return empty items list with error
         assert "items" in result
         assert isinstance(result["items"], list)
         assert len(result["items"]) == 0
         assert "error" in result
         assert "Test exception" in result["error"]
+        assert "Traceback" in result["error"]


### PR DESCRIPTION
## Summary
- Fixed ListPage handling in ApifyService to resolve issue #127 where 'ListPage' object was not iterable
- Enhanced get_dataset_items method to support various ListPage formats including callable items attributes, dict-like access, and private attributes
- Added comprehensive tests for different ListPage object scenarios
- Improved error reporting with type information and full tracebacks
- Removed problematic name-tests-test pre-commit hook that conflicted with project convention

## Test plan
- Run `poetry run pytest tests/services/test_apify_service*.py -v` to verify all tests pass
- Test with a real Apify API token using `poetry run nf apify test`
- Try scraping content with `poetry run nf apify scrape-content https://example.com`
- Verify code coverage is >90% with `poetry run pytest --cov=src/local_newsifier/services/apify_service.py tests/services/test_apify_service*.py`

🤖 Generated with [Claude Code](https://claude.ai/code)