### PR TITLE
Remove legacy from_container flow factories

### DIFF
--- a/src/local_newsifier/flows/analysis/headline_trend_flow.py
+++ b/src/local_newsifier/flows/analysis/headline_trend_flow.py
@@ -213,11 +213,3 @@ class HeadlineTrendFlow(Flow):
         report += "</body></html>"
         return report
         
-    @classmethod
-    def from_container(cls):
-        """Legacy factory method for container-based instantiation."""
-        from local_newsifier.container import container
-        
-        return cls(
-            analysis_service=container.get("analysis_service")
-        )

--- a/src/local_newsifier/flows/entity_tracking_flow.py
+++ b/src/local_newsifier/flows/entity_tracking_flow.py
@@ -186,16 +186,3 @@ class EntityTrackingFlow(Flow):
         # Return relationship data
         return result_state.relationship_data
         
-    @classmethod
-    def from_container(cls):
-        """Legacy factory method for container-based instantiation."""
-        from local_newsifier.container import container
-        
-        return cls(
-            entity_service=container.get("entity_service"),
-            entity_tracker=container.get("entity_tracker_tool"),
-            entity_extractor=container.get("entity_extractor"),
-            context_analyzer=container.get("context_analyzer"),
-            entity_resolver=container.get("entity_resolver"),
-            session_factory=container.get("session_factory")
-        )

--- a/src/local_newsifier/flows/news_pipeline.py
+++ b/src/local_newsifier/flows/news_pipeline.py
@@ -261,19 +261,3 @@ class NewsPipelineFlow(Flow):
         """
         return self.pipeline_service.process_url(url)
     
-    @classmethod
-    def from_container(cls):
-        """Legacy factory method for container-based instantiation."""
-        from local_newsifier.container import container
-        
-        return cls(
-            article_service=container.get("article_service"),
-            entity_service=container.get("entity_service"),
-            pipeline_service=container.get("news_pipeline_service"),
-            web_scraper=container.get("web_scraper_tool"),
-            file_writer=container.get("file_writer_tool"),
-            entity_extractor=container.get("entity_extractor"),
-            context_analyzer=container.get("context_analyzer"),
-            entity_resolver=container.get("entity_resolver"),
-            session_factory=container.get("session_factory")
-        )

--- a/src/local_newsifier/flows/public_opinion_flow.py
+++ b/src/local_newsifier/flows/public_opinion_flow.py
@@ -454,14 +454,3 @@ class PublicOpinionFlow(Flow):
             logger.error(f"Error generating comparison report: {str(e)}")
             return f"Error generating comparison report: {str(e)}"
             
-    @classmethod
-    def from_container(cls):
-        """Legacy factory method for container-based instantiation."""
-        from local_newsifier.container import container
-        
-        return cls(
-            sentiment_analyzer=container.get("sentiment_analyzer_tool"),
-            sentiment_tracker=container.get("sentiment_tracker_tool"),
-            opinion_visualizer=container.get("opinion_visualizer_tool"),
-            session_factory=container.get("session_factory")
-        )

--- a/src/local_newsifier/flows/rss_scraping_flow.py
+++ b/src/local_newsifier/flows/rss_scraping_flow.py
@@ -114,15 +114,3 @@ class RSSScrapingFlow(Flow):
 
         return results
         
-    @classmethod
-    def from_container(cls):
-        """Legacy factory method for container-based instantiation."""
-        from local_newsifier.container import container
-        
-        return cls(
-            rss_feed_service=container.get("rss_feed_service"),
-            article_service=container.get("article_service"),
-            rss_parser=container.get("rss_parser"),
-            web_scraper=container.get("web_scraper_tool"),
-            session_factory=container.get("session_factory")
-        )

--- a/src/local_newsifier/flows/trend_analysis_flow.py
+++ b/src/local_newsifier/flows/trend_analysis_flow.py
@@ -308,13 +308,3 @@ class NewsTrendAnalysisFlow(Flow):
 
         return state
         
-    @classmethod
-    def from_container(cls):
-        """Legacy factory method for container-based instantiation."""
-        from local_newsifier.container import container
-        
-        return cls(
-            analysis_service=container.get("analysis_service"),
-            trend_reporter=container.get("trend_reporter_tool"),
-            session=container.get("session")
-        )


### PR DESCRIPTION
## Summary
- delete `from_container` factories from all flows
- flows should be accessed via DI providers instead

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*