### PR TITLE
Remove SessionManager imports

### DIFF
--- a/src/local_newsifier/services/analysis_service.py
+++ b/src/local_newsifier/services/analysis_service.py
@@ -11,7 +11,7 @@ from fastapi import Depends
 from local_newsifier.crud.analysis_result import analysis_result
 from local_newsifier.crud.article import article
 from local_newsifier.crud.entity import entity
-from local_newsifier.database.engine import SessionManager, get_session
+from local_newsifier.database.engine import get_session
 from local_newsifier.errors.handlers import handle_database
 from local_newsifier.models.analysis_result import AnalysisResult
 from local_newsifier.models.trend import TrendAnalysis, TimeFrame

--- a/src/local_newsifier/services/article_service.py
+++ b/src/local_newsifier/services/article_service.py
@@ -9,7 +9,6 @@ from fastapi import Depends
 
 from local_newsifier.models.article import Article
 from local_newsifier.models.analysis_result import AnalysisResult
-from local_newsifier.database.engine import SessionManager
 from local_newsifier.errors import handle_database
 
 

--- a/src/local_newsifier/services/entity_service.py
+++ b/src/local_newsifier/services/entity_service.py
@@ -10,7 +10,6 @@ from fastapi import Depends
 from local_newsifier.models.entity import Entity
 from local_newsifier.models.entity_tracking import CanonicalEntity, EntityMentionContext, EntityProfile
 from local_newsifier.models.state import EntityTrackingState, EntityBatchTrackingState, EntityDashboardState, EntityRelationshipState, TrackingStatus
-from local_newsifier.database.engine import SessionManager
 from local_newsifier.errors import handle_database
 
 @injectable(use_cache=False)

--- a/src/local_newsifier/services/news_pipeline_service.py
+++ b/src/local_newsifier/services/news_pipeline_service.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import Dict, List, Optional, Any
 
 from local_newsifier.services.article_service import ArticleService
-from local_newsifier.database.engine import SessionManager
 from local_newsifier.errors import handle_database, handle_web_scraper
 
 

--- a/tests/services/test_article_service.py
+++ b/tests/services/test_article_service.py
@@ -5,8 +5,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 @pytest.mark.skip(reason="Async event loop issue in fastapi-injectable, to be fixed in a separate PR")
-@patch('local_newsifier.services.article_service.SessionManager')
-def test_process_article(mock_session_manager):
+def test_process_article():
     """Test the complete article processing flow using the service."""
     # Arrange
     # Mock the entity service
@@ -31,6 +30,7 @@ def test_process_article(mock_session_manager):
     mock_analysis_result_crud.create.return_value = MagicMock(id=1)
     
     # Mock session manager
+    mock_session_manager = MagicMock()
     mock_session = MagicMock()
     mock_session_manager.return_value.__enter__.return_value = mock_session
     
@@ -73,8 +73,7 @@ def test_process_article(mock_session_manager):
     assert result["analysis_result"]["statistics"]["total_entities"] == 1
 
 @pytest.mark.skip(reason="Async event loop issue in fastapi-injectable, to be fixed in a separate PR")
-@patch('local_newsifier.services.article_service.SessionManager')
-def test_get_article(mock_session_manager):
+def test_get_article():
     """Test retrieving an article with its analysis results."""
     # Arrange
     # Mock CRUD operations
@@ -110,6 +109,7 @@ def test_get_article(mock_session_manager):
     ]
     
     # Mock session manager
+    mock_session_manager = MagicMock()
     mock_session = MagicMock()
     mock_session_manager.return_value.__enter__.return_value = mock_session
     
@@ -139,8 +139,7 @@ def test_get_article(mock_session_manager):
     assert result["analysis_results"][0]["statistics"]["total_entities"] == 1
 
 @pytest.mark.skip(reason="Async event loop issue in fastapi-injectable, to be fixed in a separate PR")
-@patch('local_newsifier.services.article_service.SessionManager')
-def test_get_article_not_found(mock_session_manager):
+def test_get_article_not_found():
     """Test retrieving a non-existent article."""
     # Arrange
     # Mock CRUD operations
