### PR TITLE
Remove with_session usage

### DIFF
--- a/src/local_newsifier/di/providers.py
+++ b/src/local_newsifier/di/providers.py
@@ -282,7 +282,9 @@ def get_sentiment_analyzer_config():
     }
 
 @injectable(use_cache=False)
-def get_sentiment_analyzer_tool():
+def get_sentiment_analyzer_tool(
+    session: Annotated[Session, Depends(get_session)]
+):
     """Provide the sentiment analyzer tool.
 
     Uses use_cache=False to create new instances for each injection, as sentiment
@@ -292,7 +294,10 @@ def get_sentiment_analyzer_tool():
         SentimentAnalyzer instance
     """
     from local_newsifier.tools.sentiment_analyzer import SentimentAnalyzer
-    return SentimentAnalyzer(nlp_model=get_nlp_model())
+    return SentimentAnalyzer(
+        nlp_model=get_nlp_model(),
+        session=session
+    )
 
 
 @injectable(use_cache=False)
@@ -615,7 +620,10 @@ def get_entity_tracker_tool(
         EntityTracker instance
     """
     from local_newsifier.tools.entity_tracker_service import EntityTracker
-    return EntityTracker(entity_service=entity_service, session=session)
+    return EntityTracker(
+        entity_service=entity_service,
+        session_factory=lambda: session
+    )
 
 
 @injectable(use_cache=False)
@@ -1070,7 +1078,10 @@ def get_injectable_entity_tracker(
         InjectableEntityTracker instance with injected dependencies
     """
     from local_newsifier.tools.entity_tracker_service import EntityTracker
-    return EntityTracker(entity_service=entity_service, session=session)
+    return EntityTracker(
+        entity_service=entity_service,
+        session_factory=lambda: session
+    )
 
 
 @injectable(use_cache=False)

--- a/src/local_newsifier/tools/entity_tracker_service.py
+++ b/src/local_newsifier/tools/entity_tracker_service.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Any
 
 from sqlmodel import Session
 
-from local_newsifier.database.engine import with_session, get_session
+from local_newsifier.database.engine import get_session
 from local_newsifier.services.entity_service import EntityService
 from local_newsifier.crud.entity import entity as entity_crud
 from local_newsifier.crud.canonical_entity import canonical_entity as canonical_entity_crud
@@ -21,16 +21,16 @@ from local_newsifier.tools.resolution.entity_resolver import EntityResolver
 class EntityTracker:
     """Tool for tracking entities across news articles using the EntityService."""
     
-    def __init__(self, entity_service=None, session=None, container=None):
+    def __init__(self, entity_service=None, session_factory=get_session, container=None):
         """Initialize with dependencies.
-        
+
         Args:
             entity_service: Service for entity operations
-            session: Database session
+            session_factory: Callable that returns a database session
             container: Optional DI container for backward compatibility
         """
         self.entity_service = entity_service
-        self.session = session
+        self.session_factory = session_factory
         self._container = container
         
         # Initialize dependencies if needed
@@ -66,18 +66,17 @@ class EntityTracker:
             entity_extractor=EntityExtractor(),
             context_analyzer=ContextAnalyzer(),
             entity_resolver=EntityResolver(),
-            session_factory=get_session
+            session_factory=self.session_factory
         )
     
