### PR TITLE
Remove legacy container params

### DIFF
--- a/src/local_newsifier/services/apify_source_config_service.py
+++ b/src/local_newsifier/services/apify_source_config_service.py
@@ -26,7 +26,6 @@ class ApifySourceConfigService:
         apify_source_config_crud: CRUDApifySourceConfig,
         apify_service,  # ApifyService, but avoiding circular imports
         session_factory,
-        container=None
     ):
         """Initialize the service.
         
@@ -34,12 +33,10 @@ class ApifySourceConfigService:
             apify_source_config_crud: CRUD for Apify source configurations
             apify_service: Service for interacting with Apify API
             session_factory: Function that returns a database session
-            container: Optional DI container for service resolution
         """
         self.apify_source_config_crud = apify_source_config_crud
         self.apify_service = apify_service
         self.session_factory = session_factory
-        self.container = container
     
     @handle_service_error(service="apify")
     def list_configs(

--- a/src/local_newsifier/tools/entity_tracker_service.py
+++ b/src/local_newsifier/tools/entity_tracker_service.py
@@ -21,39 +21,23 @@ from local_newsifier.tools.resolution.entity_resolver import EntityResolver
 class EntityTracker:
     """Tool for tracking entities across news articles using the EntityService."""
     
-    def __init__(self, entity_service=None, session=None, container=None):
+    def __init__(self, entity_service=None, session=None):
         """Initialize with dependencies.
-        
+
         Args:
             entity_service: Service for entity operations
             session: Database session
-            container: Optional DI container for backward compatibility
         """
         self.entity_service = entity_service
         self.session = session
-        self._container = container
-        
+
         # Initialize dependencies if needed
         self._ensure_dependencies()
     
     def _ensure_dependencies(self):
-        """Ensure all dependencies are available.
-        
-        This handles backward compatibility by attempting to get
-        missing dependencies from the container.
-        """
-        # Create a default entity service if none was provided
+        """Ensure all dependencies are available."""
         if self.entity_service is None:
-            if self._container is not None:
-                try:
-                    # Try to get from container first
-                    self.entity_service = self._container.get("entity_service")
-                except (KeyError, AttributeError):
-                    # Fall back to creating a default service
-                    self.entity_service = self._create_default_service()
-            else:
-                # No container, create default service
-                self.entity_service = self._create_default_service()
+            self.entity_service = self._create_default_service()
     
     def _create_default_service(self):
         """Create default entity service with all dependencies."""

--- a/tests/services/test_apify_source_config_service.py
+++ b/tests/services/test_apify_source_config_service.py
@@ -55,7 +55,6 @@ class TestApifySourceConfigService:
             apify_source_config_crud=mock_crud,
             apify_service=mock_apify_service,
             session_factory=mock_session_factory,
-            container=None
         )
 
     def test_list_configs(self, service, mock_crud, mock_session_factory, mock_session):


### PR DESCRIPTION
## Summary
- drop deprecated container arg from `ApifySourceConfigService`
- drop container arg and fallback logic from `EntityTracker`
- update service test fixture

## Testing
- `pytest -q` *(fails: command not found)*
- `pre-commit run --files src/local_newsifier/services/apify_source_config_service.py src/local_newsifier/tools/entity_tracker_service.py tests/services/test_apify_source_config_service.py` *(fails: command not found)*