### PR TITLE
Fix: Add web-scraper command for Apify integration

### DIFF
--- a/src/local_newsifier/cli/commands/apify.py
+++ b/src/local_newsifier/cli/commands/apify.py
@@ -8,10 +8,10 @@ This module provides commands for interacting with the Apify API, including:
 - Testing the Apify connection
 """
 
-import os
 import json
+import os
+
 import click
-from datetime import datetime
 from tabulate import tabulate
 
 # Import directly instead of using container to avoid loading flow dependencies
@@ -27,7 +27,7 @@ def apify_group():
 
 def _ensure_token():
     """Ensure the Apify token is set in environment or settings.
-    
+
     Returns:
         bool: True if token is available, False otherwise
     """
@@ -36,11 +36,11 @@ def _ensure_token():
     if token:
         settings.APIFY_TOKEN = token
         return True
-        
+
     # Check if already set in settings
     if settings.APIFY_TOKEN:
         return True
-        
+
     click.echo(click.style("Error: APIFY_TOKEN is not set.", fg="red"), err=True)
     click.echo("Please set it using one of these methods:")
     click.echo("  1. Export as environment variable: export APIFY_TOKEN=your_token")
@@ -57,24 +57,26 @@ def test_connection(token):
         settings.APIFY_TOKEN = token
     elif not _ensure_token():
         return
-    
+
     try:
         # Create the Apify service directly
         apify_service = ApifyService(token)
-        
+
         # Test if we can access the client
         client = apify_service.client
-        
+
         # Simple test operation - get user info
         user = client.user().get()
-        
+
         click.echo(click.style("✓ Connection to Apify API successful!", fg="green"))
         click.echo(f"Connected as: {user.get('username', 'Unknown user')}")
-        
+
     except ValueError as e:
         click.echo(click.style(f"Error: {str(e)}", fg="red"), err=True)
     except Exception as e:
-        click.echo(click.style(f"Error connecting to Apify API: {str(e)}", fg="red"), err=True)
+        click.echo(
+            click.style(f"Error connecting to Apify API: {str(e)}", fg="red"), err=True
+        )
 
 
 @apify_group.command(name="run-actor")
@@ -85,48 +87,58 @@ def test_connection(token):
 @click.option("--output", "-o", help="Save output to file")
 def run_actor(actor_id, input, wait, token, output):
     """Run an Apify actor.
-    
+
     ACTOR_ID can be in the format username/actor-name or actor-id.
-    
+
+    For specific actor types, we recommend using the following specialized commands:
+    - For web-scraper actor: Use 'nf apify web-scraper' command (handles pageFunction)
+    - For website-content-crawler: Use 'nf apify scrape-content' command
+
     Examples:
-        nf apify run-actor apify/web-scraper --input '{"startUrls":[{"url":"https://example.com"}]}'
+        nf apify run-actor apify/web-scraper --input '{"startUrls":[{"url":"https://example.com"}],
+            "pageFunction":"async function pageFunction(c) { return {url: c.request.url} }"}'
         nf apify run-actor apify/website-content-crawler --input actor_input.json
     """
     if token:
         settings.APIFY_TOKEN = token
     elif not _ensure_token():
         return
-    
+
     # Parse input
     run_input = {}
     if input:
         if os.path.isfile(input):
             try:
-                with open(input, 'r') as f:
+                with open(input, "r") as f:
                     run_input = json.load(f)
                 click.echo(f"Loaded input from file: {input}")
             except Exception as e:
-                click.echo(click.style(f"Error loading input file: {str(e)}", fg="red"), err=True)
+                click.echo(
+                    click.style(f"Error loading input file: {str(e)}", fg="red"),
+                    err=True,
+                )
                 return
         else:
             try:
                 run_input = json.loads(input)
             except json.JSONDecodeError:
-                click.echo(click.style("Error: Input must be valid JSON", fg="red"), err=True)
+                click.echo(
+                    click.style("Error: Input must be valid JSON", fg="red"), err=True
+                )
                 return
-    
+
     try:
         # Create Apify service directly
         apify_service = ApifyService(token)
-        
+
         # Run the actor
         click.echo(f"Running actor {actor_id}...")
         result = apify_service.run_actor(actor_id, run_input)
-        
+
         # Process result
         if wait:
             click.echo(click.style("✓ Actor run completed!", fg="green"))
-            
+
             # Get the dataset ID
             dataset_id = result.get("defaultDatasetId")
             if dataset_id:
@@ -135,15 +147,15 @@ def run_actor(actor_id, input, wait, token, output):
         else:
             click.echo(click.style("✓ Actor run started!", fg="green"))
             click.echo("Run details:")
-        
+
         # Display or save output
         if output:
-            with open(output, 'w') as f:
+            with open(output, "w") as f:
                 json.dump(result, f, indent=2)
             click.echo(f"Output saved to {output}")
         else:
             click.echo(json.dumps(result, indent=2))
-        
+
     except ValueError as e:
         click.echo(click.style(f"Error: {str(e)}", fg="red"), err=True)
     except Exception as e:
@@ -152,17 +164,24 @@ def run_actor(actor_id, input, wait, token, output):
 
 @apify_group.command(name="get-dataset")
 @click.argument("dataset_id", required=True)
-@click.option("--limit", type=int, default=10, help="Maximum number of items to retrieve")
+@click.option(
+    "--limit", type=int, default=10, help="Maximum number of items to retrieve"
+)
 @click.option("--offset", type=int, default=0, help="Number of items to skip")
 @click.option("--token", help="Apify API token (overrides environment/settings)")
 @click.option("--output", "-o", help="Save output to file")
-@click.option("--format", "format_type", type=click.Choice(['json', 'table']), default='json',
-              help="Output format (json or table)")
+@click.option(
+    "--format",
+    "format_type",
+    type=click.Choice(["json", "table"]),
+    default="json",
+    help="Output format (json or table)",
+)
 def get_dataset(dataset_id, limit, offset, token, output, format_type):
     """Retrieve items from an Apify dataset.
-    
+
     DATASET_ID is the ID of the dataset to retrieve.
-    
+
     Examples:
         nf apify get-dataset bPmJXQ5Ym98KjL9TP --limit 5
         nf apify get-dataset bPmJXQ5Ym98KjL9TP --output dataset_results.json
@@ -171,39 +190,41 @@ def get_dataset(dataset_id, limit, offset, token, output, format_type):
         settings.APIFY_TOKEN = token
     elif not _ensure_token():
         return
-    
+
     try:
         # Create Apify service directly
         apify_service = ApifyService(token)
-        
+
         # Get dataset items
         click.echo(f"Retrieving items from dataset {dataset_id}...")
         result = apify_service.get_dataset_items(dataset_id, limit=limit, offset=offset)
-        
+
         items = result.get("items", [])
         count = len(items)
-        
+
         click.echo(click.style(f"✓ Retrieved {count} items!", fg="green"))
-        
+
         # Process output
         if output:
-            with open(output, 'w') as f:
+            with open(output, "w") as f:
                 json.dump(result, f, indent=2)
             click.echo(f"Output saved to {output}")
             return
-        
+
         # Display results
-        if format_type == 'table' and items:
+        if format_type == "table" and items:
             # Try to create a tabular view if possible
             if isinstance(items[0], dict):
                 # Use the first item's keys as columns
                 headers = list(items[0].keys())
-                
+
                 # Limit to a reasonable number of columns
                 if len(headers) > 5:
                     headers = headers[:5]
-                    click.echo("Note: Only showing first 5 columns due to space constraints")
-                
+                    click.echo(
+                        "Note: Only showing first 5 columns due to space constraints"
+                    )
+
                 # Create table data
                 table_data = []
                 for item in items:
@@ -217,18 +238,20 @@ def get_dataset(dataset_id, limit, offset, token, output, format_type):
                             value = str(type(value).__name__)
                         row.append(value)
                     table_data.append(row)
-                
+
                 click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
             else:
                 click.echo("Cannot display as table - items are not dictionaries")
                 click.echo(json.dumps(items, indent=2))
         else:
             click.echo(json.dumps(items, indent=2))
-        
+
     except ValueError as e:
         click.echo(click.style(f"Error: {str(e)}", fg="red"), err=True)
     except Exception as e:
-        click.echo(click.style(f"Error retrieving dataset: {str(e)}", fg="red"), err=True)
+        click.echo(
+            click.style(f"Error retrieving dataset: {str(e)}", fg="red"), err=True
+        )
 
 
 @apify_group.command(name="get-actor")
