### PR TITLE
Remove legacy session utils

### DIFF
--- a/src/local_newsifier/database/CLAUDE.md
+++ b/src/local_newsifier/database/CLAUDE.md
@@ -11,9 +11,8 @@ The database module manages database connections, sessions, and transaction hand
 - Supports multiple database instances through environment variables
 
 ### Session Utilities
-- **session_utils.py**: Provides legacy session management utilities
-- Includes context managers and decorators for working with sessions
-- The project is transitioning to FastAPI-Injectable for session management
+- Legacy `session_utils.py` module has been removed
+- Use the `get_session` provider via FastAPI-Injectable for session management
 
 ## Database Connection Patterns
 

--- a/src/local_newsifier/database/session_utils.py
+++ b/src/local_newsifier/database/session_utils.py
@@ -1,8 +1,0 @@
-"""Legacy session utilities removed in favor of the standard provider."""
-
-# This module previously exposed ``get_container_session`` and
-# ``with_container_session`` helpers.  These have been deleted as part of the
-# migration to the ``get_session`` provider defined in
-# :mod:`local_newsifier.di.providers`.  Any code that relied on the old helpers
-# should import and use ``get_session`` directly.
-


### PR DESCRIPTION
## Summary
- drop the old `session_utils.py` module
- note the removal in the database guide

## Testing
- `poetry run pytest` *(fails: Command not found: pytest)*