### PR TITLE
Add injectable provider for apify config service

### DIFF
--- a/src/local_newsifier/cli/commands/apify_config.py
+++ b/src/local_newsifier/cli/commands/apify_config.py
@@ -14,8 +14,9 @@ import click
 from datetime import datetime
 from tabulate import tabulate
 
-from local_newsifier.container import container
-from local_newsifier.database.engine import get_session
+from fastapi_injectable import get_injected_obj
+
+from local_newsifier.di.providers import get_apify_source_config_service
 
 
 @click.group(name="apify-config")
@@ -32,8 +33,8 @@ def apify_config_group():
 @click.option("--source-type", help="Filter by source type (e.g., news, blog)")
 def list_configs(active_only, json_output, limit, skip, source_type):
     """List all Apify source configurations with optional filtering."""
-    # Get the service from the container
-    apify_source_config_service = container.get("apify_source_config_service")
+    # Get the service using the injectable provider
+    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
     
     # Get configs based on filters
     configs_dict = apify_source_config_service.list_configs(
@@ -93,8 +94,8 @@ def list_configs(active_only, json_output, limit, skip, source_type):
 @click.option("--input", "-i", help="JSON string or file path for actor input configuration")
 def add_config(name, actor_id, source_type, source_url, schedule, input):
     """Add a new Apify source configuration."""
-    # Get the service from the container
-    apify_source_config_service = container.get("apify_source_config_service")
+    # Get the service using the injectable provider
+    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
     
     # Parse input configuration if provided
     input_configuration = None
@@ -141,8 +142,8 @@ def add_config(name, actor_id, source_type, source_url, schedule, input):
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 def show_config(id, json_output):
     """Show Apify source configuration details."""
-    # Get the service from the container
-    apify_source_config_service = container.get("apify_source_config_service")
+    # Get the service using the injectable provider
+    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
     
     try:
         config = apify_source_config_service.get_config(id)
@@ -185,8 +186,8 @@ def show_config(id, json_output):
 @click.option("--force", is_flag=True, help="Skip confirmation")
 def remove_config(id, force):
     """Remove an Apify source configuration."""
-    # Get the service from the container
-    apify_source_config_service = container.get("apify_source_config_service")
+    # Get the service using the injectable provider
+    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
     
     try:
         config = apify_source_config_service.get_config(id)
@@ -219,8 +220,8 @@ def remove_config(id, force):
 @click.option("--input", "-i", help="JSON string or file path for actor input configuration")
 def update_config(id, name, actor_id, source_type, source_url, schedule, active, input):
     """Update Apify source configuration properties."""
-    # Get the service from the container
-    apify_source_config_service = container.get("apify_source_config_service")
+    # Get the service using the injectable provider
+    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
     
     try:
         # Check if at least one property to update was provided
@@ -286,8 +287,8 @@ def run_config(id, output):
         nf apify-config run 1
         nf apify-config run 2 --output result.json
     """
-    # Get the service from the container
-    apify_source_config_service = container.get("apify_source_config_service")
+    # Get the service using the injectable provider
+    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
     
     try:
         # Run the configuration

--- a/src/local_newsifier/di/providers.py
+++ b/src/local_newsifier/di/providers.py
@@ -661,6 +661,34 @@ def get_apify_schedule_manager(
 
 
 @injectable(use_cache=False)
+def get_apify_source_config_service(
+    apify_source_config_crud: Annotated["CRUDApifySourceConfig", Depends(get_apify_source_config_crud)],
+    apify_service: Annotated["ApifyService", Depends(get_apify_service)],
+    session: Annotated[Session, Depends(get_session)]
+):
+    """Provide the ApifySourceConfigService for CLI commands.
+
+    This provider returns a fresh service instance on every injection,
+    ensuring state is not shared across operations.
+
+    Args:
+        apify_source_config_crud: CRUD for Apify source configurations
+        apify_service: Apify service for API interactions
+        session: Database session
+
+    Returns:
+        ApifySourceConfigService instance
+    """
+    from local_newsifier.services.apify_source_config_service import ApifySourceConfigService
+
+    return ApifySourceConfigService(
+        apify_source_config_crud=apify_source_config_crud,
+        apify_service=apify_service,
+        session_factory=lambda: session
+    )
+
+
+@injectable(use_cache=False)
 def get_analysis_service(
     analysis_result_crud: Annotated["CRUDAnalysisResult", Depends(get_analysis_result_crud)],
     article_crud: Annotated["CRUDArticle", Depends(get_article_crud)],


### PR DESCRIPTION
## Summary
- provide `get_apify_source_config_service` via fastapi-injectable
- switch `apify_config` CLI commands to use the injectable provider
- clarify provider docstring

## Testing
- `make setup-poetry` *(fails: All attempts to connect to pypi.org failed)*