### PR TITLE
docs: add Apify integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This system automatically fetches local news articles, performs Named Entity Rec
 - Named Entity Recognition (NER) analysis
 - Headline trend analysis with NLP-powered keyword extraction
 - Temporal tracking of trending terms in news coverage
+- Web scraping via Apify integration for websites without RSS feeds
 - Robust error handling and retry mechanisms
 - State persistence and workflow resumption
 - Comprehensive logging and monitoring
@@ -56,6 +57,26 @@ nf feeds process <id>      # Process a feed manually
 ```
 
 For detailed CLI documentation, see [README_CLI.md](README_CLI.md).
+
+### Apify Web Scraping
+
+The system integrates with Apify for scraping content from websites without RSS feeds:
+
+```bash
+# Test Apify connection
+nf apify test
+
+# Scrape content from a website
+nf apify scrape-content https://example.com
+
+# Use web-scraper actor with custom selectors
+nf apify web-scraper https://example.com --selector "article a"
+
+# Get items from an Apify dataset
+nf apify get-dataset <dataset_id>
+```
+
+For detailed Apify integration documentation, see [docs/apify_integration.md](docs/apify_integration.md).
 
 ### Scripts
 
@@ -174,16 +195,16 @@ The testing framework now includes robust environment variable management:
   def test_with_clean_environment():
       # Store original environment
       original_env = {k: os.environ.get(k) for k in relevant_keys}
-      
+
       try:
           # Clear environment for test
           for key in original_env:
               if key in os.environ:
                   del os.environ[key]
-          
+
           # Run test with clean environment
           result = test_function()
-          
+
       finally:
           # Restore original environment
           for key, value in original_env.items():
@@ -206,10 +227,10 @@ Database testing has been improved with:
       mock_settings_instance = MagicMock()
       mock_settings_instance.DATABASE_URL = "test_url"
       mock_settings.return_value = mock_settings_instance
-      
+
       # Run test
       result = database_operation()
-      
+
       # Verify behavior
       mock_init_db.assert_called_once_with("test_url")
   ```
@@ -252,17 +273,21 @@ src/
 │   │   ├── analysis/   # Analysis tools (headline trends, etc.)
 │   │   └── ...         # Other tools (web scraper, NER, etc.)
 │   ├── models/         # Pydantic models
+│   │   └── apify.py    # Apify integration models
 │   ├── flows/          # crew.ai Flow definitions
 │   │   ├── analysis/   # Analysis workflows
 │   │   └── ...         # Other flows (news pipeline, RSS, etc.)
 │   ├── cli/            # Command Line Interface
 │   │   └── commands/   # CLI command implementations
+│   │       └── apify.py # Apify CLI commands
 │   ├── crud/           # Database CRUD operations
 │   ├── services/       # Business logic services
+│   │   └── apify_service.py # Apify API integration service
 │   ├── api/            # FastAPI web API
 │   └── config/         # Configuration
 tests/                  # Test suite
 scripts/                # Runtime scripts
+docs/                   # Documentation
 ```
 
 ## Configuration
@@ -270,6 +295,14 @@ scripts/                # Runtime scripts
 The system can be configured through:
 - Environment variables
 - Configuration files in `src/local_newsifier/config/`
+
+### Key Environment Variables
+
+| Variable        | Description                                  | Required For                 |
+|-----------------|----------------------------------------------|------------------------------|
+| APIFY_TOKEN     | API token for Apify web scraping integration | Apify integration            |
+| CURSOR_DB_ID    | Unique ID for cursor-specific database       | Multi-cursor support         |
+| DATABASE_URL    | PostgreSQL connection string                 | Database operations          |
 
 ## Error Handling
 

--- a/README_CLI.md
+++ b/README_CLI.md
@@ -1,6 +1,6 @@
 # Local Newsifier CLI
 
-The Local Newsifier CLI provides command-line tools for managing RSS feeds, processing articles, and interacting with the system.
+The Local Newsifier CLI provides command-line tools for managing RSS feeds, processing articles, interacting with Apify for web scraping, and other system operations.
 
 ## Installation - Development Mode
 
@@ -106,6 +106,65 @@ poetry run nf feeds remove 1
 # Remove a feed (skip confirmation)
 poetry run nf feeds remove 1 --force
 ```
