### PR TITLE
Update docs for fastapi-injectable

### DIFF
--- a/FastAPI-Injectable-Migration-Plan.md
+++ b/FastAPI-Injectable-Migration-Plan.md
@@ -6,9 +6,9 @@ This document outlines a comprehensive plan for migrating from our custom DI con
 
 ## Current Status
 
-We have successfully implemented the foundation for migration to fastapi-injectable:
+We have completed the migration to fastapi-injectable:
 
-- The adapter layer is in place to bridge between DIContainer and fastapi-injectable
+- The former adapter layer has been removed
 - Core provider functions are defined for fundamental dependencies
 - Documentation is complete with examples and best practices
 - FastAPI integration is working with proper session management
@@ -157,7 +157,7 @@ Testing is critical to ensure the migration doesn't introduce regressions. The s
 The migration will be considered successful when:
 
 1. All components use fastapi-injectable for dependency resolution
-2. No direct references to DIContainer remain in the codebase
+2. No references to the old container remain in the codebase
 3. All tests pass with the new dependency injection system
 4. Performance matches or exceeds the previous implementation
 5. Documentation is complete and up-to-date

--- a/README.md
+++ b/README.md
@@ -24,16 +24,14 @@ This system automatically fetches local news articles, performs Named Entity Rec
 
 ### Dependency Injection
 
-Local Newsifier uses a hybrid dependency injection (DI) approach as it migrates from a custom DI container to fastapi-injectable:
+Local Newsifier uses **fastapi-injectable** for all dependency injection. Provider
+functions defined in `local_newsifier.di.providers` expose dependencies and are
+injected with FastAPI's `Depends()` pattern.
 
-- **Custom DIContainer**: The original DI system for service management
-- **fastapi-injectable**: The newer DI framework leveraging FastAPI's dependency injection
-- **Adapter Layer**: Bridges both systems during the transition period
-
-For detailed information on our DI architecture, testing strategies, and migration guidelines, see:
+For details on the architecture and testing strategies see:
 - [DI Architecture Guide](docs/di_architecture.md)
-- [Original DIContainer Documentation](docs/dependency_injection.md)
-- [fastapi-injectable Migration Guide](docs/fastapi_injectable.md)
+- [Dependency Injection Guide](docs/dependency_injection.md)
+- [fastapi-injectable Guide](docs/fastapi_injectable.md)
 
 ## Setup
 

--- a/docs/dependency_injection.md
+++ b/docs/dependency_injection.md
@@ -1,164 +1,64 @@
-# Dependency Injection System
+# Dependency Injection Guide
 
-> **IMPORTANT NOTICE**: Local Newsifier is currently migrating from this custom DIContainer to fastapi-injectable.
-> For comprehensive guidance on the current DI architecture and transition strategy, please refer to the
-> [DI Architecture Guide](di_architecture.md). This document is maintained for reference purposes.
+Local Newsifier uses **fastapi-injectable** as its dependency injection framework. All dependencies are exposed through provider functions defined in `local_newsifier.di.providers` and injected with FastAPI's `Depends()` syntax.
 
-This document explains the original dependency injection (DI) container implementation in the Local Newsifier project.
+## Provider Functions
 
-## Overview
-
-The DI container provides a centralized way to manage service dependencies, making it easier to:
-
-- Test individual components in isolation
-- Manage service lifecycles
-- Handle circular dependencies
-- Replace implementations without changing client code
-
-## Key Components
-
-### DIContainer
-
-The core `DIContainer` class in `src/local_newsifier/di_container.py` provides:
-
-- Service registration and resolution
-- Factory method support for lazy loading
-- Parameterized factory methods for dynamic dependency creation
-- Service lifetime management (Singleton, Transient, Scoped)
-- Circular dependency detection and resolution
-- Child container support for request scoping
-- Service cleanup handlers
-
-### Container Instance
-
-The singleton container instance is created in `src/local_newsifier/container.py`, which:
-
-- Registers all application services
-- Configures environment-specific settings
-- Manages service dependencies
-
-## Service Lifetimes
-
-The DI container supports three service lifetimes:
-
-1. **Singleton** (default): One instance for the entire application
-2. **Transient**: New instance every time it's requested
-3. **Scoped**: One instance per scope (e.g., per request)
+Provider functions are decorated with `@injectable(use_cache=False)` to ensure a new instance is created on each injection. This avoids state leakage between requests.
 
 ```python
-from local_newsifier.di_container import DIContainer, Scope
+from typing import Generator
+from fastapi_injectable import injectable
+from sqlmodel import Session
 
-container = DIContainer()
-
-# Register with different lifetimes
-container.register("singleton_service", service, scope=Scope.SINGLETON)
-container.register("transient_service", service, scope=Scope.TRANSIENT)
-container.register("scoped_service", service, scope=Scope.SCOPED)
+@injectable(use_cache=False)
+def get_session() -> Generator[Session, None, None]:
+    """Provide a database session."""
+    from local_newsifier.database.engine import get_session as get_db_session
+    session = next(get_db_session())
+    try:
+        yield session
+    finally:
+        session.close()
 ```
 
