### PR TITLE
Implement background task manager provider

### DIFF
--- a/src/local_newsifier/api/dependencies.py
+++ b/src/local_newsifier/api/dependencies.py
@@ -4,6 +4,9 @@ import os
 import pathlib
 from typing import Generator
 
+from fastapi_injectable import injectable
+from local_newsifier.services.background_task_manager import BackgroundTaskManager
+
 from fastapi import HTTPException, Request, status
 from fastapi.templating import Jinja2Templates
 from sqlmodel import Session
@@ -95,3 +98,13 @@ def get_rss_feed_service() -> RSSFeedService:
     # Use injectable provider with session
     with next(get_session()) as session:
         return get_injectable_rss_feed_service(session=session)
+
+
+# Create a shared instance for the background task manager
+_background_task_manager = BackgroundTaskManager()
+
+
+@injectable(use_cache=True)
+def get_background_task_manager() -> BackgroundTaskManager:
+    """Get the shared background task manager instance."""
+    return _background_task_manager

--- a/src/local_newsifier/services/background_task_manager.py
+++ b/src/local_newsifier/services/background_task_manager.py
@@ -1,0 +1,14 @@
+class BackgroundTaskManager:
+    """Simple background task manager placeholder."""
+
+    def __init__(self):
+        self.tasks = []
+
+    def add_task(self, func, *args, **kwargs):
+        self.tasks.append((func, args, kwargs))
+
+    def run_tasks(self):
+        for func, args, kwargs in self.tasks:
+            func(*args, **kwargs)
+        self.tasks.clear()
+


### PR DESCRIPTION
## Summary
- add a placeholder `BackgroundTaskManager` service
- expose a shared instance through `get_background_task_manager` in API dependencies

## Testing
- `pip install -e . --break-system-packages` *(fails: no matching distribution for poetry-core)*
- `pytest -q` *(fails: command not found)*