### PR TITLE
Implement simple background task API

### DIFF
--- a/src/local_newsifier/api/routers/tasks.py
+++ b/src/local_newsifier/api/routers/tasks.py
@@ -1,43 +1,86 @@
-"""
-API router for Celery task management.
-This module provides endpoints for submitting, checking, and managing asynchronous tasks.
+"""Task management API router.
+
+This router exposes simple endpoints for creating and tracking background
+jobs executed using FastAPI's ``BackgroundTasks`` utility. Tasks are stored in a
+process-local dictionary and are not persisted between restarts.
 """
 
-from typing import Annotated, Dict, List, Optional, Union
+from __future__ import annotations
 
-from celery.result import AsyncResult
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+)
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel
 
 from local_newsifier.api.dependencies import (
     get_templates,
-    get_session,
-    get_article_service,
-    get_rss_feed_service,
 )
-from local_newsifier.celery_app import app as celery_app
 from local_newsifier.config.settings import settings
-from local_newsifier.services.article_service import ArticleService
-from local_newsifier.services.rss_feed_service import RSSFeedService
-from local_newsifier.tasks import (
-    fetch_rss_feeds,
-    process_article,
-)
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 
-@router.get("/", response_class=HTMLResponse)
-async def tasks_dashboard(
-    request: Request, 
-    templates: Jinja2Templates = Depends(get_templates)
-):
-    """
-    Task management dashboard.
+class TaskRecord(BaseModel):
+    """Representation of a background task."""
 
-    Provides a web interface for submitting and monitoring tasks.
-    """
+    id: str
+    name: str
+    status: str
+    created_at: datetime
+    result: Optional[Any] = None
+    error: Optional[str] = None
+
+
+# In-memory task storage
+TASK_STORE: Dict[str, TaskRecord] = {}
+
+
+def _run_process_article(task_id: str, article_id: int) -> None:
+    """Background worker for ``process_article``."""
+    record = TASK_STORE[task_id]
+    record.status = "running"
+    try:
+        from local_newsifier.tasks import process_article
+
+        record.result = process_article.run(article_id)
+        record.status = "completed"
+    except Exception as exc:  # pragma: no cover - defensive
+        record.status = "failed"
+        record.error = str(exc)
+
+
+def _run_fetch_rss_feeds(task_id: str, feed_urls: List[str]) -> None:
+    """Background worker for ``fetch_rss_feeds``."""
+    record = TASK_STORE[task_id]
+    record.status = "running"
+    try:
+        from local_newsifier.tasks import fetch_rss_feeds
+
+        record.result = fetch_rss_feeds.run(feed_urls)
+        record.status = "completed"
+    except Exception as exc:  # pragma: no cover - defensive
+        record.status = "failed"
+        record.error = str(exc)
+
+
+@router.get("/dashboard", response_class=HTMLResponse)
+async def tasks_dashboard(
+    request: Request,
+    templates: Jinja2Templates = Depends(get_templates),
+):
+    """Render the task management dashboard."""
     return templates.TemplateResponse(
         "tasks_dashboard.html",
         {
@@ -48,115 +91,67 @@ async def tasks_dashboard(
     )
 
 
-@router.post("/process-article/{article_id}")
-async def process_article_endpoint(
-    article_id: int = Path(..., title="Article ID", description="ID of the article to process"),
-    article_service: ArticleService = Depends(get_article_service),
-):
-    """
-    Submit a task to process an article asynchronously.
-
-    Args:
-        article_id: ID of the article to process
-
-    Returns:
-        Task information including task ID
-    """
-    # Verify article exists
-    article = article_service.get_article(article_id)
-    if not article:
-        raise HTTPException(status_code=404, detail=f"Article with ID {article_id} not found")
-
-    # Submit task
-    task = process_article.delay(article_id)
-    
-    return {
-        "task_id": task.id,
-        "article_id": article_id,
-        "article_title": article.title,
-        "status": "queued",
-        "task_url": f"/tasks/status/{task.id}",
-    }
+@router.get("", response_model=List[TaskRecord])
+async def list_tasks(
+    status: Optional[str] = Query(None, description="Filter tasks by status"),
+    limit: int = Query(100, gt=0, le=1000, description="Maximum number of records"),
+) -> List[TaskRecord]:
+    """Return tasks with optional status filtering."""
+    records = list(TASK_STORE.values())
+    if status:
+        records = [t for t in records if t.status == status]
+    records.sort(key=lambda r: r.created_at, reverse=True)
+    return records[:limit]
 
 
-@router.post("/fetch-rss-feeds")
-async def fetch_rss_feeds_endpoint(
-    feed_urls: Optional[List[str]] = Query(None, description="List of RSS feed URLs to process"),
-    rss_feed_service: RSSFeedService = Depends(get_rss_feed_service),
-):
-    """
-    Submit a task to fetch articles from RSS feeds.
-
-    Args:
-        feed_urls: Optional list of RSS feed URLs. If not provided, uses default feeds from settings.
-        rss_feed_service: RSS feed service provided by dependency injection
-
-    Returns:
-        Task information including task ID
-    """
-    if not feed_urls:
-        feed_urls = settings.RSS_FEED_URLS
-
-    task = fetch_rss_feeds.delay(feed_urls)
-    
-    return {
-        "task_id": task.id,
-        "feed_count": len(feed_urls),
-        "status": "queued",
-        "task_url": f"/tasks/status/{task.id}",
-    }
+@router.get("/{task_id}", response_model=TaskRecord)
+async def get_task(task_id: str = Path(..., description="Task identifier")) -> TaskRecord:
+    """Retrieve a single task."""
+    task = TASK_STORE.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return task
 
 
-@router.get("/status/{task_id}")
-async def get_task_status(
-    task_id: str = Path(..., title="Task ID", description="ID of the task to check status for")
-):
-    """
-    Check the status of a task.
+@router.post("/{task_name}", response_model=TaskRecord)
+async def create_task(
+    background_tasks: BackgroundTasks,
+    task_name: str = Path(..., description="Name of the task to run"),
+    article_id: Optional[int] = Query(None, description="Article ID for process_article"),
+    feed_urls: Optional[List[str]] = Query(None, description="Feed URLs for fetch_rss_feeds"),
+) -> TaskRecord:
+    """Create and queue a new task."""
+    if task_name not in {"process_article", "fetch_rss_feeds"}:
+        raise HTTPException(status_code=404, detail="Unknown task")
 
