### PR TITLE
Enable entity processing integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,10 +91,9 @@ jobs:
         # Note: Dependencies like psycopg2-binary, sqlalchemy, and pydantic-settings
         # are already managed by Poetry and should not be installed separately
 
-    - name: Download spaCy models
+    - name: Initialize spaCy models
       run: |
-        poetry run python -m spacy download en_core_web_sm
-        poetry run python -m spacy download en_core_web_lg
+        bash scripts/init_spacy_models.sh
 
     - name: Create test database
       env:

--- a/scripts/init_spacy_models.sh
+++ b/scripts/init_spacy_models.sh
@@ -2,23 +2,31 @@
 
 # Script to download spaCy models during app initialization
 
-echo "Checking for spaCy model en_core_web_lg..."
 
-# Check if model is already installed
-python -c "import spacy; spacy.load('en_core_web_lg')" 2>/dev/null
+MODELS=("en_core_web_sm" "en_core_web_lg")
 
-if [ $? -ne 0 ]; then
-    echo "SpaCy model en_core_web_lg not found. Downloading..."
-    python -m spacy download en_core_web_lg
-    if [ $? -eq 0 ]; then
-        echo "Successfully downloaded spaCy model en_core_web_lg"
+for MODEL in "${MODELS[@]}"; do
+    echo "Checking for spaCy model $MODEL..."
+
+    # Check if model is already installed
+    python - <<EOF 2>/dev/null
+import spacy
+spacy.load("$MODEL")
+EOF
+
+    if [ $? -ne 0 ]; then
+        echo "SpaCy model $MODEL not found. Downloading..."
+        python -m spacy download "$MODEL"
+        if [ $? -eq 0 ]; then
+            echo "Successfully downloaded spaCy model $MODEL"
+        else
+            echo "ERROR: Failed to download spaCy model $MODEL"
+            exit 1
+        fi
     else
-        echo "ERROR: Failed to download spaCy model en_core_web_lg"
-        exit 1
+        echo "SpaCy model $MODEL is already installed"
     fi
-else
-    echo "SpaCy model en_core_web_lg is already installed"
-fi
+done
 
 # Continue to the next command
 echo "SpaCy model initialization complete"

--- a/tests/integration/test_entity_processing.py
+++ b/tests/integration/test_entity_processing.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 from sqlmodel import Session, SQLModel, create_engine
 from sqlalchemy.orm import sessionmaker
 
-@pytest.mark.skip(reason="Integration test requires full environment and NLP models")
 def test_entity_processing_integration():
     """Test the complete entity processing flow with real components."""
     # Setup in-memory database


### PR DESCRIPTION
# Description

The skipped entity processing integration test now runs as part of the suite. CI is updated to ensure required spaCy models are available.

# Changes
- removed unconditional skip from `tests/integration/test_entity_processing.py`
- expanded `scripts/init_spacy_models.sh` to install both `en_core_web_sm` and `en_core_web_lg`
- CI workflow now calls the setup script instead of directly downloading models

# Testing
- `python -m pytest tests/integration/test_entity_processing.py -vv` *(fails: No module named pytest)*
