### PR TITLE
Implement Minimal Clean API for DIContainer (Issue #184)

### DIFF
--- a/src/local_newsifier/di_container.py
+++ b/src/local_newsifier/di_container.py
@@ -35,6 +35,22 @@ class DIContainer:
         self._scopes = {}           # Lifetime scope of each service
         self._creating = set()      # Set of services currently being created (for circular dep detection)
         self._cleanup_handlers = {} # Handlers for cleanup when a service is removed
+        
+    def get_all_services(self) -> Dict[str, Any]:
+        """Get all registered service instances.
+        
+        Returns:
+            A copy of the dictionary mapping service names to their instances
+        """
+        return self._services.copy()
+        
+    def get_all_factories(self) -> Dict[str, Callable]:
+        """Get all registered factory functions.
+        
+        Returns:
+            A copy of the dictionary mapping service names to their factory functions
+        """
+        return self._factories.copy()
 
     def register(self, name: str, instance: Any, scope: Scope = Scope.SINGLETON) -> 'DIContainer':
         """Register a service instance directly.

--- a/src/local_newsifier/fastapi_injectable_adapter.py
+++ b/src/local_newsifier/fastapi_injectable_adapter.py
@@ -75,15 +75,15 @@ class ContainerAdapter:
         
         # If not found by name, try to find by type
         # TODO: Test coverage needed for type-based lookup path
-        for name, service in di_container._services.items():
+        for name, service in di_container.get_all_services().items():
             if isinstance(service, service_type):
                 return cast(T, service)
                 
         # Last resort: check factories and try to create the service
         # TODO: Test coverage needed for factory-based service creation
-        for name, factory in di_container._factories.items():
+        for name, factory in di_container.get_all_factories().items():
             try:
-                service = di_container._create_service(name, **kwargs)
+                service = di_container.get(name, **kwargs)
                 if isinstance(service, service_type):
                     return cast(T, service)
             except Exception:
@@ -283,7 +283,7 @@ async def migrate_container_services(app: FastAPI) -> None:
     await register_app(app)
     
     # Register direct service instances
-    for name, service in di_container._services.items():
+    for name, service in di_container.get_all_services().items():
         if service is not None:
             try:
                 service_class = service.__class__
@@ -301,7 +301,7 @@ async def migrate_container_services(app: FastAPI) -> None:
     
     # Register factory-created services
     registered_factories = 0
-    for name, factory in di_container._factories.items():
+    for name, factory in di_container.get_all_factories().items():
         # Try to determine the return type from factory signature
         try:
             # Try to get a service instance to determine type

--- a/tests/test_di_container.py
+++ b/tests/test_di_container.py
@@ -286,3 +286,49 @@ class TestDIContainer:
         assert child_result == "Child 1"
         assert parent_calls == 1
         assert child_calls == 1
+        
+    # Tests for the new public API methods
+    
+    def test_get_all_services(self):
+        """Test getting all registered service instances."""
+        # Arrange
+        container = DIContainer()
+        service1 = object()
+        service2 = object()
+        container.register("service1", service1)
+        container.register("service2", service2)
+        
+        # Act
+        services = container.get_all_services()
+        
+        # Assert
+        assert isinstance(services, dict)
+        assert len(services) == 2
+        assert services["service1"] is service1
+        assert services["service2"] is service2
+        
+        # Verify it's a copy not the original
+        services["newkey"] = "newvalue"
+        assert "newkey" not in container.get_all_services()
+        
+    def test_get_all_factories(self):
+        """Test getting all registered factory functions."""
+        # Arrange
+        container = DIContainer()
+        factory1 = lambda c: "result1"
+        factory2 = lambda c: "result2"
+        container.register_factory("factory1", factory1)
+        container.register_factory("factory2", factory2)
+        
+        # Act
+        factories = container.get_all_factories()
+        
+        # Assert
+        assert isinstance(factories, dict)
+        assert len(factories) == 2
+        assert factories["factory1"] is factory1
+        assert factories["factory2"] is factory2
+        
+        # Verify it's a copy not the original
+        factories["newkey"] = lambda c: "new"
+        assert "newkey" not in container.get_all_factories()


### PR DESCRIPTION
## Summary
This PR provides a minimal solution for implementing a clean public API for DIContainer:

- Adds two core methods: get_all_services() and get_all_factories() that return copies of the internal collections
- Updates the fastapi-injectable adapter to use these methods instead of direct access to private variables
- Adds basic tests to verify functionality

## Benefits
- Minimal code changes (only ~70 lines total)
- No breaking changes or deprecation warnings needed
- Maintains backward compatibility
- Provides immediate encapsulation while allowing for future expansion

## Test plan
- Added specific tests for the new public methods
- Verified that the adapter works correctly with existing tests
- All tests pass for the modified components