### PR TITLE
Remove DI container references

### DIFF
--- a/src/local_newsifier/services/apify_source_config_service.py
+++ b/src/local_newsifier/services/apify_source_config_service.py
@@ -26,7 +26,6 @@ class ApifySourceConfigService:
         apify_source_config_crud: CRUDApifySourceConfig,
         apify_service,  # ApifyService, but avoiding circular imports
         session_factory,
-        container=None
     ):
         """Initialize the service.
         
@@ -34,12 +33,10 @@ class ApifySourceConfigService:
             apify_source_config_crud: CRUD for Apify source configurations
             apify_service: Service for interacting with Apify API
             session_factory: Function that returns a database session
-            container: Optional DI container for service resolution
         """
         self.apify_source_config_crud = apify_source_config_crud
         self.apify_service = apify_service
         self.session_factory = session_factory
-        self.container = container
     
     @handle_service_error(service="apify")
     def list_configs(

--- a/src/local_newsifier/services/rss_feed_service.py
+++ b/src/local_newsifier/services/rss_feed_service.py
@@ -329,7 +329,7 @@ class RSSFeedService:
         }
 
     def _format_log_dict(self, log: RSSFeedProcessingLog) -> Dict[str, Any]:
-        """Format processing log as a dict.
+"""Format processing log as a dict.
 
         Args:
             log: Processing log model instance
@@ -347,21 +347,3 @@ class RSSFeedService:
             "started_at": log.started_at.isoformat(),
             "completed_at": log.completed_at.isoformat() if log.completed_at else None,
         }
-
-
-# For backwards compatibility during transition
-# Will be removed once all code is updated to use the container
-def register_article_service(article_svc):
-    """Register the article service to avoid circular imports.
-    
-    This function will be called from tasks.py after all imports are complete.
-    TEMPORARY: Will be removed once all code is updated to use the container.
-    
-    Args:
-        article_svc: The initialized article service
-    """
-    # Import at runtime to avoid circular imports
-    from local_newsifier.container import container
-    rss_feed_service = container.get("rss_feed_service")
-    if rss_feed_service:
-        rss_feed_service.article_service = article_svc

--- a/tests/services/test_apify_source_config_service.py
+++ b/tests/services/test_apify_source_config_service.py
@@ -55,7 +55,6 @@ class TestApifySourceConfigService:
             apify_source_config_crud=mock_crud,
             apify_service=mock_apify_service,
             session_factory=mock_session_factory,
-            container=None
         )
 
     def test_list_configs(self, service, mock_crud, mock_session_factory, mock_session):

--- a/tests/services/test_isolated_rss_feed.py
+++ b/tests/services/test_isolated_rss_feed.py
@@ -279,23 +279,3 @@ def test_temporary_service_creation():
             assert mock_temp_article_service.create_article_from_rss_entry.call_count == 2
 
 
-@pytest.mark.skip(reason="Async event loop issue in fastapi-injectable, to be fixed in a separate PR")
-def test_register_article_service_with_container():
-    """Test registering the article service in RSSFeedService through container."""
-    from local_newsifier.services.rss_feed_service import register_article_service
-    
-    # Create mock objects
-    mock_article_service = MagicMock()
-    mock_rss_feed_service = MagicMock()
-    mock_container = MagicMock()
-    
-    # Configure container to return our mock service
-    mock_container.get.return_value = mock_rss_feed_service
-    
-    # Test the function
-    with patch('local_newsifier.container.container', mock_container):
-        register_article_service(mock_article_service)
-        
-        # Verify the article service was registered
-        mock_container.get.assert_called_with("rss_feed_service")
-        assert mock_rss_feed_service.article_service == mock_article_service

--- a/tests/services/test_mock_rss_feed_service.py
+++ b/tests/services/test_mock_rss_feed_service.py
@@ -4,11 +4,7 @@ import pytest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch, call
 
-from local_newsifier.services.rss_feed_service import (
-    RSSFeedService,
-    register_article_service,
-)
-from local_newsifier.container import container
+from local_newsifier.services.rss_feed_service import RSSFeedService
 
 
 @pytest.fixture

--- a/tests/services/test_rss_feed_service.py
+++ b/tests/services/test_rss_feed_service.py
@@ -4,13 +4,9 @@ import pytest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch, call
 
-from local_newsifier.services.rss_feed_service import (
-    RSSFeedService,
-    register_article_service,
-)
+from local_newsifier.services.rss_feed_service import RSSFeedService
 from local_newsifier.models.rss_feed import RSSFeed, RSSFeedProcessingLog
 from local_newsifier.di_container import DIContainer
-from local_newsifier.container import container
 
 
 
@@ -1005,38 +1001,6 @@ def test_get_feed_processing_logs(mock_db_session, mock_session_factory):
 #     
 #     # Assert - should be set to the mock task
 #     assert local_newsifier.services.rss_feed_service._process_article_task is mock_task
-
-
-@pytest.mark.skip(reason="Async event loop issue in fastapi-injectable, to be fixed in a separate PR")
-def test_register_article_service():
-    """Test registering the article service.
-    
-    This test is mainly to maintain backward compatibility during migration.
-    In the future, direct container access should be used instead.
-    """
-    # Create a mock container
-    mock_container = MagicMock(spec=DIContainer)
-    mock_rss_feed_service = MagicMock()
-    
-    # Make the mock container return our mock rss_feed_service
-    def mock_get(name):
-        if name == "rss_feed_service":
-            return mock_rss_feed_service
-        return None
-    
-    mock_container.get.side_effect = mock_get
-    
-    # Mock article service
-    mock_article_service = MagicMock()
-    
-    # Patch the container module import in the function
-    with patch('local_newsifier.container.container', mock_container):
-        # Act
-        register_article_service(mock_article_service)
-        
-        # Assert
-        mock_container.get.assert_called_with("rss_feed_service")
-        assert mock_rss_feed_service.article_service == mock_article_service
 
 
 @pytest.mark.skip(reason="Async event loop issue in fastapi-injectable, to be fixed in a separate PR")


### PR DESCRIPTION
## Summary
- purge container usage from tasks and services
- adjust ApifySourceConfigService init signature
- clean up tests that relied on container registration

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*