### PR TITLE
Add CLI utils and refactor commands

### DIFF
--- a/src/local_newsifier/cli/cli_utils.py
+++ b/src/local_newsifier/cli/cli_utils.py
@@ -1,0 +1,18 @@
+"""Helper utilities for CLI commands."""
+
+from typing import Any, Callable
+
+import click
+from tabulate import tabulate
+from fastapi_injectable import get_injected_obj
+
+
+def load_dependency(provider: Callable[..., Any]) -> Any:
+    """Load a dependency using fastapi-injectable."""
+    return get_injected_obj(provider)
+
+
+def print_table(headers, rows) -> None:
+    """Print a table using ``tabulate`` with the project's default format."""
+    click.echo(tabulate(rows, headers=headers, tablefmt="simple"))
+

--- a/src/local_newsifier/cli/commands/apify.py
+++ b/src/local_newsifier/cli/commands/apify.py
@@ -14,9 +14,9 @@ import os
 from typing import Optional
 
 import click
-from tabulate import tabulate
 from sqlmodel import Session
-from fastapi_injectable import get_injected_obj
+
+from local_newsifier.cli.cli_utils import load_dependency, print_table
 
 from local_newsifier.config.settings import settings
 from local_newsifier.services.apify_service import ApifyService
@@ -75,7 +75,7 @@ def test_connection(token):
 
     try:
         # Get ApifyService from injectable provider with token parameter
-        apify_service = get_injected_obj(lambda: get_apify_service_cli(token))
+        apify_service = load_dependency(lambda: get_apify_service_cli(token))
 
         # Test if we can access the client
         client = apify_service.client
@@ -144,7 +144,7 @@ def run_actor(actor_id, input, wait, token, output):
 
     try:
         # Get ApifyService from injectable provider with token parameter
-        apify_service = get_injected_obj(lambda: get_apify_service_cli(token))
+        apify_service = load_dependency(lambda: get_apify_service_cli(token))
 
         # Run the actor
         click.echo(f"Running actor {actor_id}...")
@@ -208,7 +208,7 @@ def get_dataset(dataset_id, limit, offset, token, output, format_type):
 
     try:
         # Get ApifyService from injectable provider with token parameter
-        apify_service = get_injected_obj(lambda: get_apify_service_cli(token))
+        apify_service = load_dependency(lambda: get_apify_service_cli(token))
 
         # Get dataset items
         click.echo(f"Retrieving items from dataset {dataset_id}...")
@@ -261,7 +261,7 @@ def get_dataset(dataset_id, limit, offset, token, output, format_type):
                         row.append(value)
                     table_data.append(row)
 
-                click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
+                print_table(headers, table_data)
             else:
                 click.echo("Cannot display as table - items are not dictionaries")
                 click.echo(json.dumps(items, indent=2))
@@ -294,7 +294,7 @@ def get_actor(actor_id, token):
 
     try:
         # Get ApifyService from injectable provider with token parameter
-        apify_service = get_injected_obj(lambda: get_apify_service_cli(token))
+        apify_service = load_dependency(lambda: get_apify_service_cli(token))
 
         # Get actor details
         click.echo(f"Retrieving details for actor {actor_id}...")
@@ -349,7 +349,7 @@ def scrape_content(url, max_pages, max_depth, token, output):
 
     try:
         # Get ApifyService from injectable provider with token parameter
