### PR TITLE
Fix pytest-asyncio deprecation warning (Issue #282)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ nf = "local_newsifier.cli.main:main"
 pytest = "^8.0.0"
 pytest-mock = "^3.12.0"
 pytest-cov = "^4.1.0"
+pytest-asyncio = "^0.26.0"
 pre-commit = "^3.6.0"
 black = "^24.1.1"
 isort = "^5.13.2"
@@ -65,8 +66,13 @@ addopts = "-xvs"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "db: marks tests that require database connection",
-    "fast: marks tests that should run quickly"
+    "fast: marks tests that should run quickly",
+    "asyncio: mark a test as an asyncio test"
 ]
+
+# Configure pytest-asyncio to fix deprecation warning
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 
 filterwarnings = [
     # Pydantic V2 deprecation warning about class-based config


### PR DESCRIPTION
## Summary
- Added pytest-asyncio as an explicit dev dependency to ensure it's available in CI
- Added asyncio marker to pytest configuration
- Configured asyncio_mode=strict for consistent behavior
- Set asyncio_default_fixture_loop_scope=function for best test isolation

## Test plan
- Verified the warning no longer appears when running tests that use asyncio marks
- No changes to test behavior, only resolved the deprecation warning

🤖 Generated with [Claude Code](https://claude.ai/code)