### PR TITLE
Create custom slash command for PR/issue management analysis (Issue #364)

### DIFF
--- a/.claude/commands/analyze_closed_prs.md
+++ b/.claude/commands/analyze_closed_prs.md
@@ -1,0 +1,34 @@
+You'll analyze recently merged PRs to find issues that are still open but have been implemented.
+
+If a timeframe argument is provided (e.g., project:analyze_closed_prs 30d):
+- Focus on PRs merged within that timeframe (e.g., last 30 days)
+- Accepted formats: 7d (days), 2w (weeks), 1m (months)
+
+If no timeframe is provided:
+- Default to analyzing PRs merged in the last 14 days
+
+Use the gh cli command to find and analyze merged PRs:
+
+1. List recently merged PRs
+   gh pr list --state merged --limit 50
+
+2. For each PR, look at the title and body for issue references:
+   gh pr view PR_NUMBER
+
+3. Check if the referenced issues are still open:
+   gh issue view ISSUE_NUMBER
+
+4. Group the results by confidence level:
+   - HIGH: Issues mentioned with "fixes #X", "closes #X" in PR title
+   - MEDIUM: Issues mentioned in PR body with implementation details
+   - LOW: Issues simply referenced in PR
+
+5. Create a report showing:
+   - Issues that can likely be closed (high confidence)
+   - Issues that need review before closing (medium confidence)
+   - Issues that need verification (low confidence)
+
+6. Provide commands to easily close issues if appropriate:
+   gh issue close ISSUE_NUMBER --reason "completed"
+
+This helps maintain a cleaner issue tracker by identifying issues that have been implemented but not formally closed.


### PR DESCRIPTION
## Summary
- Add new project:analyze_closed_prs command that identifies open issues referenced in merged PRs
- Support for optional timeframe argument (e.g., 30d, 2w, 1m) to control the analysis period
- Command helps find issues that have been implemented but not formally closed
- Provides clear guidance for maintaining a cleaner issue tracker

## Features
- Analyzes PR titles and bodies to find issue references
- Groups findings by confidence level (high/medium/low)
- Generates actionable report with close commands for suitable issues
- Works with or without a timeframe argument

🤖 Generated with [Claude Code](https://claude.ai/code)