### PR TITLE
Fix tests in PR #175 (Streamlined RSS Error Handling)

### DIFF
--- a/src/local_newsifier/errors/error.py
+++ b/src/local_newsifier/errors/error.py
@@ -74,7 +74,19 @@ class ServiceError(Exception):
         self.timestamp = datetime.now()
         
         # Get error type properties
-        type_info = ERROR_TYPES.get(error_type, ERROR_TYPES["unknown"])
+        # First check service-specific error types if available
+        service_specific_types = None
+        if service == "rss":
+            # Import at runtime to avoid circular imports
+            from .rss import RSS_ERROR_TYPES
+            service_specific_types = RSS_ERROR_TYPES
+        
+        # Get type info, first from service-specific types, then from general types
+        if service_specific_types and error_type in service_specific_types:
+            type_info = service_specific_types.get(error_type)
+        else:
+            type_info = ERROR_TYPES.get(error_type, ERROR_TYPES["unknown"])
+            
         self.transient = type_info.get("transient", False)
         self.exit_code = type_info.get("exit_code", 1)
         

--- a/src/local_newsifier/errors/rss.py
+++ b/src/local_newsifier/errors/rss.py
@@ -9,7 +9,7 @@ import functools
 import re
 
 from .handlers import create_service_handler, handle_cli_errors
-from .error import ServiceError, ERROR_TYPES
+from .error import ServiceError
 
 
 # RSS-specific error types


### PR DESCRIPTION
This PR fixes the failing tests in PR #175 by addressing a circular import issue in the error handling code. It updates the  class to properly handle service-specific error types like the RSS error types introduced in PR #175.

Changes:
- Fix circular import between  and 
- Add runtime import of service-specific error types in 
- Modify error type resolution to check for service-specific error types first

This PR should be merged into the  branch, not main.

Fixes the failing CI tests for PR #175.