### PR TITLE
Refactor session utils to use DI provider

### DIFF
--- a/src/local_newsifier/container.py
+++ b/src/local_newsifier/container.py
@@ -8,7 +8,7 @@ resolution and lifecycle management.
 
 from local_newsifier.di_container import DIContainer, Scope
 from local_newsifier.database.engine import SessionManager
-from local_newsifier.database.session_utils import get_container_session
+from local_newsifier.di.providers import get_session
 import logging
 
 logger = logging.getLogger(__name__)
@@ -71,10 +71,10 @@ def init_container(environment="production"):
         container.register_factory("session_factory", 
                                 lambda c: SessionManager)
     
-    # Register session utility
+    # Register session utility using injectable provider
     container.register_factory_with_params(
-        "get_session", 
-        lambda c, **kwargs: get_container_session(c, **kwargs)
+        "get_session",
+        lambda c, **kwargs: get_session()
     )
     
     # Register Core Tools

--- a/src/local_newsifier/database/session_utils.py
+++ b/src/local_newsifier/database/session_utils.py
@@ -12,7 +12,6 @@ from typing import TypeVar, Callable, Any, Optional, Dict
 
 from sqlmodel import Session
 
-# Import container at runtime to avoid circular imports
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -22,47 +21,27 @@ F = TypeVar('F', bound=Callable[..., Any])
 T = TypeVar('T')
 
 
-def get_container_session(container=None, test_mode: bool = False, **kwargs):
-    """Get a session from the container's session factory.
-    
-    This function obtains the session factory from the container
-    and returns a session context manager.
-    
-    Args:
-        container: The DI container instance (optional, will be imported if not provided)
-        test_mode: If True, use optimized settings for tests
-        **kwargs: Additional parameters to pass to the session factory
-        
-    Returns:
-        A session context manager
-    """
-    # Lazy import to avoid circular dependency
-    if container is None:
-        # Import only when needed to avoid circular imports
-        from local_newsifier.container import container
-        
-    session_factory = container.get("session_factory")
-    if session_factory is None:
-        logger.error("Session factory not available in container")
-        raise ValueError("Session factory not available in container")
-    
+def get_container_session(*, test_mode: bool = False, **kwargs):
+    """Get a session generator using the injectable provider."""
     # Detect if we're running in a test environment
     if 'pytest' in sys.modules:
         test_mode = True
-        
-    return session_factory(test_mode=test_mode)
+
+    from local_newsifier.di.providers import get_session
+
+    # The provider already handles session creation and cleanup
+    return get_session()
 
 
-def with_container_session(func: F = None, *, container=None) -> F:
-    """Decorator that provides a container-managed session to the decorated function.
-    
+def with_container_session(func: F = None) -> F:
+    """Decorator that provides a managed session to the decorated function.
+
     If a session is already provided as a keyword argument, it will be used directly.
-    Otherwise, a new session will be obtained from the container.
-    
+    Otherwise, a new session will be obtained from the injectable provider.
+
     Args:
         func: The function to decorate
-        container: Optional container instance to use
-        
+
     Returns:
         The decorated function with session management
     """
@@ -72,14 +51,14 @@ def with_container_session(func: F = None, *, container=None) -> F:
             # If a session is already provided, use it directly
             if session is not None:
                 return func(*args, session=session, **kwargs)
-            
-            # Otherwise, get a new session from the container
+
             try:
-                with get_container_session(container=container) as new_session:
-                    if new_session is None:
-                        logger.error("Failed to obtain a valid session from container")
-                        return None
+                session_gen = get_container_session()
+                new_session = next(session_gen)
+                try:
                     return func(*args, session=new_session, **kwargs)
+                finally:
+                    session_gen.close()
             except Exception as e:
                 logger.exception(f"Error in with_container_session: {e}")
                 return None

--- a/src/local_newsifier/tasks.py
+++ b/src/local_newsifier/tasks.py
@@ -5,7 +5,6 @@ This module defines asynchronous tasks for processing articles and fetching RSS 
 
 import logging
 from typing import Dict, List, Optional, Iterator
-import contextlib
 
 from celery import Task, current_task
 from celery.signals import worker_ready
@@ -14,7 +13,7 @@ from sqlmodel import Session
 from local_newsifier.celery_app import app
 from local_newsifier.config.settings import settings
 from local_newsifier.container import container
-from local_newsifier.database.session_utils import get_container_session
+from local_newsifier.di.providers import get_session
 from local_newsifier.flows.entity_tracking_flow import EntityTrackingFlow
 from local_newsifier.flows.news_pipeline import NewsPipelineFlow
 from local_newsifier.tools.rss_parser import parse_rss_feed
@@ -24,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 # Expose get_db as a module-level function for tests
 def get_db() -> Iterator[Session]:
-    """Get a database session generator using container."""
-    with contextlib.closing(get_container_session()) as session:
+    """Get a database session generator using the injectable provider."""
+    with next(get_session()) as session:
         yield session
 
 class BaseTask(Task):


### PR DESCRIPTION
## Summary
- simplify `session_utils` so it delegates to injectable providers
- update Celery tasks to use new `get_session`
- register provider in the DI container

## Testing
- `make format` *(fails: pyenv: version `3.12.3` is not installed)*