### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS Instructions
+
+The main development guide for this project is `claude.md`. Module-specific guidance is documented in the following files:
+- src/local_newsifier/api/CLAUDE.md
+- src/local_newsifier/cli/CLAUDE.md
+- src/local_newsifier/database/CLAUDE.md
+- src/local_newsifier/di/CLAUDE.md
+- src/local_newsifier/flows/CLAUDE.md
+- src/local_newsifier/models/CLAUDE.md
+- src/local_newsifier/services/CLAUDE.md
+- src/local_newsifier/tools/CLAUDE.md
+
+Additional information is available in all Markdown files under the `docs/` directory and the root documentation files:
+- FastAPI-Injectable-Migration-Plan.md
+- README.md
+- README_CLI.md
+- implementation_summary_issue_214.md
+
+If a new `CLAUDE.md` file is added or removed, update this document so Codex can locate every guide.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,5 @@ Additional information is available in all Markdown files under the `docs/` dire
 - FastAPI-Injectable-Migration-Plan.md
 - README.md
 - README_CLI.md
-- implementation_summary_issue_214.md
 
 If a new `CLAUDE.md` file is added or removed, update this document so Codex can locate every guide.

--- a/claude.md
+++ b/claude.md
@@ -321,3 +321,7 @@ with patch("my_module.async_dependency", AsyncMock(return_value=mock_result)):
 def test_problematic_in_ci(event_loop_fixture):
     # Test code here
 ```
+## Maintaining AGENTS.md
+
+Whenever you add or remove a `CLAUDE.md` file anywhere in the repository, update the root `AGENTS.md` so Codex can find all of the guides.
+


### PR DESCRIPTION
## Summary
- add an AGENTS.md pointing codex to markdown docs
- document need to keep AGENTS.md updated in claude.md

## Testing
- `poetry run pre-commit run --files AGENTS.md claude.md` *(fails: Command not found)*
- `pip install pre-commit` *(fails: cannot connect to proxy)*