### PR TITLE
Add Claude Code CLI commands for worktree and environment initialization

### DIFF
--- a/src/local_newsifier/cli/commands/claude.py
+++ b/src/local_newsifier/cli/commands/claude.py
@@ -1,0 +1,295 @@
+"""CLI commands for Claude Code integration.
+
+This module provides commands for setting up and managing Claude Code integration
+with the Local Newsifier project.
+"""
+
+import logging
+import os
+import shutil
+from pathlib import Path
+
+import click
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+@click.group(name="claude")
+def claude_group():
+    """Commands for managing Claude Code integration."""
+    pass
+
+
+@claude_group.command(name="init")
+@click.argument("directory", type=click.Path(file_okay=False))
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Force initialization even if directory exists and is not empty",
+)
+@click.option("--skip-db", is_flag=True, help="Skip database initialization")
+def init_claude_code(directory, force, skip_db):
+    """
+    Initialize a new Claude Code workspace in the specified directory.
+
+    This command:
+    1. Creates the directory if it doesn't exist
+    2. Copies project files to the new directory
+    3. Initializes a cursor-specific database for the new directory
+    4. Sets up environment files
+
+    DIRECTORY is the path where the new workspace will be created.
+    """
+    # Convert to absolute path
+    directory = Path(directory).resolve()
+
+    # Check if directory exists and handle accordingly
+    if directory.exists():
+        if not directory.is_dir():
+            raise click.BadParameter(f"'{directory}' exists but is not a directory")
+
+        # Check if directory is empty or if force flag is set
+        if any(directory.iterdir()) and not force:
+            raise click.BadParameter(
+                f"Directory '{directory}' is not empty. Use --force to initialize anyway."
+            )
+    else:
+        # Create directory
+        directory.mkdir(parents=True)
+        click.echo(f"Created directory: {directory}")
+
+    # Get current project root
+    current_dir = Path.cwd()
+
+    # Copy essential files for a minimal functioning project
+    files_to_copy = [
+        ".env.example",
+        "pyproject.toml",
+        "README.md",
+    ]
+
+    dirs_to_copy = [
+        "src",
+        "scripts",
+    ]
+
+    click.echo("Copying project files...")
+
+    for file in files_to_copy:
+        src_path = current_dir / file
+        if src_path.exists():
+            shutil.copy2(src_path, directory / file)
+            click.echo(f"  ✓ Copied {file}")
+        else:
+            click.echo(f"  ! Skipped {file} (not found)")
+
+    for dir_name in dirs_to_copy:
+        src_path = current_dir / dir_name
+        dest_path = directory / dir_name
+        if src_path.exists():
+            if dest_path.exists():
+                shutil.rmtree(dest_path)
+            shutil.copytree(src_path, dest_path)
+            click.echo(f"  ✓ Copied {dir_name}/")
+        else:
+            click.echo(f"  ! Skipped {dir_name}/ (not found)")
+
+    # Create CLAUDE.md file with default configuration
+    claude_md_path = directory / "CLAUDE.md"
+    claude_md_content = """# Local Newsifier Development Guide
+
+## Project Overview
+- News article analysis system using SQLModel, PostgreSQL, and dependency injection
+- Focuses on entity tracking, sentiment analysis, and headline trend detection
+- Uses NLP for entity recognition and relationship mapping
+- Supports multiple content acquisition methods (RSS feeds, Apify web scraping)
+- Uses Celery with Redis for asynchronous task processing
+
+## Environment Setup
+
+This project requires Python 3.10-3.12, with Python 3.12 recommended to match CI.
+
+## Getting Started
+
+1. Run database initialization:
+   ```bash
+   python scripts/init_cursor_db.py
+   ```
+
+2. Install spaCy models:
+   ```bash
+   python -m spacy download en_core_web_lg
+   ```
+
+3. Add an RSS feed:
+   ```bash
+   python -m src.local_newsifier.cli.main feeds add https://example.com/rss
+   ```
+
+4. Process a feed:
+   ```bash
+   python -m src.local_newsifier.cli.main feeds process <feed_id>
+   ```
+
+## Common Commands
+
+### CLI Commands
+- `nf help`: Show available commands and options
+- `nf feeds list`: List configured RSS feeds
+- `nf feeds add <URL>`: Add a new RSS feed
+- `nf feeds process <ID>`: Process a specific feed
+- `nf db stats`: Show database statistics
+"""
+
+    with open(claude_md_path, "w") as f:
+        f.write(claude_md_content)
+    click.echo("  ✓ Created CLAUDE.md with default configuration")
+
+    # Create .env file with default configuration
+    env_path = directory / ".env"
+    env_content = """# Database settings
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+# POSTGRES_DB will be automatically set by the cursor system
+
+# Output directories
+OUTPUT_DIR=output
+CACHE_DIR=cache
+
+# Logging
+LOG_LEVEL=INFO
+
+# NLP settings
+NER_MODEL=en_core_web_lg
+"""
+
+    with open(env_path, "w") as f:
+        f.write(env_content)
+    click.echo("  ✓ Created .env with default configuration")
+
+    # Initialize database for the new directory if not skipped
+    if not skip_db:
+        click.echo("\nInitializing database...")
+
+        # Change to the new directory to run the initialization script
+        # This ensures .env.cursor is created in the right place
+        os.chdir(directory)
+
+        try:
+            # Import here to avoid circular imports
+            from scripts.init_cursor_db import init_cursor_db
+
+            db_name = init_cursor_db()
+            click.echo(f"  ✓ Initialized database: {db_name}")
+            click.echo("  ✓ Created .env.cursor file")
+
+        except Exception as e:
+            click.echo(f"  ! Database initialization failed: {e}")
+            click.echo("    You can run database initialization manually later:")
+            click.echo("    cd " + str(directory))
+            click.echo("    python scripts/init_cursor_db.py")
+
+        # Change back to original directory
+        os.chdir(current_dir)
+
+    click.echo("\n✅ Claude Code workspace initialized successfully!")
+    click.echo(f"Workspace directory: {directory}")
+    click.echo("\nNext steps:")
+    click.echo("1. cd " + str(directory))
+    click.echo("2. source .env.cursor")
+    click.echo("3. Run 'poetry install' to install dependencies")
+    click.echo("4. Run 'python -m spacy download en_core_web_lg' to install NLP models")
+    click.echo("5. Start working with Claude Code!")
+
+
+@claude_group.command(name="validate")
+@click.option(
+    "--directory",
+    "-d",
+    type=click.Path(exists=True, file_okay=False),
+    default=".",
+    help="Directory to validate (defaults to current directory)",
+)
+def validate_claude_code(directory):
+    """
+    Validate that the current directory is a properly set up Claude Code workspace.
+
+    This command checks for:
+    1. Presence of required files
+    2. Database configuration
+    3. Environment setup
+    """
+    directory = Path(directory).resolve()
+    click.echo(f"Validating Claude Code workspace in: {directory}")
+
+    # Required files
+    required_files = [
+        "CLAUDE.md",
+        ".env",
+        "pyproject.toml",
+        "src/local_newsifier/config/settings.py",
+    ]
+
+    # Check required files
+    all_files_present = True
+    click.echo("\nChecking required files:")
+    for file in required_files:
+        file_path = directory / file
+        if file_path.exists():
+            click.echo(f"  ✓ {file}")
+        else:
+            click.echo(f"  ✗ {file} (missing)")
+            all_files_present = False
+
+    # Check database environment
+    click.echo("\nChecking database configuration:")
+    env_cursor_path = directory / ".env.cursor"
+    if env_cursor_path.exists():
+        with open(env_cursor_path, "r") as f:
+            cursor_content = f.read()
+            if "CURSOR_DB_ID" in cursor_content:
+                click.echo("  ✓ .env.cursor contains CURSOR_DB_ID")
+            else:
+                click.echo("  ✗ .env.cursor missing CURSOR_DB_ID (invalid format)")
+    else:
+        click.echo("  ✗ .env.cursor file missing (database not initialized)")
+
+    # Check .env file content
+    click.echo("\nChecking environment configuration:")
+    env_path = directory / ".env"
+    required_env_vars = [
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+    ]
+
+    if env_path.exists():
+        with open(env_path, "r") as f:
+            env_content = f.read()
+            for var in required_env_vars:
+                if var in env_content:
+                    click.echo(f"  ✓ {var}")
+                else:
+                    click.echo(f"  ✗ {var} (missing from .env)")
+
+    # Summary
+    click.echo("\nValidation summary:")
+    if all_files_present and env_cursor_path.exists():
+        click.echo("✅ Claude Code workspace is properly configured.")
+    else:
+        click.echo("⚠️ Claude Code workspace has configuration issues.")
+        click.echo(
+            "   Run 'nf claude init --force .' to reinitialize in current directory."
+        )
+
+
+if __name__ == "__main__":
+    claude_group()

