### PR TITLE
Remove migration comments

### DIFF
--- a/docs/examples/conditional_decorator_example.py
+++ b/docs/examples/conditional_decorator_example.py
@@ -28,10 +28,10 @@ class DataProcessorTool:
     
     def __init__(self, session: Optional[Session] = None, container=None):
         """Initialize with optional dependencies.
-        
+
         Args:
             session: Optional database session for data persistence
-            container: Optional DI container for backward compatibility
+            container: Optional legacy container for backward compatibility
         """
         self.session = session
         self._container = container
@@ -47,17 +47,17 @@ class DataProcessorTool:
     def _ensure_dependencies(self):
         """Ensure all dependencies are available.
         
-        This provides backward compatibility with the container approach
+        This provides backward compatibility with the legacy container approach
         and ensures the component can function in both approaches.
         """
         if self.session is None and self._container is not None:
-            # Try to get a session from the container if available
+            # Try to get a session from the legacy container if available
             try:
                 session_factory = self._container.get("session_factory")
                 if session_factory:
                     self.session = session_factory()
             except (KeyError, AttributeError):
-                # Failed to get from container, continue with None
+                # Failed to get from legacy container, continue with None
                 pass
     
     def process_data(self, 

--- a/src/local_newsifier/api/dependencies.py
+++ b/src/local_newsifier/api/dependencies.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException, Request, status
 from fastapi.templating import Jinja2Templates
 from sqlmodel import Session
 
-# No direct container import as we're using injectable providers
+# Use injectable providers directly instead of the DIContainer
 from local_newsifier.services.article_service import ArticleService
 from local_newsifier.services.rss_feed_service import RSSFeedService
 

--- a/src/local_newsifier/api/main.py
+++ b/src/local_newsifier/api/main.py
@@ -47,8 +47,8 @@ async def lifespan(app: FastAPI):
         logger.info("Initializing fastapi-injectable")
         await register_app(app)
         
-        # Migrate container services to fastapi-injectable
-        logger.info("Migrating container services to fastapi-injectable")
+        # Register legacy DIContainer services with fastapi-injectable
+        logger.info("Registering DIContainer services with fastapi-injectable")
         await migrate_container_services(app)
         
         logger.info("fastapi-injectable initialization completed")

--- a/src/local_newsifier/di/__init__.py
+++ b/src/local_newsifier/di/__init__.py
@@ -1,6 +1,6 @@
 """
-Dependency Injection module.
+Dependency injection helpers.
 
-This module provides the migration path from the custom DIContainer 
-to fastapi-injectable.
+This package contains the fastapi-injectable provider functions and maintains
+compatibility with the legacy DIContainer.
 """

--- a/src/local_newsifier/fastapi_injectable_adapter.py
+++ b/src/local_newsifier/fastapi_injectable_adapter.py
@@ -1,9 +1,8 @@
-"""Adapter module for integrating fastapi-injectable with the DIContainer.
+"""Adapter module bridging the legacy DIContainer with fastapi-injectable.
 
-This module provides a comprehensive adapter layer between the current DIContainer
-and fastapi-injectable, allowing both systems to coexist during migration. It includes
-utilities for registering services, resolving dependencies, and providing compatibility
-between the two DI systems.
+This adapter exposes helper functions for registering services and resolving
+dependencies so that components using the older container can continue to work
+alongside the fastapi-injectable approach.
 """
 
 import inspect
@@ -316,7 +315,7 @@ async def migrate_container_services(app: FastAPI) -> None:
             logger.warning(f"Could not register factory {name}: {str(e)}")
 
     # Log summary
-    logger.info("Migration complete. Registered services with fastapi-injectable.")
+    logger.info("Service registration with fastapi-injectable completed.")
 
 
 @asynccontextmanager

--- a/src/local_newsifier/services/rss_feed_service.py
+++ b/src/local_newsifier/services/rss_feed_service.py
@@ -349,13 +349,13 @@ class RSSFeedService:
         }
 
 
-# For backwards compatibility during transition
-# Will be removed once all code is updated to use the container
+# For backwards compatibility with legacy DIContainer
+# Will be removed once all code uses fastapi-injectable
 def register_article_service(article_svc):
     """Register the article service to avoid circular imports.
     
     This function will be called from tasks.py after all imports are complete.
-    TEMPORARY: Will be removed once all code is updated to use the container.
+    TEMPORARY: Will be removed once all code uses fastapi-injectable.
     
     Args:
         article_svc: The initialized article service

--- a/src/local_newsifier/tasks.py
+++ b/src/local_newsifier/tasks.py
@@ -31,7 +31,7 @@ class BaseTask(Task):
     """Base Task class with common functionality for all tasks."""
     
     def __init__(self):
-        """Initialize BaseTask with session factory from container."""
+        """Initialize BaseTask with session factory from injectable providers."""
         self._session = None
         self._session_factory = None
     
@@ -100,7 +100,7 @@ class BaseTask(Task):
         from local_newsifier.di.providers import get_rss_feed_service
         service = get_rss_feed_service()
         
-        # For backward compatibility during transition
+        # For backward compatibility with the legacy DIContainer
         if hasattr(service, 'container'):
             service.container = container
             
@@ -271,6 +271,5 @@ def on_worker_ready(sender, **kwargs):
     """
     logger.info("Celery worker is ready")
     
-    # Register the process_article task in the container for backward compatibility
-    # This can be removed once full transition to injectable is completed
+    # Legacy registration for code that still relies on DIContainer
     container.register("process_article_task", process_article)

--- a/src/local_newsifier/tools/entity_tracker_service.py
+++ b/src/local_newsifier/tools/entity_tracker_service.py
@@ -23,11 +23,11 @@ class EntityTracker:
     
     def __init__(self, entity_service=None, session=None, container=None):
         """Initialize with dependencies.
-        
+
         Args:
             entity_service: Service for entity operations
             session: Database session
-            container: Optional DI container for backward compatibility
+            container: Optional legacy container for backward compatibility
         """
         self.entity_service = entity_service
         self.session = session
@@ -40,19 +40,19 @@ class EntityTracker:
         """Ensure all dependencies are available.
         
         This handles backward compatibility by attempting to get
-        missing dependencies from the container.
+        missing dependencies from the legacy container.
         """
         # Create a default entity service if none was provided
         if self.entity_service is None:
             if self._container is not None:
                 try:
-                    # Try to get from container first
+                    # Try to get from the legacy container first
                     self.entity_service = self._container.get("entity_service")
                 except (KeyError, AttributeError):
                     # Fall back to creating a default service
                     self.entity_service = self._create_default_service()
             else:
-                # No container, create default service
+                # No legacy container, create default service
                 self.entity_service = self._create_default_service()
     
     def _create_default_service(self):

--- a/tests/services/test_isolated_rss_feed.py
+++ b/tests/services/test_isolated_rss_feed.py
@@ -1,4 +1,4 @@
-"""Tests for RSSFeedService focusing on container-based dependency injection."""
+"""Tests for RSSFeedService focusing on legacy container integration."""
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -8,7 +8,7 @@ from local_newsifier.services.rss_feed_service import RSSFeedService
 
 @pytest.mark.skip(reason="Async event loop issue in fastapi-injectable, to be fixed in a separate PR")
 def test_container_task_usage():
-    """Test that the service uses the task from the container when no task_queue_func is provided."""
+    """Test that the service uses the task from the legacy container when no task_queue_func is provided."""
     # Create mock dependencies
     mock_rss_feed_crud = MagicMock()
     mock_feed_processing_log_crud = MagicMock()

--- a/tests/services/test_rss_feed_service.py
+++ b/tests/services/test_rss_feed_service.py
@@ -1010,9 +1010,9 @@ def test_get_feed_processing_logs(mock_db_session, mock_session_factory):
 @pytest.mark.skip(reason="Async event loop issue in fastapi-injectable, to be fixed in a separate PR")
 def test_register_article_service():
     """Test registering the article service.
-    
-    This test is mainly to maintain backward compatibility during migration.
-    In the future, direct container access should be used instead.
+
+    This test preserves compatibility with the legacy DIContainer.
+    In the future, direct fastapi-injectable providers should be used instead.
     """
     # Create a mock container
     mock_container = MagicMock(spec=DIContainer)

--- a/tests/test_fastapi_injectable_adapter.py
+++ b/tests/test_fastapi_injectable_adapter.py
@@ -331,7 +331,7 @@ class TestRegistration:
 
 
 class TestMigration:
-    """Tests for DI container migration."""
+    """Tests for integrating legacy DIContainer services."""
 
     def test_register_bulk_services_functionality(self, mock_di_container):
         """Test bulk service registration functionality."""

--- a/tests/test_fastapi_injectable_core.py
+++ b/tests/test_fastapi_injectable_core.py
@@ -1,4 +1,4 @@
-"""Test core functionality of the fastapi-injectable migration."""
+"""Test core functionality of the fastapi-injectable integration."""
 
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
## Summary
- remove container migration remarks in code
- clean up comments referencing DIContainer

## Testing
- `make test` *(fails: Command '['/root/.pyenv/shims/python', '-EsSc', 'import sys; print(sys.executable)']' returned non-zero exit status 127)*