### PR TITLE
Remove ApifySourceConfig references from codebase

### DIFF
--- a/src/local_newsifier/container.py
+++ b/src/local_newsifier/container.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 # Import CRUD modules
 from local_newsifier.crud import (
     analysis_result,
-    apify_source_config,
     article,
     canonical_entity,
     entity,
@@ -53,7 +52,6 @@ def init_container(environment="production"):
     # Register CRUD modules
     container.register("article_crud", article)
     container.register("analysis_result_crud", analysis_result)
-    container.register("apify_source_config_crud", apify_source_config)
     container.register("entity_crud", entity)
     container.register("canonical_entity_crud", canonical_entity)
     container.register("entity_mention_context_crud", entity_mention_context)

--- a/src/local_newsifier/di/providers.py
+++ b/src/local_newsifier/di/providers.py
@@ -55,18 +55,6 @@ def get_session() -> Generator[Session, None, None]:
 
 # CRUD providers
 
-@injectable(use_cache=False)
-def get_apify_source_config_crud():
-    """Provide the apify source config CRUD component.
-    
-    Uses use_cache=False to create new instances for each injection, as CRUD 
-    components interact with the database and should not share state between operations.
-    
-    Returns:
-        ApifySourceConfigCRUD instance
-    """
-    from local_newsifier.crud.apify_source_config import apify_source_config
-    return apify_source_config
 
 
 @injectable(use_cache=False)


### PR DESCRIPTION
This PR resolves merge conflicts in PR #256 by removing all references to ApifySourceConfig. The ApifySourceConfig implementation will be handled separately.

- Removed ApifySourceConfig from container.py
- Removed get_apify_source_config_crud provider from providers.py

The test suite passes with these changes.