### PR TITLE
Update test docs for providers

### DIFF
--- a/tests/api/test_dependencies.py
+++ b/tests/api/test_dependencies.py
@@ -41,14 +41,14 @@ class TestServiceDependencies:
     
     @pytest.mark.skip(reason="Integration test only - complex mocking needed")
     def test_get_article_service(self, event_loop_fixture, injectable_service_fixture):
-        """Test that get_article_service returns the service from the container."""
+        """Test that get_article_service returns the service from the injectable provider."""
         # This test is too complex to mock properly due to runtime imports in dependencies.py
         # The functionality is tested through integration tests
         pass
     
     @pytest.mark.skip(reason="Integration test only - complex mocking needed")
     def test_get_rss_feed_service(self, event_loop_fixture, injectable_service_fixture):
-        """Test that get_rss_feed_service returns the service from the container."""
+        """Test that get_rss_feed_service returns the service from the injectable provider."""
         # This test is too complex to mock properly due to runtime imports in dependencies.py
         # The functionality is tested through integration tests
         pass

--- a/tests/di/test_sentiment_analyzer_provider.py
+++ b/tests/di/test_sentiment_analyzer_provider.py
@@ -14,8 +14,8 @@ def mock_nlp():
 
 @pytest.fixture
 def mock_container(mock_nlp):
-    """Create a mock container with dependencies."""
-    # Add mock to container
+    """Create a mock provider environment with dependencies."""
+    # Inject the mock into the provider environment
     with patch("local_newsifier.di.providers.get_nlp_model", return_value=mock_nlp):
         yield None
 

--- a/tests/fixtures/event_loop.py
+++ b/tests/fixtures/event_loop.py
@@ -166,7 +166,7 @@ def injectable_service_fixture(event_loop_fixture):
     """
     # Define helper function to inject a service
     def get_injected_service(service_factory, *args, **kwargs):
-        """Get a service from the injected container with proper event loop handling.
+        """Get a service from an injectable provider with proper event loop handling.
         
         This function wraps the fastapi-injectable `get_injected_obj` function
         to ensure it runs in a proper event loop, falling back to a thread-specific


### PR DESCRIPTION
## Summary
- clarify test docstrings to note services come from injectable providers
- remove outdated container references in test fixtures

## Testing
- `poetry run pytest` *(fails: Command not found: pytest)*