### PR TITLE
Update Apify docs and CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ nf apify web-scraper https://example.com --selector "article a"
 
 # Get items from an Apify dataset
 nf apify get-dataset <dataset_id>
+
+# Manage stored configurations
+nf apify-config list
+nf apify-config add --name "Example" --actor-id apify/web-scraper --source-type news --schedule "0 8 * * *" --input input.json
+
+# Create or check schedules
+nf apify schedules create <config_id>
+nf apify schedules status <config_id>
 ```
 
 For detailed Apify integration documentation, see [docs/apify_integration.md](docs/apify_integration.md).

--- a/README_CLI.md
+++ b/README_CLI.md
@@ -164,6 +164,26 @@ poetry run nf apify get-dataset dataset_id
 poetry run nf apify get-dataset dataset_id --limit 20 --format table
 ```
 
+#### Manage Source Configurations
+
+```bash
+# List stored configurations
+poetry run nf apify-config list
+
+# Add a new configuration
+poetry run nf apify-config add --name "Example" --actor-id apify/web-scraper --source-type news --schedule "0 8 * * *" --input input.json
+```
+
+#### Manage Schedules
+
+```bash
+# Create a schedule for a config
+poetry run nf apify schedules create 1
+
+# Check schedule status
+poetry run nf apify schedules status 1
+```
+
 For more comprehensive documentation on Apify integration, see [docs/apify_integration.md](docs/apify_integration.md).
 
 ## Testing the CLI

--- a/docs/apify_integration.md
+++ b/docs/apify_integration.md
@@ -118,13 +118,15 @@ To add a new source for scraping with Apify:
    ```
 
 4. **Configure Database Entry**:
-   Once you've established a working configuration, you can add it to the database for regular scheduling. This typically involves:
+   Once you've established a working configuration, register it with the CLI so it can be scheduled automatically:
 
-   - Creating an `ApifySourceConfig` record with the actor ID and input configuration
-   - Setting up scheduling parameters
-   - Enabling the source
+   - Use `nf apify-config add` to create an `ApifySourceConfig` record with the actor ID and input configuration
+   - Set the cron schedule and mark the source as active
+   - Manage schedules with `nf apify schedules` (e.g., `create`, `status`, `update`)
 
-   *Note: Direct database configuration is currently managed through scripts or API. Dedicated CLI commands for managing Apify sources are planned for future releases.*
+   These commands persist the configuration in the `ApifySourceConfig` table and synchronize scheduling information with Apify.
+
+   After the configuration is stored, run `nf apify schedules create <CONFIG_ID>` to create the schedule in Apify and use `nf apify schedules update` to keep it synchronized with any changes.
 
 ## Scheduling & Webhooks
 


### PR DESCRIPTION
## Summary
- document `nf apify-config` and `nf apify schedules` commands
- explain how ApifySourceConfig works with scheduling
- show new CLI usage in README and README_CLI

## Testing
- `make test` *(fails: command returned non-zero exit status 127)*
- `poetry install` *(fails: all attempts to connect to pypi.org failed)*