@@ -148,6 +147,7 @@ def test_get_article_not_found(mock_session_manager):
     mock_article_crud.get.return_value = None
     
     # Mock session manager
+    mock_session_manager = MagicMock()
     mock_session = MagicMock()
     mock_session_manager.return_value.__enter__.return_value = mock_session
     

--- a/tests/services/test_news_pipeline_service.py
+++ b/tests/services/test_news_pipeline_service.py
@@ -4,8 +4,7 @@ import pytest
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_process_url(mock_session_manager):
+def test_process_url():
     """Test processing an article from a URL."""
     # Arrange
     # Mock the web scraper
@@ -43,9 +42,6 @@ def test_process_url(mock_session_manager):
         }
     }
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with mocks
     from local_newsifier.services.news_pipeline_service import NewsPipelineService
@@ -78,17 +74,13 @@ def test_process_url(mock_session_manager):
     assert result["entities"][0]["original_text"] == "John Doe"
     assert result["analysis_result"]["statistics"]["total_entities"] == 1
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_process_url_scraping_failed(mock_session_manager):
+def test_process_url_scraping_failed():
     """Test processing an article when scraping fails."""
     # Arrange
     # Mock the web scraper to return None (scraping failed)
     mock_web_scraper = MagicMock()
     mock_web_scraper.scrape_url.return_value = None
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with mocks
     from local_newsifier.services.news_pipeline_service import NewsPipelineService
@@ -105,8 +97,7 @@ def test_process_url_scraping_failed(mock_session_manager):
     assert result["status"] == "error"
     assert "Failed to scrape content" in result["message"]
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_process_content(mock_session_manager):
+def test_process_content():
     """Test processing article content directly."""
     # Arrange
     # Mock the article service
@@ -136,9 +127,6 @@ def test_process_content(mock_session_manager):
         }
     }
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with mocks
     from local_newsifier.services.news_pipeline_service import NewsPipelineService
@@ -173,8 +161,7 @@ def test_process_content(mock_session_manager):
     assert result["entities"][0]["original_text"] == "John Doe"
     assert result["analysis_result"]["statistics"]["total_entities"] == 1
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_process_content_with_file_writer(mock_session_manager):
+def test_process_content_with_file_writer():
     """Test processing article content with file writer."""
     # Arrange
     # Mock the article service
@@ -191,9 +178,6 @@ def test_process_content_with_file_writer(mock_session_manager):
     mock_file_writer = MagicMock()
     mock_file_writer.write_results.return_value = "/path/to/output.json"
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with mocks
     from local_newsifier.services.news_pipeline_service import NewsPipelineService

--- a/tests/services/test_news_pipeline_service_extended.py
+++ b/tests/services/test_news_pipeline_service_extended.py
@@ -4,8 +4,7 @@ import pytest
 from datetime import datetime
 from unittest.mock import MagicMock, patch, call
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_pipeline_initialization_with_custom_config(mock_session_manager):
+def test_pipeline_initialization_with_custom_config():
     """Test initializing pipeline with custom configuration."""
     # Arrange
     # Create custom mock dependencies
@@ -14,9 +13,6 @@ def test_pipeline_initialization_with_custom_config(mock_session_manager):
     mock_file_writer = MagicMock()
     mock_custom_session_factory = MagicMock()
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with custom configuration
     from local_newsifier.services.news_pipeline_service import NewsPipelineService
@@ -35,8 +31,7 @@ def test_pipeline_initialization_with_custom_config(mock_session_manager):
     assert service.session_factory is mock_custom_session_factory
 
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_process_url_with_stage_error(mock_session_manager):
+def test_process_url_with_stage_error():
     """Test handling errors in specific pipeline stages."""
     # Arrange
     # Mock the web scraper to succeed
@@ -51,9 +46,6 @@ def test_process_url_with_stage_error(mock_session_manager):
     mock_article_service = MagicMock()
     mock_article_service.process_article.side_effect = Exception("Processing error")
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with mocks
     from local_newsifier.services.news_pipeline_service import NewsPipelineService
@@ -80,8 +72,7 @@ def test_process_url_with_stage_error(mock_session_manager):
     assert "Processing error" in result["message"]
 
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_process_content_with_custom_session(mock_session_manager):
+def test_process_content_with_custom_session():
     """Test processing with a custom database session."""
     # Arrange
     # Mock the article service
