### PR TITLE
Fix tests in PR #175 (try #2)

### DIFF
--- a/src/local_newsifier/errors/__init__.py
+++ b/src/local_newsifier/errors/__init__.py
@@ -5,18 +5,42 @@ This module provides a unified approach to handling errors from
 external services like Apify, RSS feeds, and web scrapers.
 """
 
-from .error import ServiceError, handle_service_error, with_retry, with_timing
+# Import error core components first to avoid circular dependencies
+from .error import ServiceError, handle_service_error, with_retry, with_timing, ERROR_TYPES
+
+# Import rss-specific components - this must come after error imports
+from .rss import handle_rss_service, handle_rss_cli, RSS_ERROR_TYPES, get_rss_error_message
+
+# Register RSS error types with the main ERROR_TYPES dictionary
+ERROR_TYPES.update(RSS_ERROR_TYPES)
+
+# Import other handlers
 from .handlers import handle_apify, handle_rss, handle_web_scraper
-from .cli import handle_cli_errors, handle_apify_cli, handle_rss_cli
+from .cli import handle_cli_errors, handle_apify_cli
+
+# Override the imported handles with their more specific implementations
+handle_rss = handle_rss_service  # Use the more specific implementation
+handle_rss_cli = handle_rss_cli  # Already correct but included for clarity
 
 __all__ = [
+    # Core components
     'ServiceError',
     'handle_service_error',
     'with_retry',
     'with_timing',
+    'ERROR_TYPES',
+    
+    # RSS-specific components
+    'handle_rss_service',
+    'RSS_ERROR_TYPES',
+    'get_rss_error_message',
+    
+    # Service handlers
     'handle_apify', 
     'handle_rss',
     'handle_web_scraper',
+    
+    # CLI handlers
     'handle_cli_errors',
     'handle_apify_cli',
     'handle_rss_cli'

--- a/src/local_newsifier/errors/error.py
+++ b/src/local_newsifier/errors/error.py
@@ -74,18 +74,9 @@ class ServiceError(Exception):
         self.timestamp = datetime.now()
         
         # Get error type properties
-        # First check service-specific error types if available
-        service_specific_types = None
-        if service == "rss":
-            # Import at runtime to avoid circular imports
-            from .rss import RSS_ERROR_TYPES
-            service_specific_types = RSS_ERROR_TYPES
-        
-        # Get type info, first from service-specific types, then from general types
-        if service_specific_types and error_type in service_specific_types:
-            type_info = service_specific_types.get(error_type)
-        else:
-            type_info = ERROR_TYPES.get(error_type, ERROR_TYPES["unknown"])
+        # Note: Service-specific error types should be registered with ERROR_TYPES
+        # before being used. The init.py module does this for RSS error types.
+        type_info = ERROR_TYPES.get(error_type, ERROR_TYPES["unknown"])
             
         self.transient = type_info.get("transient", False)
         self.exit_code = type_info.get("exit_code", 1)

--- a/src/local_newsifier/errors/rss.py
+++ b/src/local_newsifier/errors/rss.py
@@ -8,8 +8,9 @@ from typing import Dict, Any, Callable, Optional, cast
 import functools
 import re
 
-from .handlers import create_service_handler, handle_cli_errors
-from .error import ServiceError
+from .handlers import create_service_handler
+from .cli import handle_cli_errors
+from .error import ServiceError, ERROR_TYPES
 
 
 # RSS-specific error types


### PR DESCRIPTION
This PR is a second attempt to fix the failing tests in PR #175.

Changes:
1. Update  to explicitly import all RSS error components
2. Register RSS error types with the main ERROR_TYPES dictionary
3. Simplify ServiceError initialization by using pre-registered error types
4. Fix module import order to avoid circular dependencies

This PR should be merged into the  branch, not main.

Fixes the failing CI tests for PR #175.