### PR TITLE
Add task persistence utilities

### DIFF
--- a/src/local_newsifier/api/tasks/__init__.py
+++ b/src/local_newsifier/api/tasks/__init__.py
@@ -1,0 +1,5 @@
+"""Persistence utilities for task management."""
+
+from .persistence import TaskRecord, load_tasks, save_tasks
+
+__all__ = ["TaskRecord", "load_tasks", "save_tasks"]

--- a/src/local_newsifier/api/tasks/persistence.py
+++ b/src/local_newsifier/api/tasks/persistence.py
@@ -1,0 +1,75 @@
+# Task persistence helpers for API tasks.
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import List
+
+# Global lock to prevent concurrent file access
+_TASK_FILE_LOCK = asyncio.Lock()
+
+
+@dataclass
+class TaskRecord:
+    """Simple representation of a task for persistence."""
+
+    id: str
+    type: str
+    description: str
+    status: str
+    submitted: str  # ISO formatted datetime string
+
+
+async def _read_json(path: Path) -> List[dict]:
+    return await asyncio.to_thread(_sync_read_json, path)
+
+
+def _sync_read_json(path: Path) -> List[dict]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+async def _write_json(path: Path, data: List[dict]) -> None:
+    await asyncio.to_thread(_sync_write_json, path, data)
+
+
+def _sync_write_json(path: Path, data: List[dict]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+async def load_task_records(file_path: str | Path) -> List[TaskRecord]:
+    """Load task records from a JSON file."""
+    path = Path(file_path)
+    if not path.exists():
+        return []
+
+    async with _TASK_FILE_LOCK:
+        raw = await _read_json(path)
+        return [TaskRecord(**item) for item in raw]
+
+
+async def save_task_records(file_path: str | Path, tasks: List[TaskRecord]) -> None:
+    """Save task records to a JSON file."""
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = [asdict(t) for t in tasks]
+
+    async with _TASK_FILE_LOCK:
+        await _write_json(path, data)
+
+
+async def load_tasks(manager) -> List[TaskRecord]:
+    """Helper to load tasks using a manager with a persistence_path attribute."""
+    tasks = await load_task_records(manager.persistence_path)
+    manager.tasks = tasks
+    return tasks
+
+
+async def save_tasks(manager) -> None:
+    """Helper to save tasks using a manager with a persistence_path attribute."""
+    tasks: List[TaskRecord] = getattr(manager, "tasks", [])
+    await save_task_records(manager.persistence_path, tasks)

--- a/tests/api/test_task_persistence.py
+++ b/tests/api/test_task_persistence.py
@@ -1,0 +1,56 @@
+"""Tests for task persistence helper functions."""
+
+from pathlib import Path
+import pytest
+
+from tests.fixtures.event_loop import event_loop_fixture
+
+from local_newsifier.api.tasks.persistence import (
+    TaskRecord,
+    load_tasks,
+    save_tasks,
+)
+
+
+class DummyManager:
+    """Simple manager object for testing."""
+
+    def __init__(self, path: Path):
+        self.persistence_path = str(path)
+        self.tasks: list[TaskRecord] = []
+
+
+pytestmark = pytest.mark.usefixtures("event_loop_fixture")
+
+
+def test_save_and_load_tasks(tmp_path, event_loop_fixture):
+    """Ensure tasks are persisted and loaded correctly."""
+    file_path = tmp_path / "tasks.json"
+    manager = DummyManager(file_path)
+
+    manager.tasks = [
+        TaskRecord(
+            id="1",
+            type="process_article",
+            description="Article 1",
+            status="queued",
+            submitted="2024-01-01T00:00:00Z",
+        ),
+        TaskRecord(
+            id="2",
+            type="fetch_rss",
+            description="RSS",
+            status="queued",
+            submitted="2024-01-02T00:00:00Z",
+        ),
+    ]
+
+    event_loop_fixture.run_until_complete(save_tasks(manager))
+
+    manager.tasks = []
+
+    event_loop_fixture.run_until_complete(load_tasks(manager))
+
+    assert len(manager.tasks) == 2
+    assert manager.tasks[0].id == "1"
+    assert manager.tasks[1].type == "fetch_rss"


### PR DESCRIPTION
## Summary
- implement new persistence module for API tasks
- expose helper functions via package init
- add a unit test for saving and loading TaskRecord objects

## Testing
- `pip install --no-index --find-links=wheels -r requirements.txt` *(fails: No matching distribution found for sqlalchemy>=2.0.27)*