### PR TITLE
Fix database error handling and add comprehensive tests (Issue #190)

### DIFF
--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -75,6 +75,29 @@ class ArticleService:
             return self.article_crud.get(session, id=article_id)
 ```
 
+### Database Error Handling and Retry Behavior
+
+The `@handle_database` decorator provides robust error handling for database operations:
+
+- **Classification**: Automatically classifies SQLAlchemy exceptions into appropriate error types
+- **Error Messages**: Provides descriptive error messages with troubleshooting hints
+- **Retry Logic**: Automatically retries transient errors with backoff
+
+#### Retry Behavior for Database Errors
+
+| Error Type    | Is Retried | Retry Attempts | Description                                      |
+|---------------|------------|----------------|--------------------------------------------------|
+| `connection`  | Yes        | 3 (default)    | Database connection issues, server unavailable   |
+| `timeout`     | Yes        | 3 (default)    | Query timeout, long-running operations          |
+| `transaction` | Yes        | 3 (default)    | Transaction errors, deadlocks                   |
+| `integrity`   | No         | N/A            | Constraint violations (unique, foreign key)     |
+| `validation`  | No         | N/A            | Input validation failures                       |
+| `not_found`   | No         | N/A            | Record not found (business logic issue)         |
+| `multiple`    | No         | N/A            | Multiple records when one expected              |
+
+Each retry uses exponential backoff (1s, 2s, 4s) to allow temporary issues to resolve.
+```
+
 ### CLI Commands
 
 ```python

--- a/src/local_newsifier/errors/__init__.py
+++ b/src/local_newsifier/errors/__init__.py
@@ -2,11 +2,12 @@
 Streamlined error handling for external services.
 
 This module provides a unified approach to handling errors from
-external services like Apify, RSS feeds, and web scrapers.
+external services like Apify, RSS feeds, web scrapers, and internal
+operations like database access.
 """
 
 from .error import ServiceError, handle_service_error, with_retry, with_timing
-from .handlers import handle_apify, handle_rss, handle_web_scraper
+from .handlers import handle_apify, handle_rss, handle_web_scraper, handle_database
 from .cli import handle_cli_errors, handle_apify_cli, handle_rss_cli
 
 __all__ = [
@@ -17,6 +18,7 @@ __all__ = [
     'handle_apify', 
     'handle_rss',
     'handle_web_scraper',
+    'handle_database',
     'handle_cli_errors',
     'handle_apify_cli',
     'handle_rss_cli'

--- a/src/local_newsifier/errors/cli.py
+++ b/src/local_newsifier/errors/cli.py
@@ -78,3 +78,4 @@ def handle_cli_errors(service: str) -> Callable:
 # Pre-configured handlers for common services
 handle_apify_cli = handle_cli_errors("apify")
 handle_rss_cli = handle_cli_errors("rss")
+handle_database_cli = handle_cli_errors("database")

--- a/src/local_newsifier/errors/error.py
+++ b/src/local_newsifier/errors/error.py
@@ -233,6 +233,59 @@ def with_timing(service: str) -> Callable:
     return decorator
 
 
+def _classify_database_error(error: Exception) -> tuple:
+    """Classify database-specific exceptions into appropriate error types.
+    
+    Args:
+        error: The database-related exception to classify
+        
+    Returns:
+        Tuple of (error_type, error_message)
+    """
+    error_name = type(error).__name__
+    error_str = str(error).lower()
+    
+    # SQLAlchemy-specific errors (handle version differences)
+    if any(name in error_name.lower() for name in ["sqlalchemy", "sql", "dbapi"]):
+        # Connection errors (handle both legacy and modern SQLAlchemy error names)
+        if any(err in error_name for err in ["OperationalError", "DisconnectionError", "DBAPIError"]):
+            if any(term in error_str for term in ["connection", "connect", "timeout"]):
+                if "timeout" in error_str:
+                    return "timeout", f"Database query timeout: {error}"
+                return "connection", f"Database connection error: {error}"
+            return "connection", f"Database operational error: {error}"
+        
+        # Integrity errors (constraints, etc.)
+        if "IntegrityError" in error_name:
+            if "unique constraint" in error_str:
+                return "integrity", f"Unique constraint violation: {error}"
+            if "foreign key constraint" in error_str:
+                return "integrity", f"Foreign key constraint violation: {error}"
+            return "integrity", f"Database integrity error: {error}"
+        
+        # Not found errors (orm.exc.NoResultFound or core.exc.NoResultFound)
+        if "NoResultFound" in error_name:
+            return "not_found", f"Record not found in the database"
+        
+        # Multiple results errors
+        if "MultipleResultsFound" in error_name:
+            return "multiple", f"Multiple records found where only one was expected"
+        
+        # Data validation errors
+        if any(err in error_name for err in ["ValidationError", "DataError", "StatementError"]):
+            return "validation", f"Database data validation error: {error}"
+            
+        # Transaction errors
+        if any(err in error_name for err in ["TransactionError", "InvalidRequestError"]):
+            return "transaction", f"Database transaction error: {error}"
+            
+        # Generic database error
+        return "unknown", f"Database error: {error}"
+    
+    # Generic error (should not reach here if properly filtered by caller)
+    return "unknown", f"Unknown database error: {error}"
+
+
 def _classify_error(error: Exception, service: str) -> tuple:
     """Classify an exception into an appropriate error type.
     
@@ -245,45 +298,7 @@ def _classify_error(error: Exception, service: str) -> tuple:
     """
     # Handle database-specific errors when service is "database"
     if service == "database":
-        error_name = type(error).__name__
-        error_str = str(error).lower()
-        
-        # SQLAlchemy-specific errors
-        if "sqlalchemy" in error_name.lower() or "sql" in error_name.lower():
-            # Connection errors
-            if "OperationalError" in error_name or "DisconnectionError" in error_name:
-                if "connection" in error_str or "connect" in error_str:
-                    return "connection", f"Database connection error: {error}"
-                if "timeout" in error_str:
-                    return "timeout", f"Database query timeout: {error}"
-                return "connection", f"Database operational error: {error}"
-            
-            # Integrity errors (constraints, etc.)
-            if "IntegrityError" in error_name:
-                if "unique constraint" in error_str:
-                    return "integrity", f"Unique constraint violation: {error}"
-                if "foreign key constraint" in error_str:
-                    return "integrity", f"Foreign key constraint violation: {error}"
-                return "integrity", f"Database integrity error: {error}"
-            
-            # Not found errors
-            if "NoResultFound" in error_name:
-                return "not_found", f"Record not found in the database"
-            
-            # Multiple results errors
-            if "MultipleResultsFound" in error_name:
-                return "multiple", f"Multiple records found where only one was expected"
-            
-            # Data validation errors
-            if "ValidationError" in error_name or "DataError" in error_name:
-                return "validation", f"Database data validation error: {error}"
-                
-            # Transaction errors
-            if "TransactionError" in error_name:
-                return "transaction", f"Database transaction error: {error}"
-                
-            # Generic database error
-            return "unknown", f"Database error: {error}"
+        return _classify_database_error(error)
     
     # Standard HTTP error handling
     if hasattr(error, 'response') and hasattr(error.response, 'status_code'):

--- a/src/local_newsifier/errors/handlers.py
+++ b/src/local_newsifier/errors/handlers.py
@@ -25,6 +25,15 @@ ERROR_MESSAGES = {
         "network": "Could not connect to website. Check the URL and your internet connection.",
         "auth": "Website requires authentication or blocks automated access.",
         "parse": "Could not extract content from website. The site structure may have changed."
+    },
+    "database": {
+        "connection": "Could not connect to the database. Check database connection settings.",
+        "timeout": "Database operation timed out. The database may be overloaded.",
+        "integrity": "Database constraint violation. The operation violates database rules.",
+        "not_found": "Requested record not found in the database.",
+        "multiple": "Multiple records found where only one was expected.",
+        "validation": "Invalid database request. Check input parameters.",
+        "transaction": "Transaction error. The operation could not be completed."
     }
 }
 
@@ -74,6 +83,7 @@ def create_service_handler(
 handle_apify = create_service_handler("apify")
 handle_rss = create_service_handler("rss")
 handle_web_scraper = create_service_handler("web_scraper")
+handle_database = create_service_handler("database")
 
 
 def get_error_message(service: str, error_type: str) -> str:

--- a/src/local_newsifier/models/state.py
+++ b/src/local_newsifier/models/state.py
@@ -138,11 +138,21 @@ class EntityTrackingState(BaseModel):
     
     def set_error(self, task: str, error: Exception) -> None:
         """Set error details and update status."""
+        # Extract original error message if it's a ServiceError, otherwise use as is
+        if hasattr(error, 'original') and error.original:
+            error_type = error.original.__class__.__name__
+            message = str(error.original)
+            traceback_snippet = str(error.original.__traceback__)
+        else:
+            error_type = error.__class__.__name__
+            message = str(error)
+            traceback_snippet = str(error.__traceback__)
+            
         self.error_details = ErrorDetails(
             task=task,
-            type=error.__class__.__name__,
-            message=str(error),
-            traceback_snippet=str(error.__traceback__),
+            type=error_type,
+            message=message,
+            traceback_snippet=traceback_snippet,
         )
         self.status = TrackingStatus.FAILED
         self.touch()
@@ -190,11 +200,21 @@ class EntityBatchTrackingState(BaseModel):
     
     def set_error(self, task: str, error: Exception) -> None:
         """Set error details and update status."""
+        # Extract original error message if it's a ServiceError, otherwise use as is
+        if hasattr(error, 'original') and error.original:
+            error_type = error.original.__class__.__name__
+            message = str(error.original)
+            traceback_snippet = str(error.original.__traceback__)
+        else:
+            error_type = error.__class__.__name__
+            message = str(error)
+            traceback_snippet = str(error.__traceback__)
+            
         self.error_details = ErrorDetails(
             task=task,
-            type=error.__class__.__name__,
-            message=str(error),
-            traceback_snippet=str(error.__traceback__),
+            type=error_type,
+            message=message,
+            traceback_snippet=traceback_snippet,
         )
         self.status = TrackingStatus.FAILED
         self.touch()
@@ -248,11 +268,21 @@ class EntityDashboardState(BaseModel):
     
     def set_error(self, task: str, error: Exception) -> None:
         """Set error details and update status."""
+        # Extract original error message if it's a ServiceError, otherwise use as is
+        if hasattr(error, 'original') and error.original:
+            error_type = error.original.__class__.__name__
+            message = str(error.original)
+            traceback_snippet = str(error.original.__traceback__)
+        else:
+            error_type = error.__class__.__name__
+            message = str(error)
+            traceback_snippet = str(error.__traceback__)
+            
         self.error_details = ErrorDetails(
             task=task,
-            type=error.__class__.__name__,
-            message=str(error),
-            traceback_snippet=str(error.__traceback__),
+            type=error_type,
+            message=message,
+            traceback_snippet=traceback_snippet,
         )
         self.status = TrackingStatus.FAILED
         self.touch()
@@ -298,11 +328,21 @@ class EntityRelationshipState(BaseModel):
     
     def set_error(self, task: str, error: Exception) -> None:
         """Set error details and update status."""
+        # Extract original error message if it's a ServiceError, otherwise use as is
+        if hasattr(error, 'original') and error.original:
+            error_type = error.original.__class__.__name__
+            message = str(error.original)
+            traceback_snippet = str(error.original.__traceback__)
+        else:
+            error_type = error.__class__.__name__
+            message = str(error)
+            traceback_snippet = str(error.__traceback__)
+            
         self.error_details = ErrorDetails(
             task=task,
-            type=error.__class__.__name__,
-            message=str(error),
-            traceback_snippet=str(error.__traceback__),
+            type=error_type,
+            message=message,
+            traceback_snippet=traceback_snippet,
         )
         self.status = TrackingStatus.FAILED
         self.touch()

--- a/src/local_newsifier/models/state.py
+++ b/src/local_newsifier/models/state.py
@@ -40,6 +40,30 @@ class ErrorDetails(BaseModel):
     type: str
     message: str
     traceback_snippet: Optional[str] = None
+    
+    
+def extract_error_details(error: Exception) -> tuple:
+    """Extract error details from an exception, unwrapping ServiceError if needed.
+    
+    Args:
+        error: The exception to extract details from
+        
+    Returns:
+        Tuple of (error_type, message, traceback_snippet)
+    """
+    # Extract original error message if it's a ServiceError, otherwise use as is
+    if hasattr(error, 'original') and error.original:
+        # Unwrap the ServiceError to get the original exception
+        error_type = error.original.__class__.__name__
+        message = str(error.original)
+        traceback_snippet = str(error.original.__traceback__)
+    else:
+        # Use the provided exception as is
+        error_type = error.__class__.__name__
+        message = str(error)
+        traceback_snippet = str(error.__traceback__)
+        
+    return error_type, message, traceback_snippet
 
 
 class NewsAnalysisState(BaseModel):
@@ -138,16 +162,7 @@ class EntityTrackingState(BaseModel):
     
     def set_error(self, task: str, error: Exception) -> None:
         """Set error details and update status."""
-        # Extract original error message if it's a ServiceError, otherwise use as is
-        if hasattr(error, 'original') and error.original:
-            error_type = error.original.__class__.__name__
-            message = str(error.original)
-            traceback_snippet = str(error.original.__traceback__)
-        else:
-            error_type = error.__class__.__name__
-            message = str(error)
-            traceback_snippet = str(error.__traceback__)
-            
+        error_type, message, traceback_snippet = extract_error_details(error)
         self.error_details = ErrorDetails(
             task=task,
             type=error_type,
@@ -200,16 +215,7 @@ class EntityBatchTrackingState(BaseModel):
     
     def set_error(self, task: str, error: Exception) -> None:
         """Set error details and update status."""
-        # Extract original error message if it's a ServiceError, otherwise use as is
-        if hasattr(error, 'original') and error.original:
-            error_type = error.original.__class__.__name__
-            message = str(error.original)
-            traceback_snippet = str(error.original.__traceback__)
-        else:
-            error_type = error.__class__.__name__
-            message = str(error)
-            traceback_snippet = str(error.__traceback__)
-            
+        error_type, message, traceback_snippet = extract_error_details(error)
         self.error_details = ErrorDetails(
             task=task,
             type=error_type,
@@ -268,16 +274,7 @@ class EntityDashboardState(BaseModel):
     
     def set_error(self, task: str, error: Exception) -> None:
         """Set error details and update status."""
-        # Extract original error message if it's a ServiceError, otherwise use as is
-        if hasattr(error, 'original') and error.original:
-            error_type = error.original.__class__.__name__
-            message = str(error.original)
-            traceback_snippet = str(error.original.__traceback__)
-        else:
-            error_type = error.__class__.__name__
-            message = str(error)
-            traceback_snippet = str(error.__traceback__)
-            
+        error_type, message, traceback_snippet = extract_error_details(error)
         self.error_details = ErrorDetails(
             task=task,
             type=error_type,
@@ -328,16 +325,7 @@ class EntityRelationshipState(BaseModel):
     
     def set_error(self, task: str, error: Exception) -> None:
         """Set error details and update status."""
-        # Extract original error message if it's a ServiceError, otherwise use as is
-        if hasattr(error, 'original') and error.original:
-            error_type = error.original.__class__.__name__
-            message = str(error.original)
-            traceback_snippet = str(error.original.__traceback__)
-        else:
-            error_type = error.__class__.__name__
-            message = str(error)
-            traceback_snippet = str(error.__traceback__)
-            
+        error_type, message, traceback_snippet = extract_error_details(error)
         self.error_details = ErrorDetails(
             task=task,
             type=error_type,

--- a/src/local_newsifier/services/article_service.py
+++ b/src/local_newsifier/services/article_service.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Any
 from local_newsifier.models.article import Article
 from local_newsifier.models.analysis_result import AnalysisResult
 from local_newsifier.database.engine import SessionManager
+from local_newsifier.errors import handle_database
 
 
 class ArticleService:
@@ -44,6 +45,7 @@ class ArticleService:
             
         return None
         
+    @handle_database
     def process_article(
         self, 
         url: str,
@@ -61,6 +63,9 @@ class ArticleService:
             
         Returns:
             Dictionary with article data and processing results
+            
+        Raises:
+            ServiceError: On database errors with appropriate classification
         """
         with SessionManager() as session:
             # Extract domain as source if not provided
@@ -129,6 +134,7 @@ class ArticleService:
                 "analysis_result": analysis_result_data
             }
     
+    @handle_database
     def get_article(self, article_id: int) -> Optional[Dict[str, Any]]:
         """Get article data by ID.
         
@@ -137,6 +143,9 @@ class ArticleService:
             
         Returns:
             Article data or None if not found
+            
+        Raises:
+            ServiceError: On database errors with appropriate classification
         """
         with SessionManager() as session:
             article = self.article_crud.get(session, id=article_id)
@@ -160,6 +169,7 @@ class ArticleService:
                 "analysis_results": [result.results for result in analysis_results]
             }
     
+    @handle_database
     def create_article_from_rss_entry(self, entry: Dict[str, Any]) -> Optional[int]:
         """Create a new article from an RSS feed entry.
         
@@ -168,6 +178,9 @@ class ArticleService:
             
         Returns:
             Created article or None if creation failed
+            
+        Raises:
+            ServiceError: On database errors with appropriate classification
         """
         from datetime import datetime
         

--- a/src/local_newsifier/services/entity_service.py
+++ b/src/local_newsifier/services/entity_service.py
@@ -7,6 +7,7 @@ from local_newsifier.models.entity import Entity
 from local_newsifier.models.entity_tracking import CanonicalEntity, EntityMentionContext, EntityProfile
 from local_newsifier.models.state import EntityTrackingState, EntityBatchTrackingState, EntityDashboardState, EntityRelationshipState, TrackingStatus
 from local_newsifier.database.engine import SessionManager
+from local_newsifier.errors import handle_database
 
 class EntityService:
     """Service for entity-related operations using the new refactored tools."""
@@ -46,6 +47,7 @@ class EntityService:
         self.entity_resolver = entity_resolver
         self.session_factory = session_factory or SessionManager
     
+    @handle_database
     def process_article_entities(
         self, 
         article_id: int,
@@ -63,6 +65,9 @@ class EntityService:
             
         Returns:
             List of processed entities with metadata
+            
+        Raises:
+            ServiceError: On database errors with appropriate classification
         """
         # Extract entities using the new EntityExtractor
         entities = self.entity_extractor.extract_entities(content)

--- a/tests/errors/test_database_error_classification.py
+++ b/tests/errors/test_database_error_classification.py
@@ -28,9 +28,9 @@ def create_db_error(error_class, message, optional_orig=None):
     elif error_class == DBAPIError:
         return DBAPIError(f"SQL: select 1\nDetails: {message}", {}, optional_orig)
     elif error_class == StatementError:
-        # StatementError requires 'orig' parameter and changed order in SQLAlchemy 2.0+
+        # StatementError requires 'orig' parameter in SQLAlchemy 2.0+
         exception_orig = optional_orig if optional_orig is not None else Exception("Original exception")
-        return StatementError(f"SQL: select 1\nDetails: {message}", {}, exception_orig)
+        return StatementError(message, "SELECT 1", {}, exception_orig)
     elif error_class == TimeoutError:
         return TimeoutError(message)
     elif error_class == InvalidRequestError:

--- a/tests/errors/test_database_error_classification.py
+++ b/tests/errors/test_database_error_classification.py
@@ -28,7 +28,9 @@ def create_db_error(error_class, message, optional_orig=None):
     elif error_class == DBAPIError:
         return DBAPIError(f"SQL: select 1\nDetails: {message}", {}, optional_orig)
     elif error_class == StatementError:
-        return StatementError(f"SQL: select 1\nDetails: {message}", {}, optional_orig, "error")
+        # StatementError requires 'orig' parameter and changed order in SQLAlchemy 2.0+
+        exception_orig = optional_orig if optional_orig is not None else Exception("Original exception")
+        return StatementError(f"SQL: select 1\nDetails: {message}", {}, exception_orig)
     elif error_class == TimeoutError:
         return TimeoutError(message)
     elif error_class == InvalidRequestError:

--- a/tests/errors/test_database_error_classification.py
+++ b/tests/errors/test_database_error_classification.py
@@ -1,0 +1,183 @@
+"""Tests for database error classification in the error handling system."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import (
+    OperationalError, 
+    IntegrityError,
+    SQLAlchemyError,
+    TimeoutError, 
+    StatementError,
+    InvalidRequestError,
+    DisconnectionError,
+    DBAPIError
+)
+from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
+
+from src.local_newsifier.errors.error import _classify_database_error, ServiceError
+from src.local_newsifier.errors.handlers import handle_database
+
+
+def create_db_error(error_class, message, optional_orig=None):
+    """Helper to create SQLAlchemy errors with the appropriate attributes."""
+    if error_class == OperationalError:
+        # For SQLAlchemy 2.0+, create with appropriate signature
+        return OperationalError(f"SQL: select 1\nDetails: {message}", {}, optional_orig)
+    elif error_class == IntegrityError:
+        return IntegrityError(f"SQL: insert\nDetails: {message}", {}, optional_orig)
+    elif error_class == DBAPIError:
+        return DBAPIError(f"SQL: select 1\nDetails: {message}", {}, optional_orig)
+    elif error_class == StatementError:
+        return StatementError(f"SQL: select 1\nDetails: {message}", {}, optional_orig, "error")
+    elif error_class == TimeoutError:
+        return TimeoutError(message)
+    elif error_class == InvalidRequestError:
+        return InvalidRequestError(message, optional_orig)
+    elif error_class == DisconnectionError:
+        return DisconnectionError(message)
+    elif error_class == NoResultFound or error_class == MultipleResultsFound:
+        return error_class()
+    else:
+        return error_class(message)
+
+
+# Test database error classification
+test_cases = [
+    # Error class, message, optional_orig, expected_type, expected_message_contains
+    (OperationalError, "connection error", None, "connection", "connection error"),
+    (OperationalError, "connection refused", None, "connection", "connection error"),
+    (OperationalError, "timeout error", None, "timeout", "timeout"),
+    (DisconnectionError, "connection dropped", None, "connection", "connection error"),
+    (DBAPIError, "operational error", None, "connection", "operational error"),
+    (IntegrityError, "unique constraint violation", None, "integrity", "constraint violation"),
+    (IntegrityError, "foreign key constraint", None, "integrity", "constraint violation"),
+    (IntegrityError, "general integrity", None, "integrity", "integrity error"),
+    (NoResultFound, "", None, "not_found", "not found"),
+    (MultipleResultsFound, "", None, "multiple", "multiple records"),
+    (TimeoutError, "query timeout", None, "timeout", "timeout"),
+    (StatementError, "validation error", None, "validation", "validation error"),
+    (InvalidRequestError, "transaction error", None, "transaction", "transaction error"),
+    (Exception, "unknown database error", None, "unknown", "unknown database error")
+]
+
+
+@pytest.mark.parametrize("error_class,message,optional_orig,expected_type,expected_contains", test_cases)
+def test_database_error_classification(error_class, message, optional_orig, expected_type, expected_contains):
+    """Test database error classification with various error types."""
+    error = create_db_error(error_class, message, optional_orig)
+    error_type, error_message = _classify_database_error(error)
+    assert error_type == expected_type
+    assert expected_contains.lower() in error_message.lower()
+
+
+def test_database_error_handler_decorator():
+    """Test the database error handler decorator in isolation."""
+    
+    # Test functions that raise different types of database errors
+    @handle_database
+    def raise_operational_error():
+        raise create_db_error(OperationalError, "connection refused")
+    
+    @handle_database
+    def raise_integrity_error():
+        raise create_db_error(IntegrityError, "unique constraint violation")
+    
+    @handle_database
+    def raise_no_result_found():
+        raise NoResultFound()
+    
+    # Test operational error handling
+    with pytest.raises(ServiceError) as excinfo:
+        raise_operational_error()
+    assert excinfo.value.service == "database"
+    assert excinfo.value.error_type == "connection"
+    assert "connect to the database" in str(excinfo.value)
+    
+    # Test integrity error handling
+    with pytest.raises(ServiceError) as excinfo:
+        raise_integrity_error()
+    assert excinfo.value.service == "database"
+    assert excinfo.value.error_type == "integrity"
+    assert "constraint" in str(excinfo.value).lower()
+    
+    # Test not found error handling
+    with pytest.raises(ServiceError) as excinfo:
+        raise_no_result_found()
+    assert excinfo.value.service == "database"
+    assert excinfo.value.error_type == "not_found"
+    assert "not found" in str(excinfo.value).lower()
+
+
+@patch("src.local_newsifier.errors.error.time.sleep", MagicMock())  # Mock sleep to speed up tests
+def test_retry_behavior():
+    """Test retry behavior for transient database errors."""
+    call_count = 0
+    
+    # Function that fails twice with a connection error, then succeeds
+    @handle_database
+    def function_with_retry():
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise create_db_error(OperationalError, "connection refused")
+        return "success"
+    
+    # Should succeed on the third attempt
+    result = function_with_retry()
+    assert result == "success"
+    assert call_count == 3
+    
+    # Reset counter
+    call_count = 0
+    
+    # Function that raises a non-transient error (shouldn't retry)
+    @handle_database
+    def function_with_integrity_error():
+        nonlocal call_count
+        call_count += 1
+        raise create_db_error(IntegrityError, "unique constraint violation")
+    
+    # Should fail immediately without retry
+    with pytest.raises(ServiceError) as excinfo:
+        function_with_integrity_error()
+    assert excinfo.value.error_type == "integrity"
+    assert call_count == 1  # Only called once, no retry
+
+
+def test_error_message_customization():
+    """Test that database errors use customized error messages."""
+    # Create a function that raises a database error
+    @handle_database
+    def raise_connection_error():
+        raise create_db_error(OperationalError, "connection refused")
+    
+    # Should use the customized error message from ERROR_MESSAGES
+    with pytest.raises(ServiceError) as excinfo:
+        raise_connection_error()
+    
+    # The error should contain the custom message from handlers.py
+    assert "Could not connect to the database" in str(excinfo.value)
+
+
+@patch("sqlalchemy.orm.Session")
+def test_session_integration(mock_session_class):
+    """Test error handling integration with SQLAlchemy session."""
+    mock_session = MagicMock()
+    mock_session_class.return_value = mock_session
+    
+    # Configure the mock to raise an exception on query execution
+    mock_session.execute.side_effect = create_db_error(OperationalError, "connection refused")
+    
+    # Function that uses the session
+    @handle_database
+    def query_with_session(session):
+        session.execute("SELECT 1")
+        return True
+    
+    # Should raise a ServiceError
+    with pytest.raises(ServiceError) as excinfo:
+        query_with_session(mock_session)
+    
+    assert excinfo.value.service == "database"
+    assert excinfo.value.error_type == "connection"
+    assert mock_session.execute.called

--- a/tests/errors/test_database_error_service_integration.py
+++ b/tests/errors/test_database_error_service_integration.py
@@ -1,0 +1,132 @@
+"""Tests for database error handling integrated with services."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import OperationalError, IntegrityError
+from sqlalchemy.orm.exc import NoResultFound
+
+from src.local_newsifier.errors.error import ServiceError
+from src.local_newsifier.errors.handlers import handle_database
+from tests.errors.test_database_error_classification import create_db_error
+
+
+class MockArticleService:
+    """Mock service class for testing database error handling."""
+    
+    def __init__(self):
+        self.article_crud = MagicMock()
+        self.session_factory = MagicMock()
+        self.mock_session = MagicMock()
+        
+        # Configure session factory to return our mock session
+        self.session_factory.return_value.__enter__.return_value = self.mock_session
+        self.session_factory.return_value.__exit__.return_value = None
+    
+    @handle_database
+    def get_article(self, article_id):
+        """Method that might raise database errors."""
+        with self.session_factory() as session:
+            return self.article_crud.get(session, article_id)
+    
+    @handle_database
+    def create_article(self, article_data):
+        """Method that might raise integrity errors."""
+        with self.session_factory() as session:
+            return self.article_crud.create(session, article_data)
+    
+    @handle_database
+    def get_article_with_advanced_query(self, title):
+        """Method that performs a custom query."""
+        with self.session_factory() as session:
+            return session.execute(f"SELECT * FROM articles WHERE title = '{title}'").one()
+
+
+@pytest.fixture
+def mock_article_service():
+    """Fixture that provides a mock article service."""
+    return MockArticleService()
+
+
+def test_connection_error_handling(mock_article_service):
+    """Test handling of database connection errors."""
+    # Configure the CRUD method to raise an OperationalError
+    mock_article_service.article_crud.get.side_effect = create_db_error(
+        OperationalError, "connection refused"
+    )
+    
+    # Should convert to ServiceError with connection type
+    with pytest.raises(ServiceError) as excinfo:
+        mock_article_service.get_article(1)
+    
+    assert excinfo.value.service == "database"
+    assert excinfo.value.error_type == "connection"
+    assert mock_article_service.article_crud.get.called
+    assert "Could not connect to the database" in str(excinfo.value)
+
+
+def test_integrity_error_handling(mock_article_service):
+    """Test handling of database integrity errors."""
+    # Configure the CRUD method to raise an IntegrityError
+    mock_article_service.article_crud.create.side_effect = create_db_error(
+        IntegrityError, "unique constraint violation"
+    )
+    
+    # Should convert to ServiceError with integrity type
+    with pytest.raises(ServiceError) as excinfo:
+        mock_article_service.create_article({"title": "Duplicate Title"})
+    
+    assert excinfo.value.service == "database"
+    assert excinfo.value.error_type == "integrity"
+    assert mock_article_service.article_crud.create.called
+    assert "constraint violation" in str(excinfo.value).lower()
+
+
+def test_not_found_error_handling(mock_article_service):
+    """Test handling of database not found errors."""
+    # Configure the CRUD method to raise NoResultFound
+    mock_article_service.article_crud.get.side_effect = NoResultFound()
+    
+    # Should convert to ServiceError with not_found type
+    with pytest.raises(ServiceError) as excinfo:
+        mock_article_service.get_article(999)
+    
+    assert excinfo.value.service == "database"
+    assert excinfo.value.error_type == "not_found"
+    assert mock_article_service.article_crud.get.called
+    assert "not found" in str(excinfo.value).lower()
+
+
+def test_session_execution_error(mock_article_service):
+    """Test handling of errors from session.execute."""
+    # Configure the session execute method to raise an OperationalError
+    mock_article_service.mock_session.execute.side_effect = create_db_error(
+        OperationalError, "timeout error"
+    )
+    
+    # Should convert to ServiceError with timeout type
+    with pytest.raises(ServiceError) as excinfo:
+        mock_article_service.get_article_with_advanced_query("Article Title")
+    
+    assert excinfo.value.service == "database"
+    assert excinfo.value.error_type == "timeout"
+    assert mock_article_service.mock_session.execute.called
+    assert "timeout" in str(excinfo.value).lower()
+
+
+@patch("src.local_newsifier.errors.error.time.sleep", MagicMock())  # Mock sleep to speed up tests
+def test_service_retry_behavior(mock_article_service):
+    """Test retry behavior for transient database errors in service methods."""
+    # Configure the CRUD method to fail twice with a connection error, then succeed
+    side_effects = [
+        create_db_error(OperationalError, "connection refused"),
+        create_db_error(OperationalError, "connection refused"),
+        {"id": 1, "title": "Test Article"}
+    ]
+    mock_article_service.article_crud.get.side_effect = side_effects
+    
+    # Should retry and eventually succeed
+    result = mock_article_service.get_article(1)
+    
+    # Verify the result and that the method was called multiple times
+    assert result == {"id": 1, "title": "Test Article"}
+    assert mock_article_service.article_crud.get.call_count == 3

--- a/tests/services/test_database_error_handling.py
+++ b/tests/services/test_database_error_handling.py
@@ -1,0 +1,55 @@
+"""Tests for database error handling in service layer."""
+
+import pytest
+from unittest.mock import MagicMock
+from sqlalchemy.exc import OperationalError, IntegrityError
+
+from local_newsifier.services.article_service import ArticleService
+from local_newsifier.errors.error import ServiceError
+
+
+def test_article_service_database_error_handling():
+    """Test that the article service properly handles database errors."""
+    # Mock dependencies
+    article_crud = MagicMock()
+    analysis_result_crud = MagicMock()
+    session_factory = MagicMock()
+    
+    # Create a service with mocked dependencies
+    service = ArticleService(
+        article_crud=article_crud,
+        analysis_result_crud=analysis_result_crud,
+        session_factory=session_factory
+    )
+    
+    # Mock session
+    mock_session = MagicMock()
+    session_factory.return_value.__enter__.return_value = mock_session
+    
+    # Test connection error
+    article_crud.get.side_effect = OperationalError(
+        statement="SELECT * FROM articles", 
+        params={}, 
+        orig=Exception("connection error")
+    )
+    
+    with pytest.raises(ServiceError) as exc_info:
+        service.get_article(article_id=1)
+    
+    error = exc_info.value
+    assert error.service == "database"
+    assert error.error_type == "connection"
+    
+    # Test integrity error
+    article_crud.get.side_effect = IntegrityError(
+        statement="INSERT INTO articles", 
+        params={}, 
+        orig=Exception("integrity error")
+    )
+    
+    with pytest.raises(ServiceError) as exc_info:
+        service.get_article(article_id=1)
+    
+    error = exc_info.value
+    assert error.service == "database"
+    assert error.error_type == "integrity"

--- a/tests/services/test_database_error_handling.py
+++ b/tests/services/test_database_error_handling.py
@@ -1,8 +1,15 @@
 """Tests for database error handling in service layer."""
 
 import pytest
-from unittest.mock import MagicMock
-from sqlalchemy.exc import OperationalError, IntegrityError
+from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import (
+    OperationalError, 
+    IntegrityError,
+    TimeoutError, 
+    StatementError,
+    InvalidRequestError
+)
+from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
 from local_newsifier.services.article_service import ArticleService
 from local_newsifier.errors.error import ServiceError
@@ -53,3 +60,79 @@ def test_article_service_database_error_handling():
     error = exc_info.value
     assert error.service == "database"
     assert error.error_type == "integrity"
+
+
+def test_database_error_classification():
+    """Test classification of various database error types."""
+    # Mock dependencies
+    article_crud = MagicMock()
+    analysis_result_crud = MagicMock()
+    session_factory = MagicMock()
+    
+    # Create a service with mocked dependencies
+    service = ArticleService(
+        article_crud=article_crud,
+        analysis_result_crud=analysis_result_crud,
+        session_factory=session_factory
+    )
+    
+    # Mock session
+    mock_session = MagicMock()
+    session_factory.return_value.__enter__.return_value = mock_session
+    
+    # Test various error types
+    test_cases = [
+        # (exception, expected_error_type)
+        (NoResultFound(), "not_found"),
+        (MultipleResultsFound(), "multiple"),
+        (TimeoutError("query timeout"), "timeout"),
+        (StatementError("statement error", {}, None), "validation"),
+        (InvalidRequestError("invalid request"), "transaction"),
+    ]
+    
+    for exception, expected_type in test_cases:
+        article_crud.get.side_effect = exception
+        
+        with pytest.raises(ServiceError) as exc_info:
+            service.get_article(article_id=1)
+        
+        error = exc_info.value
+        assert error.service == "database"
+        assert error.error_type == expected_type, f"Expected {expected_type} for {type(exception).__name__}"
+
+
+@patch('local_newsifier.errors.error.with_retry')
+def test_retry_behavior(mock_with_retry):
+    """Test that transient database errors are retried."""
+    # Setup mock retry decorator that just returns the original function
+    mock_with_retry.return_value = lambda f: f
+    
+    # Mock dependencies
+    article_crud = MagicMock()
+    analysis_result_crud = MagicMock()
+    session_factory = MagicMock()
+    
+    # Create a service with mocked dependencies
+    service = ArticleService(
+        article_crud=article_crud,
+        analysis_result_crud=analysis_result_crud,
+        session_factory=session_factory
+    )
+    
+    # Mock session
+    mock_session = MagicMock()
+    session_factory.return_value.__enter__.return_value = mock_session
+    
+    # Create a connection error (should be retried)
+    article_crud.get.side_effect = OperationalError(
+        statement="SELECT * FROM articles", 
+        params={}, 
+        orig=Exception("connection error")
+    )
+    
+    # Should fail even with mocked retry
+    with pytest.raises(ServiceError):
+        service.get_article(article_id=1)
+    
+    # Verify that with_retry was called with retry_attempts=3 (default)
+    mock_with_retry.assert_called_with(3)


### PR DESCRIPTION
Fixes issue with database error handling by improving error message extraction.

This PR:
1. Updates the state.set_error method to extract the original error message when a ServiceError is caught
2. Preserves the original exception type and traceback information
3. Fixes a failing test case in test_entity_service.py

The change ensures better error messages are shown to the user when database errors are wrapped in ServiceError objects.

Fixes Issue #190
