### PR TITLE
Fix DI container message in trend analysis

### DIFF
--- a/src/local_newsifier/flows/trend_analysis_flow.py
+++ b/src/local_newsifier/flows/trend_analysis_flow.py
@@ -140,7 +140,7 @@ class NewsTrendAnalysisFlow(Flow):
                 raise RuntimeError(
                     "Cannot initialize AnalysisService without required dependencies. "
                     "Please provide an analysis_service instance or ensure the required "
-                    "dependencies are available through the DI container."
+                    "dependencies are available via fastapi-injectable providers."
                 )
         
         # For backwards compatibility with tests


### PR DESCRIPTION
## Summary
- update error message in `TrendAnalysisFlow` to mention `fastapi-injectable` providers

## Testing
- `poetry run pytest` *(fails: Command not found: pytest)*