+
+### Using Apify for Web Scraping
+
+Local Newsifier integrates with Apify for scraping content from websites without RSS feeds.
+
+#### Test Apify Connection
+
+```bash
+# Test API connection
+poetry run nf apify test
+
+# Test with a specific token
+poetry run nf apify test --token your_token_here
+```
+
+#### Scrape Content from a Website
+
+```bash
+# Basic content scraping
+poetry run nf apify scrape-content https://example.com
+
+# Advanced options
+poetry run nf apify scrape-content https://example.com --max-pages 10 --max-depth 2 --output results.json
+```
+
+#### Use Web Scraper Actor
+
+```bash
+# Basic web scraping
+poetry run nf apify web-scraper https://example.com
+
+# With custom selectors
+poetry run nf apify web-scraper https://example.com --selector "article a" --output results.json
+
+# With wait-for selector
+poetry run nf apify web-scraper https://example.com --wait-for "#content .loaded"
+```
+
+#### Run Custom Apify Actors
+
+```bash
+# Run a custom actor with JSON input
+poetry run nf apify run-actor apify/web-scraper --input '{"startUrls":[{"url":"https://example.com"}]}'
+
+# Run actor with input from file
+poetry run nf apify run-actor apify/web-scraper --input input.json --output results.json
+```
+
+#### Get Dataset Items
+
+```bash
+# Get items from a dataset
+poetry run nf apify get-dataset dataset_id
+
+# With formatting options
+poetry run nf apify get-dataset dataset_id --limit 20 --format table
+```
+
+For more comprehensive documentation on Apify integration, see [docs/apify_integration.md](docs/apify_integration.md).
 
 ## Testing the CLI
 

