### PR TITLE
Add support for running tests on PRs targeting other PRs (Issue #292)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,27 @@
 name: Tests
 
+# This workflow runs tests in these scenarios:
+# 1. Push to main branch
+# 2. Pull request targeting main branch
+# 3. Pull request targeting another PR branch (PR chain)
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # pull_request_target allows tests to run on PRs targeting branches other than main
+  pull_request_target:
+    branches-ignore: [ main ]  # Only for PRs targeting branches other than main
 
 jobs:
   test:
+    # Security check: only run pull_request_target event if PR is from the same repo
+    # This prevents potential security issues with untrusted code execution
+    if: |
+      (github.event_name == 'push') ||
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
+    
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,7 +43,12 @@ jobs:
           --health-retries 5
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        # For pull_request_target events, we need to check out the PR head
+        # instead of the base branch (which would be the default)
+        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -112,6 +131,8 @@ jobs:
         "
 
     - name: Run tests with coverage
+      id: run_tests
+      continue-on-error: true  # Continue to the next step even if tests fail
       env:
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: postgres
@@ -121,9 +142,53 @@ jobs:
         TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
       run: |
         poetry run pytest --cov=src/local_newsifier --cov-report=xml --cov-report=term-missing --cov-fail-under=80 tests/
+        echo "status=$?" >> $GITHUB_OUTPUT
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: coverage.xml
+
+    # Post a comment on the PR with the test results
+    # This only runs for pull_request and pull_request_target events
+    - name: Post results to PR
+      if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const pr_number = context.issue.number;
+          const { owner, repo } = context.repo;
+          const workflowRunUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+          
+          let targetType = 'the main branch';
+          if (context.eventName === 'pull_request_target') {
+            targetType = 'another PR branch';
+          }
+          
+          let testStatus = '${{ steps.run_tests.outputs.status }}';
+          let body = '';
+          
+          if (testStatus === '0') {
+            body = `## CI Test Results ✅\n\n`;
+            body += `Tests passed for this PR targeting ${targetType}!\n\n`;
+          } else {
+            body = `## CI Test Results ❌\n\n`;
+            body += `Tests failed for this PR targeting ${targetType}.\n\n`;
+            body += `Please check the logs for details on the failing tests.\n\n`;
+          }
+          
+          body += `[View full details](${workflowRunUrl})`;
+          
+          github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: pr_number,
+            body
+          });
+
+    # Fail the workflow if tests failed
+    - name: Fail if tests failed
+      if: steps.run_tests.outputs.status != '0'
+      run: exit 1

--- a/docs/ci_pr_chains.md
+++ b/docs/ci_pr_chains.md
@@ -1,0 +1,51 @@
+# CI Support for PR Chains
+
+This document explains how our CI system handles Pull Request (PR) chains in the Local Newsifier project.
+
+## What are PR Chains?
+
+PR chains occur when you create a new PR that targets another PR branch instead of the main branch. This is useful in several scenarios:
+
+1. Building on work that isn't yet merged to main
+2. Splitting large changes into multiple, sequential PRs
+3. Creating dependent features that build on each other
+
+## How CI Works with PR Chains
+
+Our GitHub Actions workflow has been configured to support testing PRs that target other PRs. Here's how it works:
+
+1. When you create a PR targeting the main branch, tests run as usual
+2. When you create a PR targeting another PR branch, tests will also run
+3. Test results appear in GitHub as checks on your PR
+4. A comment will be posted to the PR with the test results
+
+This ensures that code quality is maintained throughout the PR chain, not just when merging to main.
+
+## Technical Implementation
+
+We use GitHub's `pull_request_target` event to trigger tests on PRs targeting branches other than main. For security reasons, we only allow this for PRs from the same repository.
+
+The workflow:
+1. Detects if the PR is targeting main or another branch
+2. Checks out the appropriate code
+3. Runs the tests
+4. Posts the results as a comment on the PR
+
+## Best Practices
+
+When working with PR chains:
+
+1. **Keep PRs focused**: Each PR in the chain should address a specific concern
+2. **Maintain test coverage**: Ensure tests pass at each step in the chain
+3. **Use clear PR titles**: Include references to parent PRs in the title or description
+4. **Merge in order**: Start merging from the first PR in the chain (closest to main)
+
+## Troubleshooting
+
+If tests aren't running on your PR chain:
+
+1. Verify the PR is targeting a branch other than main
+2. Check that the PR is from the same repository (not a fork)
+3. Look at the GitHub Actions workflow to see if any errors occurred
+
+For more help, reach out to the project maintainers.


### PR DESCRIPTION
## Summary

This PR adds support for running tests on Pull Requests that target other PRs instead of just main. This enables better CI support for PR chains where developers build upon each other's work.

### Changes:
- Updated GitHub Actions workflow to use  for PRs targeting branches other than main
- Added security checks to prevent running untrusted code with repo secrets
- Configured the checkout action to get the correct PR code for testing
- Added a step to comment on PRs with test results
- Created documentation explaining how PR chains work with our CI

### Testing:
- Created this PR targeting the main branch to verify tests run correctly
- Will validate with a test PR targeting this PR after this is pushed

Fixes #292