### PR TITLE
Fix SQL formatting in ApifyScheduleManager._clean_orphaned_schedules (Issue #338)

### DIFF
--- a/src/local_newsifier/services/apify_schedule_manager.py
+++ b/src/local_newsifier/services/apify_schedule_manager.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typing import Callable, Dict, List, Optional, Tuple, Any
 
 from sqlmodel import Session
+from sqlalchemy.sql import text
 
 from local_newsifier.models.apify import ApifySourceConfig
 from local_newsifier.services.apify_service import ApifyService
@@ -402,7 +403,7 @@ class ApifyScheduleManager:
         """
         # Get all configs with schedule_ids
         configs = session.exec(
-            "SELECT schedule_id FROM apify_source_configs WHERE schedule_id IS NOT NULL"
+            text("SELECT schedule_id FROM apify_source_configs WHERE schedule_id IS NOT NULL")
         ).all()
         
         # Convert to set for faster lookups


### PR DESCRIPTION
## Summary
- Fixed SQL query in ApifyScheduleManager by wrapping it with SQLAlchemy's text() function
- Added import for text from sqlalchemy.sql
- Fixes the error: "Textual SQL expression should be explicitly declared as text()"
- This resolves an issue in the 'nf apify schedules sync' command

## Test plan
- Verified that unit tests for both methods pass
- Confirmed CLI command tests pass as well

Fixes #338

🤖 Generated with [Claude Code](https://claude.ai/code)