### PR TITLE
Remove legacy session docs

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -166,14 +166,21 @@ class ApifyService:
 ```
 
 ### Session Management
-- Use context managers for database sessions:
+Use the `get_session` provider to obtain a database session:
 ```python
-with SessionManager() as session:
+from typing import Annotated, Generator
+from fastapi import Depends
+from sqlmodel import Session
+
+from local_newsifier.di.providers import get_session
+
+async def some_endpoint(
+    session: Annotated[Session, Depends(get_session)]
+):
     # Database operations here
-    # Session is committed on exit, or rolled back on exception
 ```
 
-- For service methods:
+For service methods:
 ```python
 with self.session_factory() as session:
     # Use session for database operations

--- a/docs/dependency_injection_antipatterns.md
+++ b/docs/dependency_injection_antipatterns.md
@@ -320,9 +320,10 @@ When reviewing code, look for these warning signs:
 6. Complex code executed at module level
 7. Multiple different ways to access the same dependency
 
-## Converting Legacy Code
+## Converting Legacy Code (completed)
 
-When updating old code that still references the former container:
+The migration to `fastapi-injectable` is finished. The steps below are preserved
+for historical reference only:
 
 1. Create provider functions in `di/providers.py` with appropriate scope
 2. Update code to use these providers instead of direct instantiation

--- a/docs/di_conversion_plan.md
+++ b/docs/di_conversion_plan.md
@@ -1,12 +1,14 @@
 # Dependency Injection Conversion Plan
 
+**Status:** Completed
+
 This document summarizes the plan that was used to complete the dependency injection (DI) conversion across the Local Newsifier codebase.
 
 ## Overview
 
 All components now use the `fastapi-injectable` framework. Provider functions and injectable classes are in place across the codebase.
 
-## Areas for Conversion
+## Areas for Conversion (All Completed)
 
 ### 1. Flow Classes
 
@@ -14,11 +16,11 @@ Flow classes are central to the application's business logic and need to be full
 
 | Class | Current Status | Tasks |
 |-------|---------------|-------|
-| `EntityTrackingFlow` | Basic integration | - Update constructor to accept dependencies<br>- Add provider function<br>- Update tests |
-| `NewsPipelineFlow` | Basic integration | - Update constructor to accept dependencies<br>- Add provider function<br>- Update tests |
-| `TrendAnalysisFlow` | Not integrated | - Update constructor to accept dependencies<br>- Add provider function<br>- Update tests |
-| `PublicOpinionFlow` | Not integrated | - Update constructor to accept dependencies<br>- Add provider function<br>- Update tests |
-| `RSSScrapingFlow` | Partial integration | - Complete constructor parameters<br>- Update tests |
+| `EntityTrackingFlow` | Completed | — |
+| `NewsPipelineFlow` | Completed | — |
+| `TrendAnalysisFlow` | Completed | — |
+| `PublicOpinionFlow` | Completed | — |
+| `RSSScrapingFlow` | Completed | — |
 
 ### 2. Tool Classes
 
@@ -26,13 +28,13 @@ Tool classes provide utilities used throughout the application and should be exp
 
 | Tool | Current Status | Tasks |
 |------|---------------|-------|
-| `RSSParser` | Registered | - Update instantiation to use provider functions |
-| `WebScraper` | Registered | - Update instantiation to use provider functions |
-| `SentimentAnalyzer` | Not registered | - Add provider function<br>- Update usages |
-| `EntityExtractor` | Not registered | - Add provider function<br>- Update usages |
-| `EntityResolver` | Not registered | - Add provider function<br>- Update usages |
-| `FileWriter` | Not registered | - Add provider function<br>- Update usages |
-| `TrendReporter` | Not registered | - Add provider function<br>- Update usages |
+| `RSSParser` | Completed | — |
+| `WebScraper` | Completed | — |
+| `SentimentAnalyzer` | Completed | — |
+| `EntityExtractor` | Completed | — |
+| `EntityResolver` | Completed | — |
+| `FileWriter` | Completed | — |
+| `TrendReporter` | Completed | — |
 
 ### 3. API Dependencies
 
@@ -40,9 +42,9 @@ API dependencies provide FastAPI integration points that need proper DI usage.
 
 | API Component | Current Status | Tasks |
 |--------------|---------------|-------|
-| API Dependencies | Basic integration | - Review all dependencies<br>- Ensure consistent patterns<br>- Add missing dependencies |
-| API Routes | Varied integration | - Ensure all routes use dependencies<br>- Review manual instantiation |
-| API Middleware | Not integrated | - Implement request scoping |
+| API Dependencies | Completed | — |
+| API Routes | Completed | — |
+| API Middleware | Completed | — |
 
 ### 4. Testing Infrastructure
 
@@ -50,33 +52,33 @@ Testing infrastructure needs to support easy mocking of provider functions and i
 
 | Component | Current Status | Tasks |
 |-----------|---------------|-------|
-| Test Fixtures | Basic fixtures | - Create injectable fixtures<br>- Add service mocking helpers |
-| Mock Services | Manual mocking | - Standardize service mocking pattern |
-| Test Isolation | Manual setup | - Implement dependency overrides<br>- Reset providers between tests |
+| Test Fixtures | Completed | — |
+| Mock Services | Completed | — |
+| Test Isolation | Completed | — |
 
 ## Implementation Phases
 
-### Phase 1: Complete Flow Classes Integration
+### Phase 1: Complete Flow Classes Integration (completed)
 
 1. Update each flow class to accept dependencies via constructor
 2. Create provider functions for each flow
 3. Update tests to use the provider functions
 4. Ensure circular dependencies are handled properly
 
-### Phase 2: Tool Registration and Usage
+### Phase 2: Tool Registration and Usage (completed)
 
 1. Create provider functions for all tools
 2. Update code that directly instantiates tools to use injection
 3. Implement appropriate fallbacks for direct usage
 4. Add tests for provider-based tool usage
 
-### Phase 3: Refine API Dependencies
+### Phase 3: Refine API Dependencies (completed)
 
 1. Review API dependencies for consistent patterns
 2. Implement request scoping for web requests
 3. Update API tests to use dependency overrides
 
-### Phase 4: Enhance Testing Infrastructure
+### Phase 4: Enhance Testing Infrastructure (completed)
 
 1. Create standardized test fixtures for injectable usage
 2. Implement helpers for service mocking in tests

--- a/docs/injectable_patterns.md
+++ b/docs/injectable_patterns.md
@@ -355,7 +355,7 @@ Follow these steps to create an injectable component:
 
 #### Service Migration Example
 
-**Before:**
+**Before (legacy pattern using `SessionManager`):**
 ```python
 class ArticleService:
     def __init__(self, article_crud=None, session_factory=None):

--- a/src/local_newsifier/database/CLAUDE.md
+++ b/src/local_newsifier/database/CLAUDE.md
@@ -192,18 +192,6 @@ def get_database_url():
               # Use session for database operations
   ```
 
-- For legacy components, use context managers for session handling:
-  ```python
-  with SessionManager() as session:
-      # Use session for database operations
-  ```
-
-- For decorated functions that need a session, use the `with_session` decorator:
-  ```python
-  @with_session
-  def my_function(session, other_args):
-      # Use session for database operations
-  ```
 
 ### Transaction Management
 - By default, sessions are committed at the end of the context manager


### PR DESCRIPTION
## Summary
- drop section recommending SessionManager in database guide
- refresh session docs in claude.md
- mark DI conversion plan as completed
- clarify legacy references in docs

## Testing
- `make test` *(fails: python not found)*