### PR TITLE
Fix incorrect TrendAnalysisFlow import in container.py (Issue #176)

### DIFF
--- a/src/local_newsifier/container.py
+++ b/src/local_newsifier/container.py
@@ -454,7 +454,7 @@ def register_flows(container):
         # Import all flow classes
         from local_newsifier.flows.entity_tracking_flow import EntityTrackingFlow
         from local_newsifier.flows.news_pipeline import NewsPipelineFlow
-        from local_newsifier.flows.trend_analysis_flow import TrendAnalysisFlow
+        from local_newsifier.flows.trend_analysis_flow import NewsTrendAnalysisFlow as TrendAnalysisFlow
         from local_newsifier.flows.public_opinion_flow import PublicOpinionFlow
         from local_newsifier.flows.rss_scraping_flow import RSSScrapingFlow
         


### PR DESCRIPTION
## Summary
- Fix the import statement in container.py to use `NewsTrendAnalysisFlow as TrendAnalysisFlow` to match the actual class name defined in the module
- This resolves the error shown when initializing the database or running other commands that use the container

## Test plan
- Run `poetry run python scripts/init_cursor_db.py` to verify that the database initialization works without the import error
- Run `poetry run python -m src.local_newsifier.cli.main db stats` to verify that the container can be initialized correctly

🤖 Generated with [Claude Code](https://claude.ai/code)