-    @with_session
     def process_article(
-        self, 
+        self,
         article_id: int,
         content: str,
         title: str,
         published_at: datetime,
         *,
-        session: Session = None
+        session: Session | None = None
     ) -> List[Dict[str, Any]]:
         """Process an article to track entity mentions.
         
@@ -86,7 +85,7 @@ class EntityTracker:
             content: Article content
             title: Article title
             published_at: Article publication date
-            session: Database session
+            session: Database session (optional, reserved for backward compatibility)
             
         Returns:
             List of processed entity mentions

--- a/src/local_newsifier/tools/sentiment_tracker.py
+++ b/src/local_newsifier/tools/sentiment_tracker.py
@@ -10,7 +10,6 @@ from fastapi_injectable import injectable
 from sqlmodel import Session, select
 
 # Use direct imports from the original model locations
-from local_newsifier.database.engine import with_session
 from local_newsifier.models.sentiment import SentimentAnalysis, OpinionTrend, SentimentShift
 from local_newsifier.models.article import Article
 from local_newsifier.models.analysis_result import AnalysisResult
@@ -57,7 +56,6 @@ class SentimentTracker:
 
         return self.session
 
-    @with_session
     def get_sentiment_by_period(
         self,
         start_date: datetime,
@@ -117,7 +115,6 @@ class SentimentTracker:
 
         return results
 
-    @with_session
     def get_entity_sentiment_trends(
         self,
         entity_name: str,
@@ -166,7 +163,6 @@ class SentimentTracker:
 
         return results
 
-    @with_session
     def detect_sentiment_shifts(
         self,
         topics: List[str],
@@ -209,7 +205,6 @@ class SentimentTracker:
 
         return shifts
 
-    @with_session
     def calculate_topic_correlation(
         self,
         topic1: str,
@@ -292,7 +287,6 @@ class SentimentTracker:
 
         return correlation
 
-    @with_session
     def _get_articles_in_range(self, start_date: datetime, end_date: datetime, *, session: Optional[Session] = None) -> List:
         """
         Get all articles published within the date range.
@@ -348,7 +342,6 @@ class SentimentTracker:
         else:
             return date.strftime("%Y-%m-%d")  # Default to day
 
-    @with_session
     def _get_sentiment_data_for_articles(self, article_ids: List[int], *, session: Optional[Session] = None) -> List[Dict]:
         """
         Get sentiment analysis results for articles.

--- a/tests/di/test_sentiment_analyzer_provider.py
+++ b/tests/di/test_sentiment_analyzer_provider.py
@@ -19,6 +19,11 @@ def mock_container(mock_nlp):
     with patch("local_newsifier.di.providers.get_nlp_model", return_value=mock_nlp):
         yield None
 
+@pytest.fixture
+def mock_session():
+    """Create a mock database session."""
+    return MagicMock()
+
 @patch('fastapi_injectable.decorator.run_coroutine_sync')
 def test_get_sentiment_analyzer_config(mock_run_sync, event_loop_fixture):
     """Test the sentiment analyzer configuration provider."""
@@ -37,7 +42,7 @@ def test_get_sentiment_analyzer_config(mock_run_sync, event_loop_fixture):
     assert config["model_name"] == "en_core_web_sm"
 
 @patch('fastapi_injectable.decorator.run_coroutine_sync')
-def test_get_sentiment_analyzer_tool(mock_run_sync, mock_container, mock_nlp, event_loop_fixture):
+def test_get_sentiment_analyzer_tool(mock_run_sync, mock_container, mock_nlp, mock_session, event_loop_fixture):
     """Test the sentiment analyzer tool provider."""
     # Set up the mock to use our event loop
     mock_run_sync.side_effect = lambda x: event_loop_fixture.run_until_complete(x)
@@ -47,7 +52,7 @@ def test_get_sentiment_analyzer_tool(mock_run_sync, mock_container, mock_nlp, ev
     
     with patch("local_newsifier.di.providers.get_nlp_model", return_value=mock_nlp):
         # Get the sentiment analyzer from the provider
-        sentiment_analyzer = get_sentiment_analyzer_tool()
+        sentiment_analyzer = get_sentiment_analyzer_tool(session=mock_session)
         
         # Verify it has the right attributes
         assert hasattr(sentiment_analyzer, "analyze_sentiment")


### PR DESCRIPTION
## Summary
- update providers to inject Session instead of using with_session
- rework `EntityTracker` to accept a session factory
- refactor `SentimentAnalyzer` constructor for session injection
- drop with_session decorators from sentiment tracker
- adjust provider tests for new session parameter

## Testing
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*