### PR TITLE
Migrate RSSParser to injectable pattern (Issue #405)

### DIFF
--- a/src/local_newsifier/tools/rss_parser.py
+++ b/src/local_newsifier/tools/rss_parser.py
@@ -26,9 +26,7 @@ class RSSItem(BaseModel):
     description: Optional[str] = None
 
 
-# Note: The @injectable decorator is commented out to prevent test failures
-# When used in production code via the provider functions it should be uncommented
-# @injectable(use_cache=False)
+@injectable(use_cache=False)
 class RSSParser:
     """Tool for parsing RSS feeds and extracting content."""
 

--- a/tests/tools/test_rss_parser.py
+++ b/tests/tools/test_rss_parser.py
@@ -164,8 +164,10 @@ from tests.fixtures.event_loop import event_loop_fixture  # noqa
 
 
 class TestRSSParser:
-    def setup_method(self, event_loop_fixture=None):
+    @pytest.fixture(autouse=True)
+    def setup_method(self, event_loop_fixture):
         # Use the fixture to handle potential event loop issues
+        # Create parser in each test using event_loop_fixture to properly handle @injectable
         self.parser = RSSParser()
 
     def test_init_without_cache(self, event_loop_fixture):


### PR DESCRIPTION
## Summary\n- Enabled @injectable decorator on RSSParser class\n- Fixed test setup method to properly handle event loop for @injectable\n- Ensured all tests pass for RSSParser functionality\n\n## Test plan\n- Verified RSSParser specific tests work\n- Verified RSSScrapingFlow tests work\n\n🤖 Generated with [Claude Code](https://claude.ai/code)