@@ -236,9 +259,9 @@ def get_dataset(dataset_id, limit, offset, token, output, format_type):
 @click.option("--token", help="Apify API token (overrides environment/settings)")
 def get_actor(actor_id, token):
     """Get details about an Apify actor.
-    
+
     ACTOR_ID can be in the format username/actor-name or actor-id.
-    
+
     Examples:
         nf apify get-actor apify/web-scraper
     """
@@ -246,49 +269,53 @@ def get_actor(actor_id, token):
         settings.APIFY_TOKEN = token
     elif not _ensure_token():
         return
-    
+
     try:
         # Create Apify service directly
         apify_service = ApifyService(token)
-        
+
         # Get actor details
         click.echo(f"Retrieving details for actor {actor_id}...")
         actor = apify_service.get_actor_details(actor_id)
-        
-        click.echo(click.style(f"✓ Actor details retrieved!", fg="green"))
+
+        click.echo(click.style("✓ Actor details retrieved!", fg="green"))
         click.echo(f"Name: {actor.get('name')}")
         click.echo(f"Title: {actor.get('title')}")
         click.echo(f"Description: {actor.get('description', 'N/A')}")
         click.echo(f"Version: {actor.get('version', {}).get('versionNumber', 'N/A')}")
-        
+
         # Display input schema if available
-        input_schema = actor.get('defaultRunInput')
+        input_schema = actor.get("defaultRunInput")
         if input_schema:
             click.echo("\nInput Schema:")
             click.echo(json.dumps(input_schema, indent=2))
-        
+
     except ValueError as e:
         click.echo(click.style(f"Error: {str(e)}", fg="red"), err=True)
     except Exception as e:
-        click.echo(click.style(f"Error retrieving actor details: {str(e)}", fg="red"), err=True)
+        click.echo(
+            click.style(f"Error retrieving actor details: {str(e)}", fg="red"), err=True
+        )
 
 
 @apify_group.command(name="scrape-content")
 @click.argument("url", required=True)