--- a/docs/apify_integration.md
+++ b/docs/apify_integration.md
@@ -1,0 +1,201 @@
+# Apify Integration Guide
+
+## Overview
+
+[Apify](https://apify.com/) is a web scraping and automation platform that Local Newsifier leverages to extract content from websites that don't offer RSS feeds. This integration allows the system to collect news articles from a wider range of sources.
+
+## Why Apify?
+
+Apify provides several advantages for the Local Newsifier system:
+
+1. **Powerful Web Scraping**: Apify offers pre-built actors (like web-scraper and website-content-crawler) that handle complex websites, JavaScript rendering, and anti-bot protections.
+
+2. **Scalability**: Apify handles the infrastructure for running scraping workloads, allowing Local Newsifier to focus on processing and analyzing the data.
+
+3. **Scheduling & Automation**: Apify supports scheduled runs and webhooks, making it easy to regularly collect new content.
+
+4. **Data Management**: Apify stores scraped data in datasets that can be easily accessed via API.
+
+## Setup Requirements
+
+To use Apify with Local Newsifier, you need:
+
+1. **Apify Account**: Register at [apify.com](https://apify.com/)
+2. **API Token**: Generate an API token in your Apify account settings
+3. **Configure Environment**: Set the `APIFY_TOKEN` environment variable
+
+### Setting the API Token
+
+You can set the API token in several ways:
+
+```bash
+# As an environment variable
+export APIFY_TOKEN=your_token_here
+
+# In a .env file
+echo "APIFY_TOKEN=your_token_here" >> .env
+
+# When running a command (temporary)
+nf apify test --token your_token_here
+```
+
+## CLI Commands for Apify
+
+Local Newsifier includes several CLI commands for interacting with Apify:
+
+### Test Connection
+
+Verify your Apify credentials and connection:
+
+```bash
+nf apify test
+```
+
+### Scrape Web Content
+
+Extract content from a specific URL using Apify's website-content-crawler:
+
+```bash
+# Basic usage
+nf apify scrape-content https://example.com
+
+# Advanced options
+nf apify scrape-content https://example.com --max-pages 10 --max-depth 2 --output results.json
+```
+
+### Use Web Scraper
+
+For more control over scraping, use Apify's web-scraper actor:
+
+```bash
+# Basic usage
+nf apify web-scraper https://example.com
+
+# With custom selectors
+nf apify web-scraper https://example.com --selector "article a" --output results.json
+
+# With custom page function
+nf apify web-scraper https://example.com --page-function "path/to/page_function.js"
+```
+
+### Run Custom Actors
+
+Run any Apify actor with custom input:
+
+```bash
+# With JSON input
+nf apify run-actor apify/web-scraper --input '{"startUrls":[{"url":"https://example.com"}]}'
+
+# With input from file
+nf apify run-actor apify/web-scraper --input input.json
+```
+
+### Get Dataset Items
+
+Retrieve data from an Apify dataset:
+
+```bash
+# Get dataset items (after running an actor)
+nf apify get-dataset dataset_id --limit 20 --format table
+```
+
+## Adding New Apify Sources
+
+To add a new source for scraping with Apify:
+
+1. **Identify the Website**: Determine which news source you want to scrape
+2. **Select the Appropriate Actor**: Choose between:
+   - `website-content-crawler`: For general content extraction
+   - `web-scraper`: For more precise control with custom page functions
+
+3. **Test the Scraping Configuration**:
+   ```bash
+   # Test with content crawler
+   nf apify scrape-content https://new-source-url.com --max-pages 3 --output test_output.json
+
+   # Or test with web scraper
+   nf apify web-scraper https://new-source-url.com --selector "article.news-item a" --output test_output.json
+   ```
+
+4. **Configure Database Entry**:
+   Once you've established a working configuration, you can add it to the database for regular scheduling. This typically involves:
+
+   - Creating an `ApifySourceConfig` record with the actor ID and input configuration
+   - Setting up scheduling parameters
+   - Enabling the source
+
+   *Note: Direct database configuration is currently managed through scripts or API. Dedicated CLI commands for managing Apify sources are planned for future releases.*
+
+## Scheduling & Webhooks
+
+Apify supports two main approaches for scheduling content scraping:
+
+### 1. Time-Based Scheduling
+
+Configure sources to run on a schedule using cron expressions:
+
+```
+# Example cron schedule (daily at 8 AM)
+0 8 * * *
+```
+
+### 2. Webhook Integration
+
+You can set up Apify to call back to Local Newsifier when scraping jobs complete:
+
+1. Configure a webhook URL in your application deployment
+2. Set up the webhook in Apify to trigger when runs complete
+3. Local Newsifier will automatically process new data when notified
+
+## Common Troubleshooting
+
+### Rate Limits
+
+If you encounter rate limit errors:
+
+- Space out your scraping jobs
+- Reduce concurrency in actor settings
+- Use Apify proxy services if available on your plan
+
+### Selector Issues
+
+If data isn't being extracted correctly:
+
+- Test selectors using browser developer tools
+- Start with broad selectors and refine
+- Check if the site structure changes based on user agent or JavaScript execution
+
+### Authentication Issues
+
+If you see authentication errors:
+
+```
+Error: Authentication failed. Check your API token.
+```
+
+Verify your APIFY_TOKEN is:
+- Correctly set in your environment
+- Valid and not expired
+- Has the required permissions
+
+## Environment Variables
+
+| Variable      | Description                          | Required | Default |
+|---------------|--------------------------------------|----------|---------|
+| APIFY_TOKEN   | API token for Apify authentication   | Yes      | None    |
+
+## Performance Considerations
+
+For optimal performance:
+
+- Limit the number of pages scraped per job
+- Set appropriate request delays to avoid overloading sites
+- Schedule scraping during off-peak hours
+- Use selective scraping with targeted URLs rather than crawling entire sites
+
+## Security Notes
+
+- Your Apify API token provides access to your Apify account and should be kept secure
+- Avoid committing the token to version control
+- Consider using short-lived tokens for production deployments
+- Review scraped data for sensitive information before processing


### PR DESCRIPTION
## Summary
- Created a new docs/apify_integration.md with comprehensive Apify integration documentation
- Updated README.md to include Apify integration information and commands
- Updated README_CLI.md with detailed Apify command documentation

This addresses the need for better documentation on how to use the Apify integration for web scraping in the Local Newsifier system, including setup, usage, troubleshooting, and best practices.

Fixes #117

🤖 Generated with [Claude Code](https://claude.ai/code)