-    Args:
-        task_id: ID of the task to check
+    task_id = str(uuid4())
+    record = TaskRecord(
+        id=task_id,
+        name=task_name,
+        status="queued",
+        created_at=datetime.now(timezone.utc),
+    )
+    TASK_STORE[task_id] = record
 
-    Returns:
-        Task status information
-    """
-    task_result = AsyncResult(task_id, app=celery_app)
-    
-    result = {
-        "task_id": task_id,
-        "status": task_result.status,
-    }
-    
-    # Add additional info based on task state
-    if task_result.successful():
-        result["result"] = task_result.result
-    elif task_result.failed():
-        result["error"] = str(task_result.result)
-    elif task_result.status == "PROGRESS":
-        result["progress"] = task_result.info
-        
-    return result
+    if task_name == "process_article":
+        if article_id is None:
+            raise HTTPException(status_code=400, detail="article_id required")
+        background_tasks.add_task(_run_process_article, task_id, article_id)
+    else:  # fetch_rss_feeds
+        urls = feed_urls or settings.RSS_FEED_URLS
+        background_tasks.add_task(_run_fetch_rss_feeds, task_id, urls)
+
+    return record
 
 
-@router.delete("/cancel/{task_id}")
-async def cancel_task(
-    task_id: str = Path(..., title="Task ID", description="ID of the task to cancel")
-):
-    """
-    Cancel a running task.
+@router.delete("/{task_id}", response_model=TaskRecord)
+async def cancel_task(task_id: str = Path(..., description="Task identifier")) -> TaskRecord:
+    """Mark a task as cancelled if it has not finished."""
+    task = TASK_STORE.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    if task.status in {"completed", "failed", "cancelled"}:
+        return task
+    task.status = "cancelled"
+    return task
 