--- a/src/local_newsifier/cli/main.py
+++ b/src/local_newsifier/cli/main.py
@@ -1,5 +1,4 @@
-"""
-Local Newsifier CLI - Main Entry Point
+"""Local Newsifier CLI - Main Entry Point.
 
 The `nf` command is the entry point for the Local Newsifier CLI.
 This module provides a foundation for managing RSS feeds and other local newsifier
@@ -7,8 +6,8 @@ operations from the command line.
 """
 
 import sys
+
 import click
-from tabulate import tabulate
 
 
 @click.group()
@@ -16,7 +15,7 @@ from tabulate import tabulate
 def cli():
     """
     Local Newsifier CLI - A tool for managing local news data.
-    
+
     This CLI provides commands for managing RSS feeds, processing articles,
     and analyzing news data.
     """
@@ -25,10 +24,10 @@ def cli():
 
 def is_apify_command():
     """Check if the user is trying to run an apify command.
-    
+
     This helps us avoid loading dependencies that have SQLite requirements
     when they're not needed.
-    
+
     Returns:
         bool: True if the command is apify-related
     """
@@ -36,20 +35,40 @@ def is_apify_command():
     return len(sys.argv) > 1 and sys.argv[1] == "apify"
 
 
+def is_claude_command():
+    """Check if the user is trying to run a claude command.
+
+    This helps us load claude-specific commands only when needed.
+
+    Returns:
+        bool: True if the command is claude-related
+    """
+    # Check if 'claude' is in the command arguments
+    return len(sys.argv) > 1 and sys.argv[1] == "claude"
+
+
 # Conditionally load commands to avoid unnecessary dependencies
 if is_apify_command():
     # Only load the apify command if it's being used
     from local_newsifier.cli.commands.apify import apify_group
+
     cli.add_command(apify_group)
+elif is_claude_command():
+    # Only load the claude command if it's being used
+    from local_newsifier.cli.commands.claude import claude_group
+
+    cli.add_command(claude_group)
 else:
     # Load all other command groups
-    from local_newsifier.cli.commands.feeds import feeds_group
-    from local_newsifier.cli.commands.db import db_group
     from local_newsifier.cli.commands.apify import apify_group
-    
+    from local_newsifier.cli.commands.claude import claude_group
+    from local_newsifier.cli.commands.db import db_group
+    from local_newsifier.cli.commands.feeds import feeds_group
+
     cli.add_command(feeds_group)
     cli.add_command(db_group)
     cli.add_command(apify_group)
+    cli.add_command(claude_group)
 
 
 def main():

--- a/tests/cli/test_claude_commands.py
+++ b/tests/cli/test_claude_commands.py
@@ -1,0 +1,135 @@
+"""Tests for the Claude Code CLI commands."""
+
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+from click.testing import CliRunner
+
+from local_newsifier.cli.commands.claude import claude_group
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI runner for testing."""
+    return CliRunner()
+
+
+@pytest.fixture
+def temp_dir(tmp_path):
+    """Create a temporary directory for the test."""
+    return tmp_path
+
+
+def test_claude_group_help(runner):
+    """Test that the claude command group provides help."""
+    result = runner.invoke(claude_group, ["--help"])
+    assert result.exit_code == 0
+    assert "Commands for managing Claude Code integration" in result.output
+    assert "init" in result.output
+    assert "validate" in result.output
+
+
+def test_init_claude_code_simple(runner, temp_dir):
+    """Test initializing Claude Code in a new directory with simple mocking."""
+    with runner.isolated_filesystem():
+        # Create a new directory for testing
+        new_dir = Path(temp_dir) / "claude_workspace"
+        new_dir.mkdir(exist_ok=True)
+
+        # Run with skip-db to avoid actual database initialization
+        with patch("local_newsifier.cli.commands.claude.shutil"):
+            result = runner.invoke(claude_group, ["init", str(new_dir), "--skip-db"])
+
+        # Just check basic success conditions
+        assert result.exit_code == 0
+        assert "Claude Code workspace initialized successfully" in result.output
+
+
+@patch("local_newsifier.cli.commands.claude.shutil")
+def test_init_claude_code_existing_nonempty_directory(mock_shutil, runner, temp_dir):
+    """Test initializing Claude Code in an existing, non-empty directory without force."""
+    # Create directory and a test file
+    existing_dir = temp_dir / "existing_dir"
+    existing_dir.mkdir()
+    (existing_dir / "some_file.txt").write_text("test content")
+
+    # Run the command
+    result = runner.invoke(claude_group, ["init", str(existing_dir)])
+
+    # Assertions
+    assert result.exit_code != 0
+    assert "not empty" in result.output
+    assert "--force" in result.output
+
+
+@patch("local_newsifier.cli.commands.claude.shutil")
+def test_init_claude_code_force_flag(mock_shutil, runner, temp_dir):
+    """Test initializing Claude Code with --force flag."""
+    # Create directory and a test file
+    existing_dir = temp_dir / "force_dir"
+    existing_dir.mkdir()
+    (existing_dir / "some_file.txt").write_text("test content")
+
+    # Run the command
+    with patch("builtins.open", mock_open()):
+        with patch("pathlib.Path.write_text"):
+            result = runner.invoke(
+                claude_group, ["init", str(existing_dir), "--force", "--skip-db"]
+            )
+
+    # Assertions
+    assert result.exit_code == 0
+    assert "Copying project files..." in result.output
+    assert "Claude Code workspace initialized successfully" in result.output
+
+
+def test_validate_claude_code_good_setup(runner, temp_dir):
+    """Test validating a correctly set up Claude Code workspace."""
+    # Create a mock Claude Code workspace
+    workspace_dir = temp_dir / "good_workspace"
+    workspace_dir.mkdir()
+
+    # Create required files
+    (workspace_dir / "CLAUDE.md").write_text("# Claude Code")
+    (workspace_dir / ".env").write_text(
+        "POSTGRES_USER=test\nPOSTGRES_PASSWORD=test\n"
+        "POSTGRES_HOST=localhost\nPOSTGRES_PORT=5432"
+    )
+    (workspace_dir / ".env.cursor").write_text("export CURSOR_DB_ID=12345678")
+    (workspace_dir / "pyproject.toml").write_text("[tool.poetry]")
+
+    # Create directory structure
+    src_dir = workspace_dir / "src" / "local_newsifier" / "config"
+    src_dir.mkdir(parents=True)
+    (src_dir / "settings.py").write_text("# settings")
+
+    # Run the command
+    result = runner.invoke(claude_group, ["validate", "-d", str(workspace_dir)])
+
+    # Assertions
+    assert result.exit_code == 0
+    assert "Validating Claude Code workspace" in result.output
+    assert "Checking required files:" in result.output
+    assert ".env.cursor contains CURSOR_DB_ID" in result.output
+    assert "Claude Code workspace is properly configured" in result.output
+
+
+def test_validate_claude_code_missing_files(runner, temp_dir):
+    """Test validating a Claude Code workspace with missing files."""
+    # Create a mock Claude Code workspace with issues
+    workspace_dir = temp_dir / "bad_workspace"
+    workspace_dir.mkdir()
+
+    # Create only some required files
+    (workspace_dir / ".env").write_text("POSTGRES_USER=test")
+
+    # Run the command
+    result = runner.invoke(claude_group, ["validate", "-d", str(workspace_dir)])
+
+    # Assertions
+    assert result.exit_code == 0  # Command succeeds even with validation failures
+    assert "Validating Claude Code workspace" in result.output
+    assert "✗ CLAUDE.md (missing)" in result.output
+    assert "✗ .env.cursor file missing" in result.output
+    assert "Claude Code workspace has configuration issues" in result.output


### PR DESCRIPTION
## Summary
- Added new Claude Code CLI commands to initialize a new workspace
- Added the 'nf claude init <directory>' command to create a new Claude Code workspace
- Added the 'nf claude validate' command to check Claude Code configuration
- Includes comprehensive tests for the new commands

## Implementation Details
- The init command creates a new workspace with necessary files
- Copies essential source files from the current project
- Creates customized CLAUDE.md and .env files
- Optionally sets up a cursor-specific database
- The validate command checks workspace configuration

## Test Plan
- Run 'nf claude init <new_directory>' to create a new workspace
- Run 'nf claude validate' to check configuration
- Run 'cd <new_directory> && python scripts/init_cursor_db.py' to initialize database manually if skipped

This makes it easier to set up new Claude Code environments for working with the local_newsifier project.