-## Usage Examples
+## Injectable Classes
 
-### Basic Service Registration and Resolution
+Use the `@injectable` decorator on classes to declare constructor dependencies with `Annotated` and `Depends`.
 
 ```python
-from local_newsifier.di_container import DIContainer
+from typing import Annotated
+from fastapi import Depends
+from fastapi_injectable import injectable
 
-container = DIContainer()
-
-# Register a service instance
-container.register("service_name", service_instance)
-
-# Get the service
-service = container.get("service_name")
+@injectable(use_cache=False)
+class ArticleService:
+    def __init__(self, session: Annotated[Session, Depends(get_session)]):
+        self.session = session
 ```
 
-### Factory Registration for Lazy Loading
+## Usage in FastAPI Endpoints
 
 ```python
-# Register a factory function
-container.register_factory("service_name", 
-    lambda c: ServiceClass(dependency=c.get("other_service")))
+@app.get("/articles/{article_id}")
+async def get_article(
+    article_id: int,
+    service: Annotated[ArticleService, Depends()]
+):
+    return service.fetch(article_id)
 ```
 
-### Parameterized Factory Methods
+## Testing Providers
+
+Tests can override provider functions using `monkeypatch`:
 
 ```python
-# Register a factory that accepts parameters
-container.register_factory_with_params("entity_service_with_params",
-    lambda c, **kwargs: kwargs.get("entity_service") or c.get("entity_service")
-)
-
-# Call with parameters
-service = container.get("entity_service_with_params", 
-                        custom_param="value")
-```
-
-### Circular Dependency Resolution
-
-```python
-# These services depend on each other
-container.register_factory("service_a", 
-    lambda c: ServiceA(dependency=c.get("service_b")))
-
-container.register_factory("service_b", 
-    lambda c: ServiceB(dependency=c.get("service_a")))
-
-# Works without causing infinite recursion
-service_a = container.get("service_a")
-```
-
-### Cleanup Handlers
-
-```python
-# Register a cleanup function for resource management
-container.register_cleanup("database", 
-    lambda db: db.close())
-```
-
-### Child Containers
-
-```python
-# Create a child container for a request scope
-request_container = container.create_child_scope()
-
-# Register request-specific services
-request_container.register("request_context", context)
-```
-
-## Integration Points
-
-The DI container is integrated with:
-
-1. **API Routes**: Uses container for service dependencies
-2. **CLI Commands**: Gets services from container with fallbacks
-3. **Celery Tasks**: Uses container services with graceful degradation
-4. **Test Suite**: Supports mocking services for isolation
-
-## Best Practices
-
-1. **Register services at startup**: Initialize all services in `container.py`
-2. **Use factory methods for complex services**: Avoids circular dependencies
-3. **Consider service lifetime**: Use appropriate scope for each service
-4. **Provide fallbacks**: For optional services, use fallback patterns to gracefully handle missing dependencies
-5. **Use parameterized factories sparingly**: For dynamic dependency injection needs
-
-## Testing with the Container
-
-The DI container makes testing easier by allowing service mocking:
-
-```python
-def test_with_mock_service():
-    # Create a test container
-    test_container = DIContainer()
-    
-    # Register a mock service
-    mock_service = MagicMock()
-    test_container.register("service_name", mock_service)
-    
-    # Test component that uses the service
-    component = ComponentUnderTest(container=test_container)
-    component.do_something()
-    
-    # Verify mock was called correctly
-    mock_service.method.assert_called_once()
+@pytest.fixture
+def patch_session(monkeypatch):
+    mock_session = MagicMock()
+    monkeypatch.setattr(
+        "local_newsifier.di.providers.get_session",
+        lambda: mock_session
+    )
+    return mock_session
 ```

--- a/docs/dependency_injection_antipatterns.md
+++ b/docs/dependency_injection_antipatterns.md
@@ -1,6 +1,6 @@
 # Dependency Injection Anti-Patterns
 
-This document identifies common anti-patterns related to dependency injection in the Local Newsifier codebase, particularly as we migrate from the legacy DIContainer to fastapi-injectable.
+This document identifies common anti-patterns related to dependency injection in the Local Newsifier codebase using fastapi-injectable.
 
 ## Identified Anti-Patterns
 

--- a/docs/dependency_injection_tools.md
+++ b/docs/dependency_injection_tools.md
@@ -1,338 +1,36 @@
-# Tool Registration in Dependency Injection Container
+# Tool Providers
 
-This document provides guidelines for registering tool classes in the dependency injection container and using them consistently throughout the application.
+Tools such as scrapers and analyzers are exposed through provider functions. Each provider is decorated with `@injectable(use_cache=False)` and lives in `di/providers.py`.
 