-    Args:
-        task_id: ID of the task to cancel
-
-    Returns:
-        Confirmation message
-    """
-    task_result = AsyncResult(task_id, app=celery_app)
-    
-    if task_result.successful() or task_result.failed():
-        return {"message": f"Task {task_id} already completed"}
-        
-    # Attempt to revoke the task
-    celery_app.control.revoke(task_id, terminate=True)
-    
-    return {"message": f"Task {task_id} revoke signal sent"}

--- a/src/local_newsifier/api/templates/tasks_dashboard.html
+++ b/src/local_newsifier/api/templates/tasks_dashboard.html
@@ -119,17 +119,14 @@ document.getElementById('process-article-form').addEventListener('submit', async
     const articleId = document.getElementById('article-id').value;
     
     try {
-        const response = await fetch(`/tasks/process-article/${articleId}`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            }
+        const response = await fetch(`/tasks/process_article?article_id=${articleId}`, {
+            method: 'POST'
         });
         
         const result = await response.json();
         if (response.ok) {
-            addRecentTask(result.task_id, 'Process Article', result.article_title || `Article #${articleId}`, 'queued');
-            checkTaskStatus(result.task_id);
+            addRecentTask(result.id, 'process_article', `Article #${articleId}`, result.status);
+            checkTaskStatus(result.id);
         } else {
             showError(result.detail || 'Failed to submit task');
         }
@@ -165,8 +162,8 @@ document.getElementById('fetch-rss-form').addEventListener('submit', async funct
         
         const result = await response.json();
         if (response.ok) {
-            addRecentTask(result.task_id, 'Fetch RSS Feeds', `${result.feed_count} feeds`, 'queued');
-            checkTaskStatus(result.task_id);
+            addRecentTask(result.id, 'fetch_rss_feeds', `${feedUrls.length || 'default'} feeds`, result.status);
+            checkTaskStatus(result.id);
         } else {
             showError(result.detail || 'Failed to submit task');
         }
@@ -194,7 +191,7 @@ document.getElementById('cancel-task-button').addEventListener('click', async fu
     }
     
     try {
-        const response = await fetch(`/tasks/cancel/${taskId}`, {
+        const response = await fetch(`/tasks/${taskId}`, {
             method: 'DELETE'
         });
         
@@ -202,7 +199,7 @@ document.getElementById('cancel-task-button').addEventListener('click', async fu
         showTaskResult(result);
         
         // Update the task in the recent tasks list
-        updateRecentTaskStatus(taskId, 'canceled');
+        updateRecentTaskStatus(taskId, 'cancelled');
     } catch (error) {
         showError('Error: ' + error.message);
     }
@@ -213,7 +210,7 @@ async function checkTaskStatus(taskId) {
     try {
         document.getElementById('task-id').value = taskId;
         
-        const response = await fetch(`/tasks/status/${taskId}`);
+        const response = await fetch(`/tasks/${taskId}`);
         const result = await response.json();
         
         showTaskResult(result);
@@ -222,7 +219,7 @@ async function checkTaskStatus(taskId) {
         updateRecentTaskStatus(taskId, result.status);
         
         // If task is still running, check again in 2 seconds
-        if (result.status === 'PENDING' || result.status === 'STARTED' || result.status === 'PROGRESS') {
+        if (result.status === 'queued' || result.status === 'running') {
             setTimeout(() => checkTaskStatus(taskId), 2000);
         }
     } catch (error) {
@@ -245,12 +242,12 @@ function showTaskResult(result) {
             <h5>Task Completed Successfully</h5>
             <pre class="mt-3">${JSON.stringify(result.result, null, 2)}</pre>
         </div>`;
-    } else if (result.status === 'PROGRESS') {
+    } else if (result.status === 'running') {
         html = `<div class="alert alert-info">
             <h5>Task In Progress</h5>
             <pre class="mt-3">${JSON.stringify(result.progress, null, 2)}</pre>
         </div>`;
-    } else if (result.status === 'PENDING' || result.status === 'STARTED') {
+    } else if (result.status === 'queued' || result.status === 'running') {
         html = `<div class="alert alert-warning">
             <h5>Task Pending or Starting</h5>
             <p>Task ID: ${result.task_id}</p>
@@ -337,16 +334,14 @@ function updateRecentTasksDisplay() {
             case 'failed':
                 statusBadge = '<span class="badge bg-danger">Failed</span>';
                 break;
-            case 'progress':
+            case 'running':
                 statusBadge = '<span class="badge bg-info">In Progress</span>';
                 break;
-            case 'pending':
-            case 'started':
-                statusBadge = '<span class="badge bg-warning">Pending</span>';
+            case 'queued':
+                statusBadge = '<span class="badge bg-warning">Queued</span>';
                 break;
-            case 'canceled':
-            case 'revoked':
-                statusBadge = '<span class="badge bg-secondary">Canceled</span>';
+            case 'cancelled':
+                statusBadge = '<span class="badge bg-secondary">Cancelled</span>';
                 break;
             default:
                 statusBadge = `<span class="badge bg-secondary">${task.status}</span>`;

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -1,23 +1,23 @@
-"""Tests for API tasks router."""
-import json
-from unittest.mock import MagicMock, Mock, patch
+"""Tests for task API endpoints."""
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlmodel import Session
+from unittest.mock import patch
+import pytest
 
-from tests.fixtures.event_loop import event_loop_fixture
-from tests.ci_skip_config import ci_skip_async
-
-from local_newsifier.api.dependencies import get_templates, get_session, get_article_service, get_rss_feed_service
+from local_newsifier.api.routers import tasks as tasks_router
 from local_newsifier.api.routers.tasks import router
-from local_newsifier.models.article import Article
+
+
+@pytest.fixture(autouse=True)
+def clear_store():
+    tasks_router.TASK_STORE.clear()
+    yield
+    tasks_router.TASK_STORE.clear()
 
 
 @pytest.fixture
 def app():
-    """Create FastAPI app for testing."""
     app = FastAPI()
     app.include_router(router)
     return app
@@ -25,440 +25,50 @@ def app():
 
 @pytest.fixture
 def client(app):
-    """Create test client."""
     return TestClient(app)
 
 
-@pytest.fixture
-def mock_templates():
-    """Mock templates."""
-    mock = MagicMock()
-    mock.TemplateResponse.return_value = "mocked template response"
-    return mock
+def test_tasks_dashboard(client):
+    with patch("local_newsifier.api.routers.tasks.get_templates") as gt:
+        tmpl = gt.return_value
+        tmpl.TemplateResponse.return_value = "ok"
+        resp = client.get("/tasks/dashboard")
+        assert resp.status_code == 200
+        tmpl.TemplateResponse.assert_called_once()
 
 
-@pytest.fixture
-def mock_settings():
-    """Mock settings."""
-    mock = MagicMock()
-    mock.RSS_FEED_URLS = ["https://example.com/rss1", "https://example.com/rss2"]
-    return mock
+def test_create_and_get_task(client):
+    with patch("local_newsifier.api.routers.tasks._run_process_article") as run:
+        resp = client.post("/tasks/process_article", params={"article_id": 1})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "process_article"
+        task_id = data["id"]
+        run.assert_called_once()
+
+    get_resp = client.get(f"/tasks/{task_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["id"] == task_id
 
 
-@pytest.fixture
-def mock_celery_app():
-    """Mock Celery app."""
-    mock = MagicMock()
-    mock.control = MagicMock()
-    mock.control.revoke = MagicMock()
-    return mock
-
-
-@pytest.fixture
-def mock_async_result():
-    """Mock AsyncResult."""
-    mock = MagicMock()
-    return mock
-
-
-@pytest.fixture
-def mock_task():
-    """Mock task object."""
-    mock = MagicMock()
-    mock.id = "test-task-id"
-    mock.delay.return_value = mock
-    return mock
-
-
-@pytest.fixture
-def mock_session():
-    """Mock database session."""
-    mock = MagicMock(spec=Session)
-    return mock
-
-
-@pytest.fixture
-def mock_article_service():
-    """Mock article service."""
-    mock = MagicMock()
-    return mock
-
-
-@pytest.fixture
-def mock_rss_feed_service():
-    """Mock RSS feed service."""
-    mock = MagicMock()
-    return mock
-
-
-@pytest.fixture
-def sample_article():
-    """Sample article fixture."""
-    return Article(
-        id=123,
-        title="Test Article",
-        content="This is a test article content",
-        url="https://example.com/article",
+def test_list_tasks_filter(client):
+    tasks_router.TASK_STORE["a"] = tasks_router.TaskRecord(
+        id="a", name="t1", status="queued", created_at=tasks_router.datetime.now(tasks_router.timezone.utc)
+    )
+    tasks_router.TASK_STORE["b"] = tasks_router.TaskRecord(
+        id="b", name="t2", status="completed", created_at=tasks_router.datetime.now(tasks_router.timezone.utc)
     )
 
-
-class TestTasksDashboard:
-    """Tests for tasks dashboard endpoint."""
-
-    @patch("local_newsifier.api.routers.tasks.settings", autospec=True)
-    @patch("local_newsifier.api.routers.tasks.get_templates", return_value=None)
-    def test_tasks_dashboard(self, mock_get_templates, mock_settings_module, client, mock_templates):
-        """Test tasks dashboard returns template response."""
-        # Set up the mock
-        mock_settings_module.RSS_FEED_URLS = ["https://example.com/feed"]
-        mock_get_templates.return_value = mock_templates
-
-        # Register the dependency override
-        client.app.dependency_overrides[get_templates] = lambda: mock_templates
-
-        # Make the request
-        response = client.get("/tasks/")
-
-        # Verify response
-        assert response.status_code == 200
-
-        # Verify that the template was rendered with the correct context
-        mock_templates.TemplateResponse.assert_called_once()
-        template_name, context = mock_templates.TemplateResponse.call_args[0]
-        assert template_name == "tasks_dashboard.html"
-        assert context["title"] == "Task Dashboard"
-        assert context["rss_feed_urls"] == mock_settings_module.RSS_FEED_URLS
-
-        # Clean up
-        client.app.dependency_overrides = {}
-
-
-class TestProcessArticle:
-    """Tests for process article endpoint."""
-
-    # Keep the ci_skip_async decorator for this test until we can fully fix it
-    @ci_skip_async
-    @patch("local_newsifier.api.routers.tasks.process_article", autospec=True)
-    def test_process_article_success(
-        self, mock_process_article, client, mock_article_service, sample_article, event_loop_fixture
-    ):
-        """Test successful article processing."""
-        # Set up mocks
-        mock_article_service.get_article.return_value = sample_article
-        
-        mock_task = MagicMock()
-        mock_task.id = "test-task-id"
-        mock_process_article.delay.return_value = mock_task
-
-        # Register the dependency override
-        client.app.dependency_overrides[get_article_service] = lambda: mock_article_service
-
-        # Make the request
-        article_id = 123
-        response = client.post(f"/tasks/process-article/{article_id}")
-
-        # Verify response
-        assert response.status_code == 200
-        response_data = response.json()
-        assert response_data["task_id"] == "test-task-id"
-        assert response_data["article_id"] == article_id
-        assert response_data["article_title"] == sample_article.title
-        assert response_data["status"] == "queued"
-        assert response_data["task_url"] == f"/tasks/status/test-task-id"
-
-        # Verify mocks were called
-        mock_article_service.get_article.assert_called_once_with(article_id)
-        mock_process_article.delay.assert_called_once_with(article_id)
-
-        # Clean up
-        client.app.dependency_overrides = {}
-
-    def test_process_article_not_found(self, client, mock_article_service):
-        """Test article not found error."""
-        # Set up mocks
-        mock_article_service.get_article.return_value = None
-        
-        # Register the dependency override
-        client.app.dependency_overrides[get_article_service] = lambda: mock_article_service
-
-        # Make the request
-        article_id = 999
-        response = client.post(f"/tasks/process-article/{article_id}")
-
-        # Verify response
-        assert response.status_code == 404
-        response_data = response.json()
-        assert "detail" in response_data
-        assert f"Article with ID {article_id} not found" in response_data["detail"]
-
-        # Clean up
-        client.app.dependency_overrides = {}
-
-
-class TestFetchRSSFeeds:
-    """Tests for fetch RSS feeds endpoint."""
-
-    @ci_skip_async
-    @patch("local_newsifier.api.routers.tasks.fetch_rss_feeds", autospec=True)
-    @patch("local_newsifier.api.routers.tasks.settings", autospec=True)
-    def test_fetch_rss_feeds_default(
-        self, mock_settings, mock_fetch_rss_feeds, client, mock_rss_feed_service, event_loop_fixture
-    ):
-        """Test fetching RSS feeds with default URLs from settings."""
-        # Set up mocks
-        mock_settings.RSS_FEED_URLS = ["https://example.com/rss1", "https://example.com/rss2"]
-        
-        mock_task = MagicMock()
-        mock_task.id = "test-task-id"
-        mock_fetch_rss_feeds.delay.return_value = mock_task
-
-        # Patch all async operations to avoid event loop issues
-        with patch("fastapi_injectable.concurrency.run_coroutine_sync", return_value=mock_rss_feed_service), \
-             patch("fastapi_injectable.main.solve_dependencies", return_value=mock_rss_feed_service), \
-             patch("asyncio.get_event_loop", return_value=event_loop_fixture):
-        
-            # Register the dependency override
-            client.app.dependency_overrides[get_rss_feed_service] = lambda: mock_rss_feed_service
-
-            # Make the request
-            response = client.post("/tasks/fetch-rss-feeds")
-
-            # Verify response
-            assert response.status_code == 200
-            response_data = response.json()
-            assert response_data["task_id"] == "test-task-id"
-            assert response_data["feed_count"] == len(mock_settings.RSS_FEED_URLS)
-            assert response_data["status"] == "queued"
-            assert response_data["task_url"] == f"/tasks/status/test-task-id"
-
-            # Verify mocks were called
-            mock_fetch_rss_feeds.delay.assert_called_once_with(mock_settings.RSS_FEED_URLS)
-
-            # Clean up
-            client.app.dependency_overrides = {}
-
-    @ci_skip_async
-    @patch("local_newsifier.api.routers.tasks.fetch_rss_feeds", autospec=True)
-    def test_fetch_rss_feeds_custom_urls(
-        self, mock_fetch_rss_feeds, client, mock_rss_feed_service, event_loop_fixture
-    ):
-        """Test fetching RSS feeds with custom URLs."""
-        # Set up mocks
-        custom_feeds = ["https://custom.com/feed1", "https://custom.com/feed2", "https://custom.com/feed3"]
-        
-        mock_task = MagicMock()
-        mock_task.id = "test-task-id"
-        mock_fetch_rss_feeds.delay.return_value = mock_task
-
-        # Patch all async operations to avoid event loop issues
-        with patch("fastapi_injectable.concurrency.run_coroutine_sync", return_value=mock_rss_feed_service), \
-             patch("fastapi_injectable.main.solve_dependencies", return_value=mock_rss_feed_service), \
-             patch("asyncio.get_event_loop", return_value=event_loop_fixture):
-        
-            # Register the dependency override
-            client.app.dependency_overrides[get_rss_feed_service] = lambda: mock_rss_feed_service
-
-            # Make the request
-            response = client.post("/tasks/fetch-rss-feeds", params={"feed_urls": custom_feeds})
-
-            # Verify response
-            assert response.status_code == 200
-            response_data = response.json()
-            assert response_data["task_id"] == "test-task-id"
-            assert response_data["feed_count"] == len(custom_feeds)
-            assert response_data["status"] == "queued"
-            assert response_data["task_url"] == f"/tasks/status/test-task-id"
-
-            # Verify mocks were called
-            mock_fetch_rss_feeds.delay.assert_called_once_with(custom_feeds)
-
-            # Clean up
-            client.app.dependency_overrides = {}
-
-
-class TestTaskStatus:
-    """Tests for task status endpoint."""
-
-    @patch("local_newsifier.api.routers.tasks.AsyncResult", autospec=True)
-    @patch("local_newsifier.api.routers.tasks.celery_app", autospec=True)
-    def test_get_task_status_pending(self, mock_celery_app, mock_async_result_class, client):
-        """Test getting status of a pending task."""
-        # Set up mocks
-        mock_result = MagicMock()
-        mock_result.status = "PENDING"
-        mock_result.successful.return_value = False
-        mock_result.failed.return_value = False
-        mock_async_result_class.return_value = mock_result
-
-        # Make the request
-        task_id = "test-task-id"
-        response = client.get(f"/tasks/status/{task_id}")
-
-        # Verify response
-        assert response.status_code == 200
-        response_data = response.json()
-        assert response_data["task_id"] == task_id
-        assert response_data["status"] == "PENDING"
-        assert "result" not in response_data
-        assert "error" not in response_data
-
-        # Verify mocks were called
-        mock_async_result_class.assert_called_once_with(task_id, app=mock_celery_app)
-
-    @patch("local_newsifier.api.routers.tasks.AsyncResult", autospec=True)
-    @patch("local_newsifier.api.routers.tasks.celery_app", autospec=True)
-    def test_get_task_status_success(self, mock_celery_app, mock_async_result_class, client):
-        """Test getting status of a successful task."""
-        # Set up mocks
-        mock_result = MagicMock()
-        mock_result.status = "SUCCESS"
-        mock_result.successful.return_value = True
-        mock_result.failed.return_value = False
-        mock_result.result = {"processed": 5, "skipped": 2}
-        mock_async_result_class.return_value = mock_result
-
-        # Make the request
-        task_id = "test-task-id"
-        response = client.get(f"/tasks/status/{task_id}")
-
-        # Verify response
-        assert response.status_code == 200
-        response_data = response.json()
-        assert response_data["task_id"] == task_id
-        assert response_data["status"] == "SUCCESS"
-        assert response_data["result"] == {"processed": 5, "skipped": 2}
-        assert "error" not in response_data
-
-        # Verify mocks were called
-        mock_async_result_class.assert_called_once_with(task_id, app=mock_celery_app)
-
-    @patch("local_newsifier.api.routers.tasks.AsyncResult", autospec=True)
-    @patch("local_newsifier.api.routers.tasks.celery_app", autospec=True)
-    def test_get_task_status_failure(self, mock_celery_app, mock_async_result_class, client):
-        """Test getting status of a failed task."""
-        # Set up mocks
-        mock_result = MagicMock()
-        mock_result.status = "FAILURE"
-        mock_result.successful.return_value = False
-        mock_result.failed.return_value = True
-        mock_result.result = Exception("Task processing error")
-        mock_async_result_class.return_value = mock_result
-
-        # Make the request
-        task_id = "test-task-id"
-        response = client.get(f"/tasks/status/{task_id}")
-
-        # Verify response
-        assert response.status_code == 200
-        response_data = response.json()
-        assert response_data["task_id"] == task_id
-        assert response_data["status"] == "FAILURE"
-        assert "result" not in response_data
-        assert response_data["error"] == "Task processing error"
-
-        # Verify mocks were called
-        mock_async_result_class.assert_called_once_with(task_id, app=mock_celery_app)
-
-    @patch("local_newsifier.api.routers.tasks.AsyncResult", autospec=True)
-    @patch("local_newsifier.api.routers.tasks.celery_app", autospec=True)
-    def test_get_task_status_progress(self, mock_celery_app, mock_async_result_class, client):
-        """Test getting status of a task in progress."""
-        # Set up mocks
-        mock_result = MagicMock()
-        mock_result.status = "PROGRESS"
-        mock_result.successful.return_value = False
-        mock_result.failed.return_value = False
-        mock_result.info = {"current": 5, "total": 10, "percent": 50}
-        mock_async_result_class.return_value = mock_result
-
-        # Make the request
-        task_id = "test-task-id"
-        response = client.get(f"/tasks/status/{task_id}")
-
-        # Verify response
-        assert response.status_code == 200
-        response_data = response.json()
-        assert response_data["task_id"] == task_id
-        assert response_data["status"] == "PROGRESS"
-        assert response_data["progress"] == {"current": 5, "total": 10, "percent": 50}
-        assert "result" not in response_data
-        assert "error" not in response_data
-
-        # Verify mocks were called
-        mock_async_result_class.assert_called_once_with(task_id, app=mock_celery_app)
-
-
-class TestCancelTask:
-    """Tests for cancel task endpoint."""
-
-    @patch("local_newsifier.api.routers.tasks.AsyncResult", autospec=True)
-    @patch("local_newsifier.api.routers.tasks.celery_app", autospec=True)
-    def test_cancel_running_task(self, mock_celery_app, mock_async_result_class, client):
-        """Test cancelling a running task."""
-        # Set up mocks
-        mock_result = MagicMock()
-        mock_result.status = "RUNNING"
-        mock_result.successful.return_value = False
-        mock_result.failed.return_value = False
-        mock_async_result_class.return_value = mock_result
-
-        # Make the request
-        task_id = "test-task-id"
-        response = client.delete(f"/tasks/cancel/{task_id}")
-
-        # Verify response
-        assert response.status_code == 200
-        response_data = response.json()
-        assert response_data["message"] == f"Task {task_id} revoke signal sent"
-
-        # Verify mocks were called
-        mock_async_result_class.assert_called_once_with(task_id, app=mock_celery_app)
-        mock_celery_app.control.revoke.assert_called_once_with(task_id, terminate=True)
-
-    @patch("local_newsifier.api.routers.tasks.AsyncResult", autospec=True)
-    @patch("local_newsifier.api.routers.tasks.celery_app", autospec=True)
-    def test_cancel_completed_task(self, mock_celery_app, mock_async_result_class, client):
-        """Test cancelling a completed task."""
-        # Set up mocks
-        mock_result = MagicMock()
-        mock_result.status = "SUCCESS"
-        mock_result.successful.return_value = True
-        mock_result.failed.return_value = False
-        mock_async_result_class.return_value = mock_result
-
-        # Make the request
-        task_id = "test-task-id"
-        response = client.delete(f"/tasks/cancel/{task_id}")
-
-        # Verify response
-        assert response.status_code == 200
-        response_data = response.json()
-        assert response_data["message"] == f"Task {task_id} already completed"
-
-        # Verify mocks were called
-        mock_async_result_class.assert_called_once_with(task_id, app=mock_celery_app)
-        mock_celery_app.control.revoke.assert_not_called()
-
-    @patch("local_newsifier.api.routers.tasks.AsyncResult", autospec=True)
-    @patch("local_newsifier.api.routers.tasks.celery_app", autospec=True)
-    def test_cancel_failed_task(self, mock_celery_app, mock_async_result_class, client):
-        """Test cancelling a failed task."""
-        # Set up mocks
-        mock_result = MagicMock()
-        mock_result.status = "FAILURE"
-        mock_result.successful.return_value = False
-        mock_result.failed.return_value = True
-        mock_async_result_class.return_value = mock_result
-
-        # Make the request
-        task_id = "test-task-id"
-        response = client.delete(f"/tasks/cancel/{task_id}")
-
-        # Verify response
-        assert response.status_code == 200
-        response_data = response.json()
-        assert response_data["message"] == f"Task {task_id} already completed"
-
-        # Verify mocks were called
-        mock_async_result_class.assert_called_once_with(task_id, app=mock_celery_app)
-        mock_celery_app.control.revoke.assert_not_called()
+    resp = client.get("/tasks", params={"status": "queued"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1 and data[0]["id"] == "a"
+
+
+def test_cancel_task(client):
+    tasks_router.TASK_STORE["x"] = tasks_router.TaskRecord(
+        id="x", name="t1", status="queued", created_at=tasks_router.datetime.now(tasks_router.timezone.utc)
+    )
+    resp = client.delete("/tasks/x")
+    assert resp.status_code == 200
+    assert tasks_router.TASK_STORE["x"].status == "cancelled"


### PR DESCRIPTION
## Summary
- rewrite the tasks router to use `BackgroundTasks`
- replace Celery-based endpoints with generic task CRUD
- adjust dashboard template for new routes and statuses
- update API tests for the new behaviour

## Testing
- `poetry run pytest -q` *(failed: Command '['/root/.pyenv/shims/python', '-EsSc', 'import sys; print(sys.executable)']' returned non-zero exit status 127)*