### PR TITLE
Simplify API Layer with Injectable Dependencies (Issue #232)

### DIFF
--- a/src/local_newsifier/api/routers/auth.py
+++ b/src/local_newsifier/api/routers/auth.py
@@ -1,35 +1,29 @@
 """Authentication router for admin access."""
 
-import os
-import pathlib
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
+from local_newsifier.api.dependencies import get_templates
 from local_newsifier.config.settings import settings
 
 router = APIRouter(
     tags=["auth"],
 )
 
-# Get templates directory path - works in both development and production
-if os.path.exists("src/local_newsifier/api/templates"):
-    # Development environment
-    templates_dir = "src/local_newsifier/api/templates"
-else:
-    # Production environment - use package-relative path
-    templates_dir = str(pathlib.Path(__file__).parent.parent / "templates")
-
-templates = Jinja2Templates(directory=templates_dir)
-
 
 @router.get("/login", response_class=HTMLResponse)
-async def login_page(request: Request):
+async def login_page(
+    request: Request,
+    templates: Annotated[Jinja2Templates, Depends(get_templates)]
+):
     """Render the login page.
 
     Args:
         request: FastAPI request
+        templates: Jinja2 templates
 
     Returns:
         HTML response with login form
@@ -43,6 +37,7 @@ async def login_page(request: Request):
 @router.post("/login", response_class=HTMLResponse)
 async def login(
     request: Request,
+    templates: Annotated[Jinja2Templates, Depends(get_templates)],
     username: str = Form(...),
     password: str = Form(...),
     next_url: str = Form("/system/tables"),  # Default redirect
@@ -51,6 +46,7 @@ async def login(
 
     Args:
         request: FastAPI request
+        templates: Jinja2 templates
         username: Submitted username
         password: Submitted password
         next_url: URL to redirect to after successful login

--- a/src/local_newsifier/api/routers/system.py
+++ b/src/local_newsifier/api/routers/system.py
@@ -2,14 +2,14 @@
 
 import logging
 import os
-from typing import Dict, List
+from typing import Annotated, Dict, List
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 from sqlmodel import Session, text
 
-from local_newsifier.api.dependencies import get_session, require_admin
+from local_newsifier.api.dependencies import get_session, require_admin, get_templates
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -20,18 +20,6 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 
-# Get templates directory path - works in both development and production
-if os.path.exists("src/local_newsifier/api/templates"):
-    # Development environment
-    templates_dir = "src/local_newsifier/api/templates"
-else:
-    # Production environment - use package-relative path
-    import pathlib
-
-    templates_dir = str(pathlib.Path(__file__).parent.parent / "templates")
-
-templates = Jinja2Templates(directory=templates_dir)
-
 # Flag to indicate if we're in minimal mode (no database)
 MINIMAL_MODE = False  # Permanently disabled
 
@@ -39,14 +27,16 @@ MINIMAL_MODE = False  # Permanently disabled
 @router.get("/tables", response_class=HTMLResponse)
 async def get_tables(
     request: Request,
+    session: Annotated[Session, Depends(get_session)],
+    templates: Annotated[Jinja2Templates, Depends(get_templates)],
     _: bool = Depends(require_admin),
-    session: Session = Depends(get_session),
 ):
     """Get information about all tables in the database.
 
     Args:
         request: FastAPI request
         session: Database session
+        templates: Jinja2 templates
 
     Returns:
         HTML response with table information
@@ -93,7 +83,8 @@ async def get_tables(
 
 @router.get("/tables/api", response_model=List[Dict])
 async def get_tables_api(
-    _: bool = Depends(require_admin), session: Session = Depends(get_session)
+    session: Annotated[Session, Depends(get_session)],
+    _: bool = Depends(require_admin),
 ):
     """Get information about all tables in the database (API version).
 
@@ -126,8 +117,9 @@ async def get_tables_api(
 async def get_table_details(
     request: Request,
     table_name: str,
+    session: Annotated[Session, Depends(get_session)],
+    templates: Annotated[Jinja2Templates, Depends(get_templates)],
     _: bool = Depends(require_admin),
-    session: Session = Depends(get_session),
 ):
     """Get detailed information about a specific table.
 
@@ -135,6 +127,7 @@ async def get_table_details(
         request: FastAPI request
         table_name: Table name
         session: Database session
+        templates: Jinja2 templates
 
     Returns:
         HTML response with table details
@@ -219,8 +212,8 @@ async def get_table_details(
 @router.get("/tables/{table_name}/api")
 async def get_table_details_api(
     table_name: str,
+    session: Annotated[Session, Depends(get_session)],
     _: bool = Depends(require_admin),
-    session: Session = Depends(get_session),
 ):
     """Get detailed information about a specific table (API version).
 

--- a/src/local_newsifier/api/routers/tasks.py
+++ b/src/local_newsifier/api/routers/tasks.py
@@ -3,7 +3,7 @@ API router for Celery task management.
 This module provides endpoints for submitting, checking, and managing asynchronous tasks.
 """
 
-from typing import Dict, List, Optional, Union
+from typing import Annotated, Dict, List, Optional, Union
 
 from celery.result import AsyncResult
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
@@ -30,7 +30,8 @@ router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 @router.get("/", response_class=HTMLResponse)
 async def tasks_dashboard(
-    request: Request, templates: Jinja2Templates = Depends(get_templates)
+    request: Request, 
+    templates: Annotated[Jinja2Templates, Depends(get_templates)]
 ):
     """
     Task management dashboard.
@@ -49,8 +50,8 @@ async def tasks_dashboard(
 
 @router.post("/process-article/{article_id}")
 async def process_article_endpoint(
+    article_service: Annotated[ArticleService, Depends(get_article_service)],
     article_id: int = Path(..., title="Article ID", description="ID of the article to process"),
-    article_service: ArticleService = Depends(get_article_service),
 ):
     """
     Submit a task to process an article asynchronously.
@@ -80,8 +81,8 @@ async def process_article_endpoint(
 
 @router.post("/fetch-rss-feeds")
 async def fetch_rss_feeds_endpoint(
+    rss_feed_service: Annotated[RSSFeedService, Depends(get_rss_feed_service)],
     feed_urls: Optional[List[str]] = Query(None, description="List of RSS feed URLs to process"),
-    rss_feed_service: RSSFeedService = Depends(get_rss_feed_service),
 ):
     """
     Submit a task to fetch articles from RSS feeds.
@@ -104,7 +105,6 @@ async def fetch_rss_feeds_endpoint(
         "status": "queued",
         "task_url": f"/tasks/status/{task.id}",
     }
-
 
 
 @router.get("/status/{task_id}")


### PR DESCRIPTION
## Summary
- Updated API dependencies.py to consistently use fastapi-injectable pattern
- Updated API routers to use Annotated type hints with Depends()
- Removed direct container references in favor of injectable providers
- Updated tests to reflect the new dependency pattern

## Test plan
- Run API tests to ensure the changes work correctly
- Note that some tests are skipped due to known asyncio issues that are being handled in separate PRs

🤖 Generated with [Claude Code](https://claude.ai/code)