@@ -129,8 +120,7 @@ def test_process_content_with_custom_session(mock_session_manager):
     assert result["url"] == "https://example.com"
 
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_pipeline_with_alternative_scraper(mock_session_manager):
+def test_pipeline_with_alternative_scraper():
     """Test pipeline with a different web scraper implementation."""
     # Arrange
     # Create an alternative scraper with different return format
@@ -152,9 +142,6 @@ def test_pipeline_with_alternative_scraper(mock_session_manager):
         "entities": []
     }
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with the alternative scraper
     from local_newsifier.services.news_pipeline_service import NewsPipelineService
@@ -185,8 +172,7 @@ def test_pipeline_with_alternative_scraper(mock_session_manager):
     assert result["url"] == "https://example.com"
 
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_process_url_with_scraper_returning_none(mock_session_manager):
+def test_process_url_with_scraper_returning_none():
     """Test handling when scraper returns None."""
     # Arrange
     # Mock the web scraper to return None
@@ -196,9 +182,6 @@ def test_process_url_with_scraper_returning_none(mock_session_manager):
     # Mock the article service
     mock_article_service = MagicMock()
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with mocks
     from local_newsifier.services.news_pipeline_service import NewsPipelineService
@@ -223,8 +206,7 @@ def test_process_url_with_scraper_returning_none(mock_session_manager):
     assert "Failed to scrape content" in result["message"]
 
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_process_content_with_missing_published_date(mock_session_manager):
+def test_process_content_with_missing_published_date():
     """Test processing content without a published date."""
     # Arrange
     # Mock the article service
@@ -236,9 +218,6 @@ def test_process_content_with_missing_published_date(mock_session_manager):
         "entities": []
     }
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with mocks
     from local_newsifier.services.news_pipeline_service import NewsPipelineService
@@ -271,8 +250,7 @@ def test_process_content_with_missing_published_date(mock_session_manager):
     assert result["url"] == "https://example.com"
 
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_process_url_with_partial_scraper_data(mock_session_manager):
+def test_process_url_with_partial_scraper_data():
     """Test processing with partial data from scraper."""
     # Arrange
     # Mock the web scraper to return partial data
@@ -292,9 +270,6 @@ def test_process_url_with_partial_scraper_data(mock_session_manager):
         "entities": []
     }
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with mocks
     from local_newsifier.services.news_pipeline_service import NewsPipelineService
@@ -325,8 +300,7 @@ def test_process_url_with_partial_scraper_data(mock_session_manager):
     assert result["url"] == "https://example.com"
 
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_process_content_with_file_writer_error(mock_session_manager):
+def test_process_content_with_file_writer_error():
     """Test handling errors from file writer."""
     # Arrange
     # Mock the article service
@@ -342,9 +316,6 @@ def test_process_content_with_file_writer_error(mock_session_manager):
     mock_file_writer = MagicMock()
     mock_file_writer.write_results.side_effect = Exception("File writing error")
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with mocks
     from local_newsifier.services.news_pipeline_service import NewsPipelineService
@@ -381,8 +352,7 @@ def test_process_content_with_file_writer_error(mock_session_manager):
     assert "File writing error" in result["error"]
 
 
-@patch('local_newsifier.services.news_pipeline_service.SessionManager')
-def test_process_url_and_content_integration(mock_session_manager):
+def test_process_url_and_content_integration():
     """Test integration between process_url and process_content."""
     # Arrange
     # Mock the web scraper
@@ -402,9 +372,6 @@ def test_process_url_and_content_integration(mock_session_manager):
         "entities": []
     }
     
-    # Mock session manager
-    mock_session = MagicMock()
-    mock_session_manager.return_value.__enter__.return_value = mock_session
     
     # Create the service with mocks
     from local_newsifier.services.news_pipeline_service import NewsPipelineService


### PR DESCRIPTION
## Summary
- remove `SessionManager` import in services
- update related tests by removing SessionManager patching

## Testing
- `python -m pytest -n 0` *(fails: No module named pytest)*
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement poetry-core)*