### PR TITLE
Implement background task manager integration

### DIFF
--- a/src/local_newsifier/api/main.py
+++ b/src/local_newsifier/api/main.py
@@ -16,6 +16,7 @@ from local_newsifier.api.dependencies import get_templates
 from local_newsifier.api.routers import auth, system, tasks
 from local_newsifier.config.settings import get_settings, settings
 from local_newsifier.database.engine import create_db_and_tables
+from local_newsifier.di.providers import get_background_task_manager
 
 # Configure logging
 logging.basicConfig(
@@ -33,6 +34,7 @@ async def lifespan(app: FastAPI):
     """
     # Startup logic
     logger.info("Application startup initiated")
+    manager = get_background_task_manager()
     try:
         # Initialize database tables
         create_db_and_tables()
@@ -41,8 +43,11 @@ async def lifespan(app: FastAPI):
         # Initialize fastapi-injectable
         logger.info("Initializing fastapi-injectable")
         await register_app(app)
-        
+
         logger.info("fastapi-injectable initialization completed")
+
+        if hasattr(manager, "restore_tasks"):
+            await manager.restore_tasks()
     except Exception as e:
         logger.error(f"Startup error: {str(e)}")
     
@@ -52,6 +57,8 @@ async def lifespan(app: FastAPI):
     
     # Shutdown logic
     logger.info("Application shutdown initiated")
+    if hasattr(manager, "save_tasks"):
+        await manager.save_tasks()
     logger.info("Application shutdown complete")
 
 

--- a/src/local_newsifier/di/providers.py
+++ b/src/local_newsifier/di/providers.py
@@ -1168,3 +1168,11 @@ def get_feeds_process_command():
     """
     from local_newsifier.cli.commands.feeds import process_feed
     return process_feed
+
+@injectable(use_cache=True)
+def get_background_task_manager():
+    """Provide the background task manager instance."""
+    from local_newsifier.services.background_task_manager import BackgroundTaskManager
+
+    return BackgroundTaskManager()
+

--- a/src/local_newsifier/services/background_task_manager.py
+++ b/src/local_newsifier/services/background_task_manager.py
@@ -1,0 +1,31 @@
+import json
+import os
+from typing import Any, Dict, List
+
+
+class BackgroundTaskManager:
+    """Simple manager for persisting background tasks to disk."""
+
+    def __init__(self, storage_path: str = "background_tasks.json") -> None:
+        self.storage_path = storage_path
+        self.tasks: List[Dict[str, Any]] = []
+
+    async def restore_tasks(self) -> None:
+        """Load persisted tasks from disk if the file exists."""
+        if os.path.exists(self.storage_path):
+            try:
+                with open(self.storage_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                self.tasks = data.get("tasks", [])
+            except Exception:
+                # If loading fails, start with an empty task list
+                self.tasks = []
+
+    async def save_tasks(self) -> None:
+        """Persist current tasks to disk."""
+        try:
+            with open(self.storage_path, "w", encoding="utf-8") as f:
+                json.dump({"tasks": self.tasks}, f)
+        except Exception:
+            # Saving errors are ignored for now
+            pass


### PR DESCRIPTION
## Summary
- add `BackgroundTaskManager` service for persisting queued tasks
- expose `get_background_task_manager` via DI providers
- integrate the manager in the FastAPI lifespan startup/shutdown procedures

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*