-## Table of Contents
-1. [Overview](#overview)
-2. [Naming Conventions](#naming-conventions)
-3. [Registration Patterns](#registration-patterns)
-4. [Using Container-Provided Tools](#using-container-provided-tools)
-5. [Testing](#testing)
-
-## Overview
-
-All tool classes are now registered in the dependency injection container to provide:
-- Centralized management of tool instances
-- Consistent access patterns
-- Configurable initialization
-- Clear dependency relationships
-- Improved testability
-
-Tools are organized into three main categories:
-1. **Core Tools** - Basic utilities like web scraping and file handling
-2. **Analysis Tools** - Specialized analysis functionality like trend analysis and sentiment analysis
-3. **Entity Tools** - Entity extraction, resolution, and tracking
-
-## Naming Conventions
-
-### Standard Tool Names
-
-Tools registered in the container follow this naming pattern:
-
-- Standard name: `{tool_name}_tool`
-- Example: `web_scraper_tool`, `rss_parser_tool`, `trend_analyzer_tool`
-
-### Backward Compatibility
-
-For backward compatibility with existing code, each tool is also registered with a legacy name:
-
-- Legacy name: `{tool_name}` (without the _tool suffix)
-- Example: `web_scraper`, `rss_parser`, `trend_analyzer`
-
-This dual registration allows gradual migration to the new naming scheme without breaking existing code.
-
-## Registration Patterns
-
-Tool registration is handled in the `container.py` module, which initializes the DI container and registers all services and dependencies. Tools are registered in three dedicated functions:
-
-### 1. Core Tools Registration
+## Example Provider
 
 ```python
-def register_core_tools(container):
-    """Register core tool classes in the container."""
-    try:
-        from local_newsifier.tools.web_scraper import WebScraperTool
-        from local_newsifier.tools.rss_parser import RSSParser
-        from local_newsifier.tools.file_writer import FileWriterTool
-        
-        # Register tools with standard names and configurable parameters
-        container.register_factory_with_params(
-            "web_scraper_tool", 
-            lambda c, **kwargs: WebScraperTool(
-                user_agent=kwargs.get("user_agent")
-            )
-        )
-        
-        # Backward compatibility registration
-        container.register_factory(
-            "web_scraper", 
-            lambda c: c.get("web_scraper_tool")
-        )
-        
-        # More tool registrations...
-    except ImportError as e:
-        # Log error but continue initialization
-        print(f"Error registering core tools: {e}")
+from fastapi import Depends
+from fastapi_injectable import injectable
+
+@injectable(use_cache=False)
+def get_web_scraper():
+    from local_newsifier.tools.web_scraper import WebScraperTool
+    return WebScraperTool()
 ```
 
-### 2. Analysis Tools Registration
+## Using Tools in Services
 
 ```python
-def register_analysis_tools(container):
-    """Register analysis tools in the container."""
-    try:
-        # Import and register trend analysis, sentiment analysis, and other tools
-        from local_newsifier.tools.analysis.trend_analyzer import TrendAnalyzer
-        # More imports...
-        
-        container.register_factory(
-            "trend_analyzer_tool", 
-            lambda c: TrendAnalyzer()
-        )
-        
-        # Tools with session dependency
-        container.register_factory_with_params(
-            "sentiment_analyzer_tool", 
-            lambda c, **kwargs: SentimentAnalysisTool(
-                session=kwargs.get("session")
-            )
-        )
-        
-        # Backward compatibility...
-    except ImportError as e:
-        # Log error but continue initialization
-        print(f"Error registering analysis tools: {e}")
-```
-
-### 3. Entity Tools Registration
-
-```python
-def register_entity_tools(container):
-    """Register entity-related tools in the container."""
-    try:
-        # Import and register entity extraction, resolution, and tracking tools
-        from local_newsifier.tools.extraction.entity_extractor import EntityExtractor
-        # More imports...
-        
-        container.register_factory(
-            "entity_extractor_tool", 
-            lambda c: EntityExtractor()
-        )
-        
-        # Backward compatibility...
-    except ImportError as e:
-        # Log error but continue initialization
-        print(f"Error registering entity tools: {e}")
-```
-
-## Tool Registration Strategies
-
-### Simple Factory Registration
-
-For tools without dependencies or configuration options:
-
-```python
-container.register_factory(
-    "tool_name_tool", 
-    lambda c: ToolClass()
-)
-```
-
-### Parameterized Factory Registration
-
-For tools with configuration options or dependencies:
-
-```python
-container.register_factory_with_params(
-    "tool_name_tool", 
-    lambda c, **kwargs: ToolClass(
-        param1=kwargs.get("param1", default_value),
-        param2=kwargs.get("param2")
-    )
-)
-```
-
-### Dependency Injection Configuration
-
-For tools that require other services:
-
-```python
-container.register_factory(
-    "tool_name_tool", 
-    lambda c: ToolClass(
-        dependency1=c.get("other_service"),
-        dependency2=c.get("another_service")
-    )
-)
-```
-
-## Using Container-Provided Tools
-
-### Direct Access Pattern
-
-For simple tool access without parameters:
-
-```python
-from local_newsifier.container import container
-
-def some_function():
-    # Get a tool instance
-    web_scraper = container.get("web_scraper_tool")
-    
-    # Use the tool
-    result = web_scraper.scrape_url("https://example.com")
-```
-
-### Parameterized Access Pattern
-
-For tools that need runtime configuration:
-
-```python
-from local_newsifier.container import container
-
-def some_function():
-    # Get a tool instance with specific parameters
-    file_writer = container.get("file_writer_tool", output_dir="custom_output")
-    
-    # Use the tool
-    file_writer.save(state)
-```
-
-### Service Constructor Injection Pattern
-
-The preferred pattern is to accept dependencies in service constructors:
-
-```python
+@injectable(use_cache=False)
 class NewsService:
-    def __init__(
-        self, 
-        web_scraper=None, 
-        rss_parser=None,
-        container=None
-    ):
-        self.container = container
-        
-        # Prefer passed dependencies
-        self.web_scraper = web_scraper
-        self.rss_parser = rss_parser
-        
-    def _ensure_dependencies(self):
-        """Ensure all dependencies are available."""
-        if self.web_scraper is None and self.container:
-            self.web_scraper = self.container.get("web_scraper_tool")
-            
-        if self.rss_parser is None and self.container:
-            self.rss_parser = self.container.get("rss_parser_tool")
-```
-
-### Constructor Registration Pattern
-
-When registering services that use tools:
-
-```python
-# Register a service that uses tools
-container.register_factory(
-    "news_service", 
-    lambda c: NewsService(
-        web_scraper=c.get("web_scraper_tool"),
-        rss_parser=c.get("rss_parser_tool"),
-        container=c  # For lazy resolution of other dependencies
-    )
-)
+    def __init__(self, scraper: Annotated[WebScraperTool, Depends(get_web_scraper)]):
+        self.scraper = scraper
 ```
 
 ## Testing
 
-### Mocking Container-Provided Tools
-
-When testing code that uses container-provided tools:
+Override tool providers with mocks when testing:
 
 ```python
-@patch("local_newsifier.container.container.get")
-def test_function_with_container_tools(mock_container_get):
-    # Setup the mock
-    mock_tool = Mock()
-    mock_tool.some_method.return_value = expected_result
-    
-    # Configure the mock to return our mock tool when requested
-    mock_container_get.side_effect = lambda name, **kwargs: {
-        "tool_name_tool": mock_tool
-    }.get(name)
-    
-    # Call the function under test
-    result = function_to_test()
-    
-    # Assertions
-    mock_container_get.assert_called_with("tool_name_tool")
-    mock_tool.some_method.assert_called_once()
-    assert result == expected_result
+@pytest.fixture
+def patch_web_scraper(monkeypatch):
+    scraper = Mock()
+    monkeypatch.setattr("local_newsifier.di.providers.get_web_scraper", lambda: scraper)
+    return scraper
 ```
-
-### Testing Services with Container Injection
-
-When testing services that use the container:
-
-```python
-def test_service_with_container():
-    # Create a mock container
-    mock_container = Mock()
-    mock_tool = Mock()
-    
-    # Configure the mock container
-    mock_container.get.side_effect = lambda name, **kwargs: {
-        "tool_name_tool": mock_tool
-    }.get(name)
-    
-    # Create the service with the mock container
-    service = MyService(container=mock_container)
-    
-    # Call method that uses a tool
-    service.method_that_needs_tool()
-    
-    # Verify
-    mock_container.get.assert_called_with("tool_name_tool")
-    mock_tool.some_method.assert_called_once()
-```
-
-## Guidelines for Adding New Tools
-
-When adding a new tool to the system:
-
-1. Implement the tool class with a clear, focused responsibility
-2. Follow the naming convention (verb + noun + Tool)
-3. Register the tool in the appropriate function in container.py
-4. Add both standard (_tool suffix) and backward compatibility registrations
-5. Add appropriate tests for tool registration
-6. Update documentation if the tool introduces new patterns or concepts
-
-Example of adding a new tool:
-
-```python
-# 1. Implement the tool
-# in local_newsifier/tools/text_summarizer.py
-class TextSummarizerTool:
-    def __init__(self, max_length=100):
-        self.max_length = max_length
-        
-    def summarize(self, text):
-        # Implementation...
-        return summary
-
-# 2. Register the tool in container.py
-from local_newsifier.tools.text_summarizer import TextSummarizerTool
-
-# In register_analysis_tools function:
-container.register_factory_with_params(
-    "text_summarizer_tool",
-    lambda c, **kwargs: TextSummarizerTool(
-        max_length=kwargs.get("max_length", 100)
-    )
-)
-
-# Backward compatibility
-container.register_factory(
-    "text_summarizer",
-    lambda c: c.get("text_summarizer_tool")
-)
-
-# 3. Add tests in tests/utils/test_tool_registration.py

--- a/docs/di_architecture.md
+++ b/docs/di_architecture.md
@@ -1,383 +1,51 @@
 # Dependency Injection Architecture
 
+Local Newsifier uses **fastapi-injectable** exclusively. The previous custom container and its adapter have been removed.
+
 ## Overview
 
-Local Newsifier is currently in transition between two dependency injection (DI) systems:
+1. Provider functions in `local_newsifier.di.providers` create and configure dependencies.
+2. Classes and functions declare dependencies with `Annotated[Type, Depends(provider)]` and are decorated with `@injectable` when necessary.
+3. FastAPI resolves the providers and injects the resulting objects.
 
-1. **Custom DIContainer**: A homegrown DI container implementation that was the original solution
-2. **fastapi-injectable**: A third-party framework leveraging FastAPI's dependency injection patterns
+## Provider Workflow
 
-This document explains the architecture of both systems, their relationship, and provides guidance for developers during this transition period.
-
-## Architecture Overview
-
-```
-┌────────────────────────────────┐      ┌─────────────────────────────────┐
-│       DIContainer System       │      │     fastapi-injectable System    │
-│                                │      │                                  │
-│ ┌──────────┐    ┌────────────┐ │      │ ┌─────────────┐  ┌────────────┐ │
-│ │   DI     │    │ Component  │ │      │ │  Injectable │  │ Component  │ │
-│ │Container │◄───┤  Factory   │ │      │ │  Component  │◄─┤  Provider  │ │
-│ └──────────┘    └────────────┘ │      │ └─────────────┘  └────────────┘ │
-└──────────────┬─────────────────┘      └────────────┬────────────────────┘
-               │                                     │
-               │         ┌──────────────────┐        │
-               └────────►│  Adapter Layer   │◄───────┘
-                         │                  │
-                         └──────────────────┘
+```mermaid
+graph LR
+    Provider --> InjectableClass
+    InjectableClass -->|Depends| FastAPIEndpoint
 ```
 
-### Custom DIContainer System
+### Example Service
 
-The original DI system (`di_container.py`) provides:
-
-- Service registration and resolution
-- Factory methods for lazy loading
-- Parameterized factories
-- Service lifetime management
-- Circular dependency resolution
-
-### fastapi-injectable System
-
-The newer system based on `fastapi-injectable` offers:
-
-- Integration with FastAPI's dependency injection system
-- Type-safe dependency injection with `Annotated` types
-- Consistent `Depends()` pattern throughout the codebase
-- Improved testing capabilities
-
-### Adapter Layer
-
-The adapter (`fastapi_injectable_adapter.py`) bridges between the two systems, allowing:
-
-- Gradual migration from DIContainer to fastapi-injectable
-- Registration of DIContainer services with fastapi-injectable
-- Parameterized service resolution
-- Appropriate service lifetime handling
-
-## Current Status
-
-- Both systems are actively used in the codebase
-- New API endpoints primarily use fastapi-injectable
-- Most services, flows, and tools still use DIContainer
-- The adapter allows components to get services from either system
-
-## Migration Strategy
-
-The project is following a phased approach to migrate from DIContainer to fastapi-injectable:
-
-### Phase 1: Foundation (Completed)
-- Set up fastapi-injectable infrastructure
-- Create adapter layer for compatibility
-- Implement initial provider functions
-
-### Phase 2: Gradual Migration (Current)
-- Migrate components incrementally
-- Keep both systems operational
-- Adapt tests for the new pattern
-
-### Phase 3: Complete Migration (Planned)
-- Fully transition all components
-- Remove legacy DIContainer
-- Standardize on fastapi-injectable patterns
-
-## Decision Tree for Developers
-
-When working on DI-related code, use this decision tree to determine the appropriate approach:
-
-```
-Is this a new component?
-├── Yes → Use fastapi-injectable
-│   ├── Is it a service with database interaction?
-│   │   ├── Yes → Use @injectable(use_cache=False)
-│   │   └── No → Consider @injectable with appropriate caching
-│   └── Does it need to interact with DIContainer components?
-│       ├── Yes → Use the adapter
-│       └── No → Use pure fastapi-injectable approach
-└── No → Is it tightly coupled with other DIContainer components?
-    ├── Yes → Keep using DIContainer for now
-    │   └── Add to migration backlog
-    └── No → Consider migrating to fastapi-injectable
-```
-
-## Related Documentation
-
-- [Injectable Patterns Guide](injectable_patterns.md) - Comprehensive examples and patterns for all component types
-- [Original DIContainer Documentation](dependency_injection.md) - Legacy DIContainer documentation
-- [fastapi-injectable Migration Guide](fastapi_injectable.md) - Migration process overview
-- [Issue #151: Evaluate Migration to fastapi-injectable](https://github.com/arockwell/local_newsifier/issues/151) - Original evaluation issue
-
-## Testing Strategies
-
-Testing components with different DI systems requires different approaches. Here's how to test components based on their DI implementation:
-
-### Testing DIContainer Components
-
-Components that use DIContainer can be tested by creating a test-specific container:
-
-```python
-import pytest
-from unittest.mock import MagicMock
-from local_newsifier.di_container import DIContainer
-
-@pytest.fixture
-def test_container():
-    """Create a container with mock services for testing."""
-    container = DIContainer()
-    
-    # Register mock services
-    mock_entity_service = MagicMock()
-    mock_article_service = MagicMock()
-    
-    container.register("entity_service", mock_entity_service)
-    container.register("article_service", mock_article_service)
-    
-    return container, {
-        "entity_service": mock_entity_service,
-        "article_service": mock_article_service
-    }
-
-def test_flow_with_container(test_container):
-    """Test a flow that uses DIContainer."""
-    container, mocks = test_container
-    
-    # Create component with test container
-    flow = EntityTrackingFlow(container=container)
-    
-    # Test interactions
-    flow.process_entity("test_entity")
-    
-    # Verify mock was called correctly
-    mocks["entity_service"].get_entity.assert_called_once_with("test_entity")
-```
-
-### Testing fastapi-injectable Components
-
-Components using fastapi-injectable can be tested by mocking the provider functions:
-
-```python
-import pytest
-from unittest.mock import MagicMock, patch
-from local_newsifier.services.injectable_entity_service import InjectableEntityService
-
-@pytest.fixture
-def mock_injectable_dependencies(monkeypatch):
-    """Mock dependencies for injectable components."""
-    # Create mocks
-    mock_entity_crud = MagicMock()
-    mock_session = MagicMock()
-    
-    # Patch provider functions
-    monkeypatch.setattr("local_newsifier.di.providers.get_entity_crud", lambda: mock_entity_crud)
-    monkeypatch.setattr("local_newsifier.di.providers.get_session", lambda: mock_session)
-    
-    return {
-        "entity_crud": mock_entity_crud,
-        "session": mock_session
-    }
-
-def test_injectable_service(mock_injectable_dependencies):
-    """Test a service using fastapi-injectable."""
-    mocks = mock_injectable_dependencies
-    
-    # Create service directly with mocked dependencies
-    service = InjectableEntityService(
-        entity_crud=mocks["entity_crud"],
-        session=mocks["session"]
-    )
-    
-    # Test the service
-    service.get_entity(1)
-    
-    # Verify interactions
-    mocks["entity_crud"].get.assert_called_once_with(mocks["session"], id=1)
-```
-
-### Testing Components Using Both Systems
-
-For components that interact with both DI systems through the adapter:
-
-```python
-import pytest
-from unittest.mock import MagicMock, patch
-from local_newsifier.di_container import DIContainer
-
-@pytest.fixture
-def hybrid_test_environment(monkeypatch):
-    """Create a test environment that supports both DI systems."""
-    # Setup DIContainer
-    container = DIContainer()
-    mock_container_service = MagicMock()
-    container.register("legacy_service", mock_container_service)
-    
-    # Setup injectable mocks
-    mock_injectable_service = MagicMock()
-    monkeypatch.setattr("local_newsifier.di.providers.get_injectable_service", 
-                       lambda: mock_injectable_service)
-    
-    # Patch adapter to use test container
-    monkeypatch.setattr("local_newsifier.fastapi_injectable_adapter.di_container", container)
-    
-    return {
-        "container": container,
-        "legacy_service": mock_container_service,
-        "injectable_service": mock_injectable_service
-    }
-
-def test_hybrid_component(hybrid_test_environment):
-    """Test a component that uses both DI systems."""
-    mocks = hybrid_test_environment
-    
-    # Test component that might use the adapter or both systems
-    # ...
-
-    # Verify interactions with both systems
-    mocks["legacy_service"].some_method.assert_called_once()
-    mocks["injectable_service"].other_method.assert_called_once()
-```
-
-## Component Migration Guide
-
-This section provides guidance for migrating different component types from DIContainer to fastapi-injectable.
-
-### Service Migration
-
-Services are typically stateful components that perform business logic and may interact with the database.
-
-**Original DIContainer Version:**
-```python
-class EntityService:
-    def __init__(self, entity_crud=None, session_factory=None):
-        from local_newsifier.container import container
-        self.entity_crud = entity_crud or container.get("entity_crud")
-        self.session_factory = session_factory or container.get("session_factory")
-```
-
-**Migrated fastapi-injectable Version:**
-```python
-from typing import Annotated
-from fastapi import Depends
-from fastapi_injectable import injectable
-from sqlmodel import Session
-
-@injectable(use_cache=False)  # Don't cache services with database interaction
-class InjectableEntityService:
-    def __init__(
-        self,
-        entity_crud: Annotated[EntityCRUD, Depends(get_entity_crud)],
-        session: Annotated[Session, Depends(get_session)]
-    ):
-        self.entity_crud = entity_crud
-        self.session = session
-```
-
-### Flow Migration
-
-Flows orchestrate multiple services and typically contain business process logic.
-
-**Original DIContainer Version:**
-```python
-class EntityTrackingFlow:
-    def __init__(self, container=None):
-        from local_newsifier.container import container as default_container
-        self.container = container or default_container
-        self.entity_service = self.container.get("entity_service")
-        self.article_service = self.container.get("article_service")
-```
-
-**Migrated fastapi-injectable Version:**
 ```python
 from typing import Annotated
 from fastapi import Depends
 from fastapi_injectable import injectable
 
 @injectable(use_cache=False)
-class InjectableEntityTrackingFlow:
-    def __init__(
-        self,
-        entity_service: Annotated[EntityService, Depends(get_entity_service)],
-        article_service: Annotated[ArticleService, Depends(get_article_service)]
-    ):
-        self.entity_service = entity_service
-        self.article_service = article_service
+class ArticleService:
+    def __init__(self, session: Annotated[Session, Depends(get_session)]):
+        self.session = session
 ```
 
-### Tool Migration
+### Endpoint Usage
 
-Tools provide utility functions and are generally more stateless.
-
-**Original DIContainer Version:**
 ```python
-class EntityExtractor:
-    def __init__(self, nlp_model=None):
-        from local_newsifier.container import container
-        self.nlp_model = nlp_model or container.get("nlp_model")
+@app.get("/articles/{article_id}")
+async def get_article(
+    article_id: int,
+    service: Annotated[ArticleService, Depends()]
+):
+    return service.fetch(article_id)
 ```
 
-**Migrated fastapi-injectable Version:**
-```python
-from typing import Annotated
-from fastapi import Depends
-from fastapi_injectable import injectable
+## Best Practices
 
-@injectable(use_cache=True)  # Can cache stateless tools
-class InjectableEntityExtractor:
-    def __init__(
-        self,
-        nlp_model: Annotated[NLPModel, Depends(get_nlp_model)]
-    ):
-        self.nlp_model = nlp_model
-```
+- Place all provider functions in `di/providers.py`.
+- Use `use_cache=False` unless the dependency is completely stateless.
+- Avoid circular imports by keeping provider implementations lightweight.
 
-## Migration Timeline
+## Testing
 
-The migration from DIContainer to fastapi-injectable is planned to proceed in these phases:
-
-| Phase | Status | Estimated Completion | Components |
-|-------|--------|----------------------|------------|
-| Foundation | Complete | Q1 2025 | Basic infrastructure, adapter layer |
-| Core Services | In Progress | Q2 2025 | Entity service, Article service |
-| Flow Classes | Not Started | Q3 2025 | EntityTrackingFlow, NewsPipelineFlow |
-| Tools | Not Started | Q3 2025 | All analysis and extraction tools |
-| API Integration | In Progress | Q2 2025 | Remaining API endpoints |
-| CLI Commands | Not Started | Q4 2025 | All CLI commands |
-| Task System | Not Started | Q4 2025 | Celery tasks and background processing |
-| Legacy Removal | Not Started | Q1 2026 | Remove DIContainer completely |
-
-## Best Practices and Anti-patterns
-
-### Best Practices
-
-1. **Consistent Dependency Declaration**
-   - Use `Annotated[Type, Depends()]` for all dependencies
-   - Declare all dependencies in constructor parameters
-
-2. **Clear Caching Decisions**
-   - Use `use_cache=False` for stateful components
-   - Only use `use_cache=True` for truly stateless utilities
-
-3. **Proper Error Handling**
-   - Handle missing dependencies gracefully
-   - Provide meaningful error messages when dependencies can't be resolved
-
-4. **Migration Tracking**
-   - Keep track of migrated components
-   - Document components that still need migration
-
-### Anti-patterns
-
-1. **Mixing DI Systems Directly**
-   - ❌ Don't use container.get() in a class that uses @injectable
-   - ✅ Use the adapter if you need to interact with both systems
-
-2. **Inconsistent Service Lifetimes**
-   - ❌ Don't use `use_cache=True` for database-interacting services
-   - ✅ Be consistent with stateful vs stateless component caching
-
-3. **Hidden Dependencies**
-   - ❌ Don't import dependencies inside methods
-   - ✅ Declare all dependencies in constructor parameters
-
-4. **Circular Dependencies**
-   - ❌ Don't create mutual dependencies between services
-   - ✅ Use provider functions or refactor component responsibilities
+Tests should patch provider functions using fixtures. See `docs/testing_injectable_dependencies.md` for patterns.

--- a/docs/examples/conditional_decorator_example.py
+++ b/docs/examples/conditional_decorator_example.py
@@ -37,10 +37,10 @@ class DataProcessorTool:
         self._container = container
     
     def set_container(self, container):
-        """Set the DI container for backward compatibility.
-        
+        """Set the legacy container for backward compatibility.
+
         Args:
-            container: DIContainer instance
+            container: optional container instance
         """
         self._container = container
     

--- a/docs/fastapi_injectable.md
+++ b/docs/fastapi_injectable.md
@@ -11,7 +11,7 @@
 
 ## Overview
 
-Local Newsifier is transitioning from a custom DIContainer to the fastapi-injectable framework. This guide provides comprehensive information on the migration process, implementation details, and best practices.
+Local Newsifier uses **fastapi-injectable** as its dependency injection framework. This guide provides information on provider conventions, implementation details, and best practices.
 
 ## Background and Motivation
 
@@ -30,25 +30,10 @@ The migration to fastapi-injectable provides these benefits:
 4. **Less Boilerplate**: Automatic dependency resolution with decorators
 5. **Framework Alignment**: Better integration with FastAPI's dependency system
 
-## Migration Strategy
+## Migration Summary
 
-The migration follows a phased approach to minimize disruption while allowing both systems to coexist during transition:
-
-### Phase 1: Foundation (Current)
-- Set up basic infrastructure
-- Create provider functions for core dependencies
-- Configure testing utilities
-- Implement adapter layer for compatibility
-
-### Phase 2: Gradual Migration
-- Migrate individual services incrementally
-- Update tests to use the new pattern
-- Keep both systems working during transition
-
-### Phase 3: Complete Migration
-- Fully migrate all components
-- Remove the legacy DI container
-- Update documentation
+The project previously used a custom container but has now fully migrated to fastapi-injectable.
+All components rely on provider functions and the adapter has been removed.
 
 ## Implementation Components
 
@@ -70,10 +55,10 @@ setup_graceful_shutdown()
 
 # Caching strategy helper function
 def should_cache(scope: str) -> bool:
-    """Convert DIContainer scope to fastapi-injectable use_cache value.
+    """Convert a legacy scope string to a `use_cache` value.
 
     Args:
-        scope: DIContainer scope string ("singleton", "transient", "scoped")
+        scope: Scope string ("singleton", "transient", "scoped")
 
     Returns:
         Boolean indicating whether to cache the dependency
@@ -114,40 +99,7 @@ def get_entity_crud():
     return entity
 ```
 
-### 3. Adapter Layer
-
-The adapter `fastapi_injectable_adapter.py` bridges between systems:
-
-```python
-def get_service_factory(service_name: str) -> Callable:
-    """Create a factory function that gets a service from DIContainer."""
-    # These patterns indicate components that should not be cached
-    stateful_patterns = [
-        "_service", "tool", "analyzer", "parser", "extractor", "resolver", "_crud"
-    ]
-
-    # Determine appropriate caching behavior based on service type
-    use_cache = True  # Default to caching for performance
-
-    # For stateful components or those interacting with databases, disable caching
-    for pattern in stateful_patterns:
-        if pattern in service_name:
-            use_cache = False
-            break
-
-    @injectable(use_cache=use_cache)
-    def service_factory():
-        """Factory function to get service from DIContainer."""
-        return di_container.get(service_name)
-
-    # Set better function name for debugging
-    service_factory.__name__ = f"get_{service_name}"
-    logger.info(f"Created provider for {service_name} with use_cache={use_cache}")
-
-    return service_factory
-```
-
-### 4. Service Migration Pattern
+### 3. Service Migration Pattern
 
 Services can be migrated using the `@injectable` decorator:
 
@@ -368,10 +320,6 @@ reliability and maintainability outweigh this concern for our application.
 - Consider creating a custom fixture to patch multiple dependencies at once
 - Test both with direct instantiation and through the DI system
 
-### Adapter Usage
-- Use the adapter during transition to avoid breaking changes
-- Register existing services with the adapter when needed
-- Gradually replace adapter usage with direct injectable components
 
 ## Troubleshooting
 

--- a/docs/injectable_patterns.md
+++ b/docs/injectable_patterns.md
@@ -25,7 +25,7 @@ This guide provides comprehensive documentation and examples for using the injec
 
 ## Overview
 
-The Local Newsifier project is transitioning from a custom DIContainer to the `fastapi-injectable` framework. This guide provides practical examples and patterns to follow when implementing or migrating components.
+The Local Newsifier project uses the `fastapi-injectable` framework for dependency injection. This guide provides practical examples and patterns to follow when implementing components.
 
 ### Key Principles
 
@@ -323,11 +323,11 @@ def process_feed_cli(feed_id: int, limit: Optional[int] = None):
     process_feed_command(feed_id, limit)
 ```
 
-## Migration Guide
+## Implementation Guide
 
-### Step-by-Step Migration
+### Step-by-Step Process
 
-Follow these steps to migrate a component from DIContainer to injectable pattern:
+Follow these steps to create an injectable component:
 
 1. **Identify Dependencies**
    - List all dependencies used by the component

--- a/docs/testing_injectable_dependencies.md
+++ b/docs/testing_injectable_dependencies.md
@@ -273,36 +273,6 @@ async def test_async_service(mock_injectable_dependencies):
     api_client_mock.fetch_data.assert_called_once()
 ```
 
-### Testing Integration with Both DI Systems
-
-During the transition, some components may interact with both DI systems:
-
-```python
-def test_hybrid_component(mock_injectable_dependencies):
-    # Arrange - setup DIContainer mock
-    container_mock = MagicMock()
-    legacy_service_mock = MagicMock()
-    container_mock.get.return_value = legacy_service_mock
-    
-    # Setup injectable mocks
-    mock = mock_injectable_dependencies
-    injectable_service_mock = MagicMock()
-    mock.register("get_injectable_service", injectable_service_mock)
-    
-    # Patch adapter
-    with patch("local_newsifier.fastapi_injectable_adapter.di_container", container_mock):
-        # Create hybrid component that uses both systems
-        component = HybridComponent(
-            injectable_service=injectable_service_mock
-        )
-        
-        # Act
-        component.process_data()
-        
-        # Assert
-        legacy_service_mock.method.assert_called_once()
-        injectable_service_mock.method.assert_called_once()
-```
 
 ## Common Pitfalls and Solutions
 


### PR DESCRIPTION
## Summary
- update README to document fastapi-injectable usage
- rewrite dependency injection docs
- drop mentions of the old DI container
- update docs after adapter removal

## Testing
- `make test` *(fails: python not found)*