-        apify_service = get_injected_obj(lambda: get_apify_service_cli(token))
+        apify_service = load_dependency(lambda: get_apify_service_cli(token))
 
         # Configure the actor input
         run_input = {
@@ -403,7 +403,7 @@ def scrape_content(url, max_pages, max_depth, token, output):
 
             if items:
                 headers = ["#", "Title", "URL"]
-                click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
+                print_table(headers, table_data)
 
                 if len(items) > 10:
                     remaining_items = len(items) - 10
@@ -446,7 +446,7 @@ def web_scraper(url, selector, max_pages, wait_for, page_function, output, token
 
     try:
         # Get ApifyService from injectable provider with token parameter
-        apify_service = get_injected_obj(lambda: get_apify_service_cli(token))
+        apify_service = load_dependency(lambda: get_apify_service_cli(token))
 
         # Default page function if not provided
         default_page_function = """
@@ -526,7 +526,7 @@ def web_scraper(url, selector, max_pages, wait_for, page_function, output, token
 
             if items:
                 headers = ["#", "Title", "URL"]
-                click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
+                print_table(headers, table_data)
 
                 if len(items) > 10:
                     remaining_items = len(items) - 10
@@ -641,8 +641,17 @@ def list_schedules(token: str, with_apify: bool, format_type: str):
                 ]
                 table_data.append(row)
                 
-            headers = ["ID", "Name", "Schedule", "Status", "Schedule ID", "Exists", "Synced", "Last Run"]
-            click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
+            headers = [
+                "ID",
+                "Name",
+                "Schedule",
+                "Status",
+                "Schedule ID",
+                "Exists",
+                "Synced",
+                "Last Run",
+            ]
+            print_table(headers, table_data)
         else:
             # Simple table without Apify API calls
             table_data = []
@@ -660,8 +669,15 @@ def list_schedules(token: str, with_apify: bool, format_type: str):
                 ]
                 table_data.append(row)
                 
-            headers = ["ID", "Name", "Schedule", "Status", "Schedule ID", "Last Run"]
-            click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
+            headers = [
+                "ID",
+                "Name",
+                "Schedule",
+                "Status",
+                "Schedule ID",
+                "Last Run",
+            ]
+            print_table(headers, table_data)
             
     except Exception as e:
         click.echo(click.style(f"Error listing schedules: {str(e)}", fg="red"), err=True)

--- a/src/local_newsifier/cli/commands/apify_config.py
+++ b/src/local_newsifier/cli/commands/apify_config.py
@@ -12,9 +12,8 @@ This module provides commands for managing Apify source configurations, includin
 import json
 import click
 from datetime import datetime
-from tabulate import tabulate
 
-from fastapi_injectable import get_injected_obj
+from local_newsifier.cli.cli_utils import load_dependency, print_table
 
 from local_newsifier.di.providers import get_apify_source_config_service
 
@@ -34,7 +33,7 @@ def apify_config_group():
 def list_configs(active_only, json_output, limit, skip, source_type):
     """List all Apify source configurations with optional filtering."""
     # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    apify_source_config_service = load_dependency(get_apify_source_config_service)
     
     # Get configs based on filters
     configs_dict = apify_source_config_service.list_configs(
@@ -82,7 +81,7 @@ def list_configs(active_only, json_output, limit, skip, source_type):
     
     # Display table
     headers = ["ID", "Name", "Actor ID", "Type", "Active", "Last Run", "Config"]
-    click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
+    print_table(headers, table_data)
 
 
 @apify_config_group.command(name="add")
@@ -95,7 +94,7 @@ def list_configs(active_only, json_output, limit, skip, source_type):
 def add_config(name, actor_id, source_type, source_url, schedule, input):
     """Add a new Apify source configuration."""
     # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    apify_source_config_service = load_dependency(get_apify_source_config_service)
     
     # Parse input configuration if provided
     input_configuration = None
@@ -143,7 +142,7 @@ def add_config(name, actor_id, source_type, source_url, schedule, input):
 def show_config(id, json_output):
     """Show Apify source configuration details."""
     # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    apify_source_config_service = load_dependency(get_apify_source_config_service)
     
     try:
         config = apify_source_config_service.get_config(id)
@@ -187,7 +186,7 @@ def show_config(id, json_output):
 def remove_config(id, force):
     """Remove an Apify source configuration."""
     # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    apify_source_config_service = load_dependency(get_apify_source_config_service)
     
     try:
         config = apify_source_config_service.get_config(id)
@@ -221,7 +220,7 @@ def remove_config(id, force):
 def update_config(id, name, actor_id, source_type, source_url, schedule, active, input):
     """Update Apify source configuration properties."""
     # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    apify_source_config_service = load_dependency(get_apify_source_config_service)
     
     try:
         # Check if at least one property to update was provided
@@ -288,7 +287,7 @@ def run_config(id, output):
         nf apify-config run 2 --output result.json
     """
     # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    apify_source_config_service = load_dependency(get_apify_source_config_service)
     
     try:
         # Run the configuration

--- a/src/local_newsifier/cli/commands/feeds.py
+++ b/src/local_newsifier/cli/commands/feeds.py
@@ -14,7 +14,8 @@ This module provides commands for managing RSS feeds, including:
 import json
 import click
 from datetime import datetime
-from tabulate import tabulate
+
+from local_newsifier.cli.cli_utils import print_table
 
 from local_newsifier.di.providers import (
     get_rss_feed_service,
@@ -67,7 +68,7 @@ def list_feeds(active_only, json_output, limit, skip):
     
     # Display table
     headers = ["ID", "Name", "URL", "Active", "Last Fetched"]
-    click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
+    print_table(headers, table_data)
 
 
 @feeds_group.command(name="add")
@@ -152,8 +153,16 @@ def show_feed(id, json_output, show_logs):
                 log["error_message"] or ""
             ])
         
-        log_headers = ["ID", "Started At", "Completed At", "Status", "Found", "Added", "Error"]
-        click.echo(tabulate(log_data, headers=log_headers, tablefmt="simple"))
+        log_headers = [
+            "ID",
+            "Started At",
+            "Completed At",
+            "Status",
+            "Found",
+            "Added",
+            "Error",
+        ]
+        print_table(log_headers, log_data)
 
 
 @feeds_group.command(name="remove")

--- a/tests/cli/test_apify_commands.py
+++ b/tests/cli/test_apify_commands.py
@@ -127,7 +127,7 @@ class TestApifyCommands:
         settings.APIFY_TOKEN = None
         assert _ensure_token() is False
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_test_connection(
         self, mock_get_injected_obj, mock_apify_service, runner, original_token
     ):
@@ -147,7 +147,7 @@ class TestApifyCommands:
         # Verify the lambda function was called with the token
         # Since we can't directly check the lambda, we check that get_injected_obj was called
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_test_connection_with_token_param(
         self, mock_get_injected_obj, mock_apify_service, runner, original_token
     ):
@@ -162,7 +162,7 @@ class TestApifyCommands:
         assert result.exit_code == 0
         assert "Connection to Apify API successful" in result.output
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_run_actor(
         self, mock_get_injected_obj, mock_apify_service, runner, original_token
     ):
@@ -182,7 +182,7 @@ class TestApifyCommands:
         assert "Actor run completed" in result.output
         assert "Default dataset ID: test_dataset" in result.output
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_run_actor_with_input_file(
         self, mock_get_injected_obj, mock_apify_service, runner, original_token
     ):
@@ -208,7 +208,7 @@ class TestApifyCommands:
             # Clean up
             os.unlink(input_file)
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_run_actor_with_output_file(
         self, mock_get_injected_obj, mock_apify_service, runner, original_token
     ):
@@ -239,7 +239,7 @@ class TestApifyCommands:
             # Clean up
             os.unlink(output_file)
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_get_dataset(
         self, mock_get_injected_obj, runner, original_token, mock_apify_service
     ):
@@ -256,7 +256,7 @@ class TestApifyCommands:
         assert "Retrieving items from dataset test_dataset" in result.output
         assert "Retrieved 1 items" in result.output
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_get_dataset_with_table_format(
         self, mock_get_injected_obj, runner, original_token, mock_apify_service
     ):
@@ -275,7 +275,7 @@ class TestApifyCommands:
         # Table output should have headers - lowercase column names
         assert "title" in result.output
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_get_actor(
         self, mock_get_injected_obj, runner, original_token, mock_apify_service
     ):
@@ -295,7 +295,7 @@ class TestApifyCommands:
         assert "Description: Test actor description" in result.output
         assert "Input Schema" in result.output
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_scrape_content(
         self, mock_get_injected_obj, runner, original_token, mock_apify_service
     ):
@@ -314,7 +314,7 @@ class TestApifyCommands:
         assert "Scraping complete!" in result.output
         assert "Retrieved 1 pages of content" in result.output
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_scrape_content_with_output(
         self, mock_get_injected_obj, runner, original_token, mock_apify_service
     ):
@@ -345,7 +345,7 @@ class TestApifyCommands:
             # Clean up
             os.unlink(output_file)
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_web_scraper(
         self, mock_get_injected_obj, runner, original_token, mock_apify_service
     ):
@@ -363,7 +363,7 @@ class TestApifyCommands:
         assert "Using selector: a, max pages: 5" in result.output
         assert "Retrieved 1 pages of data" in result.output
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_web_scraper_with_options(
         self, mock_get_injected_obj, runner, original_token, mock_apify_service
     ):
@@ -393,7 +393,7 @@ class TestApifyCommands:
         assert "Scraping website from https://example.com" in result.output
         assert "Using selector: article a, max pages: 10" in result.output
 
-    @patch("local_newsifier.cli.commands.apify.get_injected_obj")
+    @patch("local_newsifier.cli.cli_utils.load_dependency")
     def test_web_scraper_with_output(
         self, mock_get_injected_obj, runner, original_token, mock_apify_service
     ):

--- a/tests/cli/test_db.py
+++ b/tests/cli/test_db.py
@@ -26,7 +26,7 @@ def test_db_group():
     assert "purge-duplicates" in result.output
 
 
-@patch('local_newsifier.cli.commands.db.get_injected_obj')
+@patch('local_newsifier.cli.cli_utils.load_dependency')
 def test_db_stats_command(mock_get_injected_obj):
     """Test that the db stats command runs without errors using mocks."""
     # Set up mock session
@@ -56,7 +56,7 @@ def test_db_stats_command(mock_get_injected_obj):
     assert "RSS Feeds" in result.output
 
 
-@patch('local_newsifier.cli.commands.db.get_injected_obj')
+@patch('local_newsifier.cli.cli_utils.load_dependency')
 def test_db_duplicates_no_duplicates(mock_get_injected_obj):
     """Test that the db duplicates command handles case with no duplicates."""
     # Set up mock session
@@ -83,7 +83,7 @@ def test_db_duplicates_no_duplicates(mock_get_injected_obj):
     assert "No duplicate articles found" in result.output
 
 
-@patch('local_newsifier.cli.commands.db.get_injected_obj')
+@patch('local_newsifier.cli.cli_utils.load_dependency')
 def test_db_articles_no_articles(mock_get_injected_obj):
     """Test that the db articles command handles case with no articles."""
     # Set up mock session
@@ -110,7 +110,7 @@ def test_db_articles_no_articles(mock_get_injected_obj):
     assert "No articles found matching the criteria" in result.output
 
 
-@patch('local_newsifier.cli.commands.db.get_injected_obj')
+@patch('local_newsifier.cli.cli_utils.load_dependency')
 def test_db_inspect_article_not_found(mock_get_injected_obj):
     """Test that the db inspect command handles non-existent article."""
     # Set up mock session and article_crud
@@ -140,7 +140,7 @@ def test_db_inspect_article_not_found(mock_get_injected_obj):
     assert "not found" in result.output
 
 
-@patch('local_newsifier.cli.commands.db.get_injected_obj')
+@patch('local_newsifier.cli.cli_utils.load_dependency')
 def test_db_purge_duplicates_no_duplicates(mock_get_injected_obj):
     """Test that the purge-duplicates command handles case with no duplicates."""
     # Set up mock session and article_crud

--- a/tests/cli/test_db_comprehensive.py
+++ b/tests/cli/test_db_comprehensive.py
@@ -81,7 +81,7 @@ def mock_entity():
 class TestDBStats:
     """Tests for the db stats command."""
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_db_stats_with_data(self, mock_get_injected_obj, mock_article):
         """Test the db stats command with actual data."""
         # Set up mock session
@@ -105,7 +105,7 @@ class TestDBStats:
         assert "Active: 2" in result.output
         assert "Inactive: 1" in result.output
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_db_stats_json_output(self, mock_get_injected_obj, mock_article):
         """Test the db stats command with JSON output."""
         # Set up mock session
@@ -133,7 +133,7 @@ class TestDBStats:
 class TestDBDuplicates:
     """Tests for the db duplicates command."""
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_check_duplicates_with_duplicates(self, mock_get_injected_obj, mock_article):
         """Test the duplicates command when duplicates are found."""
         # Set up mock session
@@ -163,7 +163,7 @@ class TestDBDuplicates:
         assert "Number of duplicates: 2" in result.output
         assert "Number of duplicates: 3" in result.output
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_check_duplicates_json_output(self, mock_get_injected_obj, mock_article):
         """Test the duplicates command with JSON output."""
         # Set up mock session
@@ -195,7 +195,7 @@ class TestDBDuplicates:
 class TestDBArticles:
     """Tests for the db articles command."""
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_list_articles_with_results(self, mock_get_injected_obj, mock_article):
         """Test the articles command when articles are found."""
         # Set up mock session
@@ -216,7 +216,7 @@ class TestDBArticles:
         assert "Test Article" in result.output
         assert "https://example.com/test" in result.output
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_list_articles_with_filters(self, mock_get_injected_obj):
         """Test the articles command with various filters."""
         # Set up mock session
@@ -244,7 +244,7 @@ class TestDBArticles:
         assert result.exit_code == 0
         assert "No articles found matching the criteria" in result.output
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_list_articles_json_output(self, mock_get_injected_obj, mock_article):
         """Test the articles command with JSON output."""
         # Set up mock session
@@ -268,7 +268,7 @@ class TestDBArticles:
         assert output[0]["title"] == "Test Article"
         assert output[0]["url"] == "https://example.com/test"
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_list_articles_invalid_date(self, mock_get_injected_obj):
         """Test the articles command with invalid date format."""
         # Set up mock session
@@ -287,7 +287,7 @@ class TestDBArticles:
 class TestDBInspect:
     """Tests for the db inspect command."""
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_inspect_article_found(self, mock_get_injected_obj, mock_article):
         """Test the inspect command with a found article."""
         # Create mocks for session and crud
@@ -318,7 +318,7 @@ class TestDBInspect:
         assert "Test Article" in result.output
         assert "https://example.com/test" in result.output
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_inspect_rss_feed_found(self, mock_get_injected_obj, mock_feed, mock_feed_log):
         """Test the inspect command with a found RSS feed."""
         # Create mocks for session and crud
@@ -354,7 +354,7 @@ class TestDBInspect:
         assert "Recent Processing Logs" in result.output
         assert "success" in result.output
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_inspect_feed_log_found(self, mock_get_injected_obj, mock_feed_log):
         """Test the inspect command with a found feed log."""
         # Create mocks for session and crud
@@ -386,7 +386,7 @@ class TestDBInspect:
         assert "10" in result.output  # articles_found
         assert "5" in result.output   # articles_added
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_inspect_entity_found(self, mock_get_injected_obj, mock_entity):
         """Test the inspect command with a found entity."""
         # Create mocks for session and crud
@@ -417,7 +417,7 @@ class TestDBInspect:
         assert "Test Entity" in result.output
         assert "PERSON" in result.output
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_inspect_rss_feed_not_found(self, mock_get_injected_obj):
         """Test the inspect command with a non-existent RSS feed."""
         # Create mocks for session and crud
@@ -446,7 +446,7 @@ class TestDBInspect:
         assert result.exit_code == 0
         assert "Error: RSS Feed with ID 999 not found" in result.output
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_inspect_feed_log_not_found(self, mock_get_injected_obj):
         """Test the inspect command with a non-existent feed log."""
         # Create mocks for session and crud
@@ -475,7 +475,7 @@ class TestDBInspect:
         assert result.exit_code == 0
         assert "Error: Feed Processing Log with ID 999 not found" in result.output
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_inspect_entity_not_found(self, mock_get_injected_obj):
         """Test the inspect command with a non-existent entity."""
         # Create mocks for session and crud
@@ -504,7 +504,7 @@ class TestDBInspect:
         assert result.exit_code == 0
         assert "Error: Entity with ID 999 not found" in result.output
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_inspect_json_output(self, mock_get_injected_obj, mock_article):
         """Test the inspect command with JSON output."""
         # Create mocks for session and crud
@@ -542,7 +542,7 @@ class TestDBInspect:
 class TestDBPurgeDuplicates:
     """Tests for the db purge-duplicates command."""
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_purge_duplicates_with_duplicates(self, mock_get_injected_obj, mock_article):
         """Test the purge-duplicates command when duplicates are found."""
         # Set up mock session and mock article_crud
@@ -594,7 +594,7 @@ class TestDBPurgeDuplicates:
         # Verify session.commit was called
         mock_session.commit.assert_called_once()
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_purge_duplicates_dry_run(self, mock_get_injected_obj, mock_article):
         """Test the purge-duplicates command with dry run option."""
         # Set up mock session and mock article_crud
@@ -645,7 +645,7 @@ class TestDBPurgeDuplicates:
         # Verify session.commit was not called
         mock_session.commit.assert_not_called()
 
-    @patch('local_newsifier.cli.commands.db.get_injected_obj')
+    @patch('local_newsifier.cli.cli_utils.load_dependency')
     def test_purge_duplicates_json_output(self, mock_get_injected_obj, mock_article):
         """Test the purge-duplicates command with JSON output."""
         # Set up mock session and mock article_crud

--- a/tests/cli/test_injectable_cli.py
+++ b/tests/cli/test_injectable_cli.py
@@ -11,7 +11,7 @@ from local_newsifier.di.providers import get_apify_service_cli
 from local_newsifier.services.apify_service import ApifyService
 
 
-@patch('local_newsifier.cli.commands.apify.get_injected_obj')
+@patch('local_newsifier.cli.cli_utils.load_dependency')
 def test_apify_service_injection(mock_get_injected_obj):
     """Test the Apify service injection in CLI commands."""
     # Set up mock apify service
@@ -36,7 +36,7 @@ def test_apify_service_injection(mock_get_injected_obj):
     mock_get_injected_obj.assert_called_once()
 
 
-@patch('local_newsifier.cli.commands.db.get_injected_obj')
+@patch('local_newsifier.cli.cli_utils.load_dependency')
 def test_db_stats_integration(mock_get_injected_obj):
     """Test the db stats command with injectable dependencies."""
     # Create a side effect to handle different calls to get_injected_obj
@@ -75,7 +75,7 @@ def test_db_stats_integration(mock_get_injected_obj):
     assert "Database Statistics" in result.output
 
 
-@patch('local_newsifier.cli.commands.db.get_injected_obj')
+@patch('local_newsifier.cli.cli_utils.load_dependency')
 def test_db_articles_integration(mock_get_injected_obj):
     """Test the db articles command with injectable dependencies."""
     # Set up mock session and article crud


### PR DESCRIPTION
## Summary
- add `load_dependency` and `print_table` helpers
- refactor CLI commands to use new helpers
- update unit tests for new helper imports

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*