### PR TITLE
Clean up legacy container references in docs

### DIFF
--- a/docs/dependency_injection_antipatterns.md
+++ b/docs/dependency_injection_antipatterns.md
@@ -113,7 +113,7 @@ async def get_async_thing():
 class ServiceWithHiddenDependencies:
     def __init__(self):
         # Hidden dependency fetched internally
-        from local_newsifier.container import container
+        from some_container import container  # Legacy pattern
         self.dependency = container.get("some_dependency")
 ```
 

--- a/docs/injectable_examples.md
+++ b/docs/injectable_examples.md
@@ -318,8 +318,7 @@ class TrendAnalyzer:
 def db_stats_command(detailed: bool = False):
     """Show database statistics."""
     from local_newsifier.di.providers import get_session, get_article_crud, get_entity_crud
-    from local_newsifier.container import container
-    
+
     # Get dependencies through injectable providers
     session = get_injected_obj(get_session)
     article_crud = get_injected_obj(get_article_crud)

--- a/implementation_summary_issue_214.md
+++ b/implementation_summary_issue_214.md
@@ -12,13 +12,9 @@ This implementation creates comprehensive CRUD operations for managing Apify sou
 2. **Added to CRUD Package Exports**:
    - Updated `/src/local_newsifier/crud/__init__.py` to export the new CRUD module
 
-3. **Added to Container Registration**:
-   - Updated `/src/local_newsifier/container.py` to register the CRUD module in the DI container
-
-4. **Added FastAPI Injectable Provider**:
+3. **Added FastAPI Injectable Provider**:
    - Added provider function to `/src/local_newsifier/di/providers.py` for fastapi-injectable compatibility
-
-5. **Added Comprehensive Tests**:
+4. **Added Comprehensive Tests**:
    - Created `/tests/crud/test_apify_source_config.py` with thorough test coverage
 
 ## Implementation Details
@@ -68,8 +64,7 @@ The test suite includes comprehensive tests for:
 This implementation integrates with:
 
 1. **Dependency Injection**:
-   - Traditional container registration through `container.py`
-   - Modern fastapi-injectable registration through provider functions
+   - Uses fastapi-injectable provider functions for dependency management
 
 2. **Error Handling Framework**:
    - Uses the standardized error handling approach with `ServiceError`


### PR DESCRIPTION
## Summary
- remove old `container` import from `injectable_examples.md`
- adjust anti-pattern snippet to avoid referencing the removed module
- drop container.py registration details from issue 214 summary

## Testing
- `python -m pytest -q` *(fails: pyenv version not installed)*
- `pyenv local 3.12.10 && python -m pytest -q` *(fails: No module named pytest)*