-@click.option("--max-pages", type=int, default=5, 
-              help="Maximum number of pages to scrape")
-@click.option("--max-depth", type=int, default=1,
-              help="Maximum crawl depth from start URL")
+@click.option(
+    "--max-pages", type=int, default=5, help="Maximum number of pages to scrape"
+)
+@click.option(
+    "--max-depth", type=int, default=1, help="Maximum crawl depth from start URL"
+)
 @click.option("--token", help="Apify API token (overrides environment/settings)")
 @click.option("--output", "-o", help="Save output to file")
 def scrape_content(url, max_pages, max_depth, token, output):
     """Scrape content from a website using Apify website-content-crawler.
-    
+
     This is a convenience command that uses Apify's website-content-crawler actor
     to scrape content from a website.
-    
+
     URL is the starting URL to scrape from.
-    
+
     Examples:
         nf apify scrape-content https://example.com --max-pages 10
         nf apify scrape-content https://news.site.com --max-depth 2 --output results.json
@@ -297,42 +324,46 @@ def scrape_content(url, max_pages, max_depth, token, output):
         settings.APIFY_TOKEN = token
     elif not _ensure_token():
         return
-    
+
     try:
         # Create Apify service directly
         apify_service = ApifyService(token)
-        
+
         # Configure the actor input
         run_input = {
             "startUrls": [{"url": url}],
             "maxCrawlPages": max_pages,
             "maxCrawlDepth": max_depth,
-            "maxPagesPerCrawl": max_pages
+            "maxPagesPerCrawl": max_pages,
         }
-        
+
         # Run the actor
         click.echo(f"Scraping content from {url}...")
         click.echo(f"Using max pages: {max_pages}, max depth: {max_depth}")
-        
+
         result = apify_service.run_actor("apify/website-content-crawler", run_input)
-        
+
         # Get the dataset ID
         dataset_id = result.get("defaultDatasetId")
         if not dataset_id:
-            click.echo(click.style("Error: No dataset ID found in result", fg="red"), err=True)
+            click.echo(
+                click.style("Error: No dataset ID found in result", fg="red"), err=True
+            )
             return
-            
+
         click.echo(f"Scraping complete! Retrieving data from dataset: {dataset_id}")
-        
+
         # Get the dataset items
         dataset = apify_service.get_dataset_items(dataset_id)
         items = dataset.get("items", [])
-        
-        click.echo(click.style(f"✓ Retrieved {len(items)} pages of content!", fg="green"))
-        
+
+        click.echo(
+            click.style(f"✓ Retrieved {len(items)} pages of content!", fg="green")
+        )
+
         # Save or display the results
         if output:
-            with open(output, 'w') as f:
+            with open(output, "w") as f:
                 json.dump(items, f, indent=2)
             click.echo(f"Output saved to {output}")
         else:
@@ -345,19 +376,143 @@ def scrape_content(url, max_pages, max_depth, token, output):
                 # Truncate title if too long
                 if len(title) > 50:
                     title = title[:47] + "..."
-                
+
                 table_data.append([i, title, url])
-            
+
             if items:
                 headers = ["#", "Title", "URL"]
                 click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
-                
+
                 if len(items) > 10:
-                    click.echo(f"\n...and {len(items) - 10} more items.")
+                    remaining_items = len(items) - 10
+                    click.echo(f"\n...and {remaining_items} more items.")
             else:
                 click.echo("No items were scraped.")
-        
+
     except ValueError as e:
         click.echo(click.style(f"Error: {str(e)}", fg="red"), err=True)
     except Exception as e:
         click.echo(click.style(f"Error scraping content: {str(e)}", fg="red"), err=True)
+
+
+@apify_group.command(name="web-scraper")
+@click.argument("url", required=True)
+@click.option("--selector", default="a", help="CSS selector for links to follow")
+@click.option(
+    "--max-pages", type=int, default=5, help="Maximum number of pages to scrape"
+)
+@click.option("--wait-for", help="CSS selector to wait for before scraping")
+@click.option("--page-function", help="Custom page function JavaScript code")
+@click.option("--output", "-o", help="Save output to file")
+@click.option("--token", help="Apify API token (overrides environment/settings)")
+def web_scraper(url, selector, max_pages, wait_for, page_function, output, token):
+    """Scrape websites using Apify's web-scraper actor.
+
+    This command uses Apify's web-scraper actor to scrape websites,
+    handling all required configuration including the pageFunction.
+
+    URL is the starting URL to scrape from.
+
+    Examples:
+        nf apify web-scraper https://example.com
+        nf apify web-scraper https://news.site.com --selector "article a" --output results.json
+    """
+    if token:
+        settings.APIFY_TOKEN = token
+    elif not _ensure_token():
+        return
+
+    try:
+        # Create Apify service directly
+        apify_service = ApifyService(token)
+
+        # Default page function if not provided
+        default_page_function = """
+        async function pageFunction(context) {
+            const { request, log, jQuery } = context;
+            const $ = jQuery;
+            const title = $('title').text();
+            const h1 = $('h1').text();
+
+            log.info("Page " + request.url + " loaded.");
+
+            // Extract all text from main content (if available), or body as fallback
+            const mainText = $('main, article, #content, .content').text() ||
+                $('body').text();
+
+            // Return data
+            return {
+                url: request.url,
+                title: title,
+                h1: h1,
+                content: mainText
+            };
+        }
+        """
+
+        # Configure the actor input
+        run_input = {
+            "startUrls": [{"url": url}],
+            "linkSelector": selector,
+            "pageFunction": page_function or default_page_function,
+            "maxPagesPerCrawl": max_pages,
+        }
+
+        # Add waitFor if provided
+        if wait_for:
+            run_input["waitFor"] = wait_for
+
+        # Run the actor
+        click.echo(f"Scraping website from {url}...")
+        click.echo(f"Using selector: {selector}, max pages: {max_pages}")
+
+        result = apify_service.run_actor("apify/web-scraper", run_input)
+
+        # Get the dataset ID
+        dataset_id = result.get("defaultDatasetId")
+        if not dataset_id:
+            click.echo(
+                click.style("Error: No dataset ID found in result", fg="red"), err=True
+            )
+            return
+
+        click.echo(f"Scraping complete! Retrieving data from dataset: {dataset_id}")
+
+        # Get the dataset items
+        dataset = apify_service.get_dataset_items(dataset_id)
+        items = dataset.get("items", [])
+
+        click.echo(click.style(f"✓ Retrieved {len(items)} pages of data!", fg="green"))
+
+        # Save or display the results
+        if output:
+            with open(output, "w") as f:
+                json.dump(items, f, indent=2)
+            click.echo(f"Output saved to {output}")
+        else:
+            # Display a summary of the results
+            click.echo("\nScraping Results Summary:")
+            table_data = []
+            for i, item in enumerate(items[:10], 1):  # Show up to 10 items
+                url = item.get("url", "N/A")
+                title = item.get("title", "N/A")
+                # Truncate title if too long
+                if len(title) > 50:
+                    title = title[:47] + "..."
+
+                table_data.append([i, title, url])
+
+            if items:
+                headers = ["#", "Title", "URL"]
+                click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
+
+                if len(items) > 10:
+                    remaining_items = len(items) - 10
+                    click.echo(f"\n...and {remaining_items} more items.")
+            else:
+                click.echo("No items were scraped.")
+
+    except ValueError as e:
+        click.echo(click.style(f"Error: {str(e)}", fg="red"), err=True)
+    except Exception as e:
+        click.echo(click.style(f"Error scraping website: {str(e)}", fg="red"), err=True)

--- a/tests/cli/test_apify_commands.py
+++ b/tests/cli/test_apify_commands.py
@@ -1,17 +1,17 @@
 """Tests for the Apify CLI commands."""
 
-import os
 import json
+import os
 import tempfile
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
-from local_newsifier.cli.commands.apify import (
-    apify_group, _ensure_token, test_connection,
-    run_actor, get_dataset, get_actor, scrape_content
-)
+from local_newsifier.cli.commands.apify import (_ensure_token, get_actor,
+                                                get_dataset, run_actor,
+                                                scrape_content,
+                                                test_connection, web_scraper)
 from local_newsifier.config.settings import settings
 from local_newsifier.services.apify_service import ApifyService
 
@@ -20,26 +20,26 @@ from local_newsifier.services.apify_service import ApifyService
 def mock_apify_service():
     """Create a mock ApifyService."""
     mock_service = MagicMock(spec=ApifyService)
-    
+
     # Mock client property
     mock_client = MagicMock()
     type(mock_service).client = mock_client
-    
+
     # Mock user info
     mock_client.user().get.return_value = {"username": "test_user"}
-    
+
     # Mock actor run
     mock_service.run_actor.return_value = {
         "id": "test_run",
         "status": "SUCCEEDED",
-        "defaultDatasetId": "test_dataset"
+        "defaultDatasetId": "test_dataset",
     }
-    
+
     # Mock dataset items
     mock_service.get_dataset_items.return_value = {
         "items": [{"id": 1, "title": "Test Article", "url": "https://example.com"}]
     }
-    
+
     # Mock actor details
     mock_service.get_actor_details.return_value = {
         "id": "test_actor",
@@ -47,9 +47,9 @@ def mock_apify_service():
         "title": "Test Actor Title",
         "description": "Test actor description",
         "version": {"versionNumber": "1.0.0"},
-        "defaultRunInput": {"field1": "value1"}
+        "defaultRunInput": {"field1": "value1"},
     }
-    
+
     return mock_service
 
 
@@ -64,185 +64,208 @@ def original_token():
     """Store and restore the original token."""
     original = os.environ.get("APIFY_TOKEN")
     original_settings = settings.APIFY_TOKEN
-    
+
     yield
-    
+
     # Restore the original token
     if original:
         os.environ["APIFY_TOKEN"] = original
     elif "APIFY_TOKEN" in os.environ:
         del os.environ["APIFY_TOKEN"]
-        
+
     settings.APIFY_TOKEN = original_settings
 
 
 class TestApifyCommands:
     """Test the Apify CLI commands."""
-    
+
     def test_ensure_token_with_env_var(self, original_token):
         """Test ensuring the token with the env var."""
         os.environ["APIFY_TOKEN"] = "test_token"
         assert _ensure_token() is True
         assert settings.APIFY_TOKEN == "test_token"
-    
+
     def test_ensure_token_with_settings(self, original_token):
         """Test ensuring the token with settings."""
         if "APIFY_TOKEN" in os.environ:
             del os.environ["APIFY_TOKEN"]
         settings.APIFY_TOKEN = "settings_token"
         assert _ensure_token() is True
-        
+
     def test_ensure_token_missing(self, runner, original_token):
         """Test ensuring the token when it's missing."""
         if "APIFY_TOKEN" in os.environ:
             del os.environ["APIFY_TOKEN"]
         settings.APIFY_TOKEN = None
         assert _ensure_token() is False
