### PR TITLE
Add wheelhouse workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,7 @@ Additional information is available in all Markdown files under the `docs/` dire
 - README_CLI.md
 
 If a new `CLAUDE.md` file is added or removed, update this document so Codex can locate every guide.
+
+## Wheelhouse
+
+Dependencies can be installed offline using pre-built wheels. Run `make build-wheels` on a machine with internet access to populate the `wheels/` directory, then install with `pip install --no-index --find-links=wheels -r requirements.txt`.

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 # Makefile for Local Newsifier project
 
-.PHONY: help install setup-poetry setup-spacy test lint format clean run-api run-worker run-beat run-all-celery
+.PHONY: help install setup-poetry setup-spacy build-wheels test lint format clean run-api run-worker run-beat run-all-celery
 
 help:
 	@echo "Available commands:"
 	@echo "  make install           - Install dependencies (legacy, use setup-poetry instead)"
 	@echo "  make setup-poetry      - Setup Poetry and install dependencies"
 	@echo "  make setup-spacy       - Install spaCy models"
+	@echo "  make build-wheels      - Download dependency wheels"
 	@echo "  make test              - Run tests in parallel (using all available CPU cores)"
-	@echo "  make test-serial        - Run tests serially (for debugging)"
+	@echo "  make test-serial       - Run tests serially (for debugging)"
 	@echo "  make lint              - Run linting"
 	@echo "  make format            - Format code"
 	@echo "  make clean             - Clean build artifacts"
@@ -33,6 +34,11 @@ setup-spacy:
 	poetry run python -m spacy download en_core_web_sm
 	poetry run python -m spacy download en_core_web_lg
 	@echo "spaCy models installed successfully"
+
+# Build dependency wheels for offline installation
+build-wheels:
+	@echo "Building wheels into ./wheels..."
+	./scripts/build_wheels.sh
 
 # Testing
 test:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ curl -sSL https://install.python-poetry.org | python3 -
 poetry install
 ```
 
+If your environment lacks internet access, generate the wheels directory on a
+connected machine first:
+
+```bash
+make build-wheels
+```
+
+Copy the resulting `wheels/` directory and install from it locally:
+
+```bash
+pip install --no-index --find-links=wheels -r requirements.txt
+```
+
 3. Download spaCy model:
 ```bash
 poetry run python -m spacy download en_core_web_lg

--- a/docs/python_setup.md
+++ b/docs/python_setup.md
@@ -23,6 +23,22 @@ poetry shell
 make setup-spacy
 ```
 
+### Offline Installation
+
+If your deployment environment cannot reach PyPI, build dependency wheels on a
+machine with internet access:
+
+```bash
+make build-wheels
+```
+
+Copy the generated `wheels/` directory to the target machine and install
+packages locally:
+
+```bash
+pip install --no-index --find-links=wheels -r requirements.txt
+```
+
 If you need to manually select a specific Python version for Poetry to use:
 
 ```bash

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Build wheels for dependencies in requirements.txt
+# Usage: ./scripts/build_wheels.sh
+
+set -e
+
+WHEELS_DIR="wheels"
+mkdir -p "$WHEELS_DIR"
+
+echo "Downloading wheels to $WHEELS_DIR..."
+pip wheel -r requirements.txt -w "$WHEELS_DIR"
+echo "Wheels stored in $WHEELS_DIR"


### PR DESCRIPTION
## Summary
- add build_wheels.sh helper script
- document offline wheel usage in README and python setup guide
- add build-wheels make target
- note wheelhouse process in AGENTS

## Testing
- `make test` *(fails: Command not found: pytest)*