-    
+
     @patch("local_newsifier.cli.commands.apify.ApifyService")
-    def test_test_connection(self, mock_service_class, mock_apify_service, runner, original_token):
+    def test_test_connection(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
         """Test the test connection command."""
         # Setup
         mock_service_class.return_value = mock_apify_service
         os.environ["APIFY_TOKEN"] = "test_token"
-        
+
         # Run the command
         result = runner.invoke(test_connection)
-        
+
         # Verify
         assert result.exit_code == 0
         assert "Connection to Apify API successful" in result.output
         assert "Connected as: test_user" in result.output
-    
+
     @patch("local_newsifier.cli.commands.apify.ApifyService")
-    def test_test_connection_with_token_param(self, mock_service_class, mock_apify_service, runner, original_token):
+    def test_test_connection_with_token_param(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
         """Test the test connection command with token parameter."""
         # Setup
         mock_service_class.return_value = mock_apify_service
-        
+
         # Run the command
         result = runner.invoke(test_connection, ["--token", "param_token"])
-        
+
         # Verify
         assert result.exit_code == 0
         assert "Connection to Apify API successful" in result.output
         mock_service_class.assert_called_once_with("param_token")
-    
+
     @patch("local_newsifier.cli.commands.apify.ApifyService")
-    def test_run_actor(self, mock_service_class, mock_apify_service, runner, original_token):
+    def test_run_actor(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
         """Test the run actor command."""
         # Setup
         mock_service_class.return_value = mock_apify_service
         os.environ["APIFY_TOKEN"] = "test_token"
-        
+
         # Run the command
-        result = runner.invoke(run_actor, ["test_actor", "--input", '{"param":"value"}'])
-        
+        result = runner.invoke(
+            run_actor, ["test_actor", "--input", '{"param":"value"}']
+        )
+
         # Verify
         assert result.exit_code == 0
         assert "Running actor test_actor" in result.output
         assert "Actor run completed" in result.output
         assert "Default dataset ID: test_dataset" in result.output
-        mock_apify_service.run_actor.assert_called_once_with("test_actor", {"param": "value"})
-    
+        mock_apify_service.run_actor.assert_called_once_with(
+            "test_actor", {"param": "value"}
+        )
+
     @patch("local_newsifier.cli.commands.apify.ApifyService")
-    def test_run_actor_with_input_file(self, mock_service_class, mock_apify_service, runner, original_token):
+    def test_run_actor_with_input_file(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
         """Test the run actor command with input file."""
         # Setup
         mock_service_class.return_value = mock_apify_service
         os.environ["APIFY_TOKEN"] = "test_token"
-        
+
         # Create a temporary file with input
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             json.dump({"param": "file_value"}, f)
             input_file = f.name
-        
+
         try:
             # Run the command
             result = runner.invoke(run_actor, ["test_actor", "--input", input_file])
-            
+
             # Verify
             assert result.exit_code == 0
             assert "Loaded input from file" in result.output
             assert "Running actor test_actor" in result.output
-            mock_apify_service.run_actor.assert_called_once_with("test_actor", {"param": "file_value"})
+            mock_apify_service.run_actor.assert_called_once_with(
+                "test_actor", {"param": "file_value"}
+            )
         finally:
             # Clean up
             os.unlink(input_file)
-    
+
     @patch("local_newsifier.cli.commands.apify.ApifyService")
-    def test_run_actor_with_output_file(self, mock_service_class, mock_apify_service, runner, original_token):
+    def test_run_actor_with_output_file(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
         """Test the run actor command with output to file."""
         # Setup
         mock_service_class.return_value = mock_apify_service
         os.environ["APIFY_TOKEN"] = "test_token"
-        
+
         with tempfile.NamedTemporaryFile(delete=False) as f:
             output_file = f.name
-        
+
         try:
             # Run the command
-            result = runner.invoke(run_actor, [
-                "test_actor", 
-                "--input", '{"param":"value"}',
-                "--output", output_file
-            ])
-            
+            result = runner.invoke(
+                run_actor,
+                ["test_actor", "--input", '{"param":"value"}', "--output", output_file],
+            )
+
             # Verify
             assert result.exit_code == 0
             assert f"Output saved to {output_file}" in result.output
-            
+
             # Check the output file contents
-            with open(output_file, 'r') as f:
+            with open(output_file, "r") as f:
                 output_content = json.load(f)
                 assert output_content["id"] == "test_run"
         finally:
             # Clean up
             os.unlink(output_file)
-    
+
     @patch("local_newsifier.cli.commands.apify.ApifyService")
-    def test_get_dataset(self, mock_service_class, mock_apify_service, runner, original_token):
+    def test_get_dataset(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
         """Test the get dataset command."""
         # Setup
         mock_service_class.return_value = mock_apify_service
         os.environ["APIFY_TOKEN"] = "test_token"
-        
+
         # Run the command
         result = runner.invoke(get_dataset, ["test_dataset"])
-        
+
         # Verify
         assert result.exit_code == 0
         assert "Retrieving items from dataset test_dataset" in result.output
         assert "Retrieved 1 items" in result.output
-        mock_apify_service.get_dataset_items.assert_called_once_with("test_dataset", limit=10, offset=0)
-    
+        mock_apify_service.get_dataset_items.assert_called_once_with(
+            "test_dataset", limit=10, offset=0
+        )
+
     @patch("local_newsifier.cli.commands.apify.ApifyService")
-    def test_get_dataset_with_table_format(self, mock_service_class, mock_apify_service, runner, original_token):
+    def test_get_dataset_with_table_format(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
         """Test the get dataset command with table format."""
         # Setup
         mock_service_class.return_value = mock_apify_service
         os.environ["APIFY_TOKEN"] = "test_token"
-        
+
         # Run the command
         result = runner.invoke(get_dataset, ["test_dataset", "--format", "table"])
-        
+
         # Verify
         assert result.exit_code == 0
         assert "Retrieving items from dataset test_dataset" in result.output
         assert "Retrieved 1 items" in result.output
         # Table output should have headers - lowercase column names
         assert "title" in result.output
-        
+
     @patch("local_newsifier.cli.commands.apify.ApifyService")
-    def test_get_actor(self, mock_service_class, mock_apify_service, runner, original_token):
+    def test_get_actor(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
         """Test the get actor command."""
         # Setup
         mock_service_class.return_value = mock_apify_service
         os.environ["APIFY_TOKEN"] = "test_token"
-        
+
         # Run the command
         result = runner.invoke(get_actor, ["test_actor"])
-        
+
         # Verify
         assert result.exit_code == 0
         assert "Retrieving details for actor test_actor" in result.output
@@ -251,56 +274,159 @@ class TestApifyCommands:
         assert "Description: Test actor description" in result.output
         assert "Input Schema" in result.output
         mock_apify_service.get_actor_details.assert_called_once_with("test_actor")
-    
+
     @patch("local_newsifier.cli.commands.apify.ApifyService")
-    def test_scrape_content(self, mock_service_class, mock_apify_service, runner, original_token):
+    def test_scrape_content(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
         """Test the scrape content command."""
         # Setup
         mock_service_class.return_value = mock_apify_service
         os.environ["APIFY_TOKEN"] = "test_token"
-        
+
         # Run the command
         result = runner.invoke(scrape_content, ["https://example.com"])
-        
+
         # Verify
         assert result.exit_code == 0
         assert "Scraping content from https://example.com" in result.output
         assert "Using max pages: 5, max depth: 1" in result.output
         assert "Scraping complete!" in result.output
         assert "Retrieved 1 pages of content" in result.output
-        
+
         # Check the actor input
         expected_input = {
             "startUrls": [{"url": "https://example.com"}],
             "maxCrawlPages": 5,
             "maxCrawlDepth": 1,
-            "maxPagesPerCrawl": 5
+            "maxPagesPerCrawl": 5,
         }
-        mock_apify_service.run_actor.assert_called_once_with("apify/website-content-crawler", expected_input)
-        
+        mock_apify_service.run_actor.assert_called_once_with(
+            "apify/website-content-crawler", expected_input
+        )
+
     @patch("local_newsifier.cli.commands.apify.ApifyService")
-    def test_scrape_content_with_output(self, mock_service_class, mock_apify_service, runner, original_token):
+    def test_scrape_content_with_output(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
         """Test the scrape content command with output to file."""
         # Setup
         mock_service_class.return_value = mock_apify_service
         os.environ["APIFY_TOKEN"] = "test_token"
-        
+
         with tempfile.NamedTemporaryFile(delete=False) as f:
             output_file = f.name
-        
+
         try:
             # Run the command
-            result = runner.invoke(scrape_content, [
-                "https://example.com",
-                "--output", output_file
-            ])
-            
+            result = runner.invoke(
+                scrape_content, ["https://example.com", "--output", output_file]
+            )
+
             # Verify
             assert result.exit_code == 0
             assert f"Output saved to {output_file}" in result.output
-            
+
             # Check the output file contents
-            with open(output_file, 'r') as f:
+            with open(output_file, "r") as f:
+                output_content = json.load(f)
+                assert len(output_content) == 1
+                assert output_content[0]["id"] == 1
+        finally:
+            # Clean up
+            os.unlink(output_file)
+
+    @patch("local_newsifier.cli.commands.apify.ApifyService")
+    def test_web_scraper(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
+        """Test the web-scraper command."""
+        # Setup
+        mock_service_class.return_value = mock_apify_service
+        os.environ["APIFY_TOKEN"] = "test_token"
+
+        # Run the command
+        result = runner.invoke(web_scraper, ["https://example.com"])
+
+        # Verify
+        assert result.exit_code == 0
+        assert "Scraping website from https://example.com" in result.output
+        assert "Using selector: a, max pages: 5" in result.output
+        assert "Retrieved 1 pages of data" in result.output
+
+        # Check the correct actor was called with required fields
+        mock_apify_service.run_actor.assert_called_once()
+        call_args = mock_apify_service.run_actor.call_args[0]
+        assert call_args[0] == "apify/web-scraper"
+        assert "startUrls" in call_args[1]
+        assert "linkSelector" in call_args[1]
+        assert "pageFunction" in call_args[1]
+        assert "maxPagesPerCrawl" in call_args[1]
+
+    @patch("local_newsifier.cli.commands.apify.ApifyService")
+    def test_web_scraper_with_options(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
+        """Test the web-scraper command with custom options."""
+        # Setup
+        mock_service_class.return_value = mock_apify_service
+        os.environ["APIFY_TOKEN"] = "test_token"
+
+        # Run the command with options
+        result = runner.invoke(
+            web_scraper,
+            [
+                "https://example.com",
+                "--selector",
+                "article a",
+                "--max-pages",
+                "10",
+                "--wait-for",
+                "#content",
+                "--page-function",
+                "async function pageFunction(context) { return {custom: true}; }",
+            ],
+        )
+
+        # Verify
+        assert result.exit_code == 0
+        assert "Scraping website from https://example.com" in result.output
+        assert "Using selector: article a, max pages: 10" in result.output
+
+        # Check the correct options were passed
+        mock_apify_service.run_actor.assert_called_once()
+        call_args = mock_apify_service.run_actor.call_args[0]
+        input_config = call_args[1]
+        assert input_config["startUrls"][0]["url"] == "https://example.com"
+        assert input_config["linkSelector"] == "article a"
+        assert input_config["maxPagesPerCrawl"] == 10
+        assert input_config["waitFor"] == "#content"
+        assert "async function pageFunction" in input_config["pageFunction"]
+
+    @patch("local_newsifier.cli.commands.apify.ApifyService")
+    def test_web_scraper_with_output(
+        self, mock_service_class, mock_apify_service, runner, original_token
+    ):
+        """Test the web-scraper command with output to file."""
+        # Setup
+        mock_service_class.return_value = mock_apify_service
+        os.environ["APIFY_TOKEN"] = "test_token"
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            output_file = f.name
+
+        try:
+            # Run the command
+            result = runner.invoke(
+                web_scraper, ["https://example.com", "--output", output_file]
+            )
+
+            # Verify
+            assert result.exit_code == 0
+            assert f"Output saved to {output_file}" in result.output
+
+            # Check the output file contents
+            with open(output_file, "r") as f:
                 output_content = json.load(f)
                 assert len(output_content) == 1
                 assert output_content[0]["id"] == 1


### PR DESCRIPTION
## Summary
- Fixed issue #126 where running apify/web-scraper actor was failing due to missing required pageFunction field
- Added a specialized web-scraper command that automatically provides a default pageFunction
- Added comprehensive test coverage for the new command and its options

## Test plan
- Run `poetry run pytest tests/cli/test_apify_commands.py -v` to verify all tests pass
- Test with a real Apify API token using:
  - `export APIFY_TOKEN=your_token`
  - `poetry run nf apify web-scraper https://example.com`
- Try with custom options: `poetry run nf apify web-scraper https://example.com --selector "article a" --wait-for "#content"`

🤖 Generated with [Claude Code](https://claude.ai/code)