### PR TITLE
Add BackgroundTaskManager and tests

### DIFF
--- a/src/local_newsifier/api/background_task_manager.py
+++ b/src/local_newsifier/api/background_task_manager.py
@@ -1,0 +1,44 @@
+import asyncio
+import uuid
+from typing import Any, Awaitable, Callable, Dict
+
+
+class BackgroundTaskManager:
+    """Simple manager for asyncio background tasks."""
+
+    def __init__(self) -> None:
+        self.tasks: Dict[str, asyncio.Task] = {}
+
+    def create_task(self, func: Callable[..., Awaitable[Any]], *args: Any, **kwargs: Any) -> str:
+        """Create and register an asyncio task.
+
+        The task is automatically removed from the registry when done.
+        """
+        task_id = str(uuid.uuid4())
+        task = asyncio.create_task(func(*args, **kwargs))
+        self.tasks[task_id] = task
+
+        def _cleanup(_: asyncio.Task, *, t_id: str = task_id) -> None:
+            self.tasks.pop(t_id, None)
+
+        task.add_done_callback(_cleanup)
+        return task_id
+
+    async def run_task(self, func: Callable[..., Awaitable[Any]], *args: Any, **kwargs: Any) -> Any:
+        """Run a coroutine function and wait for completion.
+
+        This registers the task and cleans it up when finished.
+        """
+        task_id = self.create_task(func, *args, **kwargs)
+        task = self.tasks[task_id]
+        return await task
+
+    def cleanup(self) -> None:
+        """Cancel all running tasks and clear the registry."""
+        for task in list(self.tasks.values()):
+            if not task.done():
+                task.cancel()
+        self.tasks.clear()
+
+    def __del__(self) -> None:  # pragma: no cover - cleanup on GC
+        self.cleanup()

--- a/tests/api/test_background_task_manager.py
+++ b/tests/api/test_background_task_manager.py
@@ -1,0 +1,73 @@
+import asyncio
+import pytest
+
+from local_newsifier.api.background_task_manager import BackgroundTaskManager
+from tests.fixtures.event_loop import event_loop_fixture
+
+
+async def _dummy_success(value: str) -> str:
+    await asyncio.sleep(0.01)
+    return value
+
+
+async def _dummy_failure() -> None:
+    await asyncio.sleep(0.01)
+    raise RuntimeError("boom")
+
+
+class TestBackgroundTaskManager:
+    """Tests for the BackgroundTaskManager class."""
+
+    def test_create_task(self, event_loop_fixture):
+        manager = BackgroundTaskManager()
+
+        async def run() -> tuple[str, str]:
+            task_id = manager.create_task(_dummy_success, "ok")
+            result = await manager.tasks[task_id]
+            await asyncio.sleep(0)  # allow done callback
+            return task_id, result
+
+        task_id, result = event_loop_fixture.run_until_complete(run())
+        assert result == "ok"
+        assert task_id not in manager.tasks
+
+    def test_run_task_success(self, event_loop_fixture):
+        manager = BackgroundTaskManager()
+
+        async def run() -> str:
+            return await manager.run_task(_dummy_success, "done")
+
+        result = event_loop_fixture.run_until_complete(run())
+        assert result == "done"
+        assert manager.tasks == {}
+
+    def test_run_task_failure(self, event_loop_fixture):
+        manager = BackgroundTaskManager()
+
+        async def run():
+            try:
+                await manager.run_task(_dummy_failure)
+            except RuntimeError as exc:  # noqa: B902
+                return str(exc)
+            return "no error"
+
+        err = event_loop_fixture.run_until_complete(run())
+        assert err == "boom"
+        assert manager.tasks == {}
+
+    def test_cleanup_cancels_tasks(self, event_loop_fixture):
+        manager = BackgroundTaskManager()
+
+        async def long():
+            await asyncio.sleep(10)
+
+        async def run() -> tuple[bool, int]:
+            task_id = manager.create_task(long)
+            task = manager.tasks[task_id]
+            manager.cleanup()
+            await asyncio.sleep(0)
+            return task.cancelled(), len(manager.tasks)
+
+        cancelled, remaining = event_loop_fixture.run_until_complete(run())
+        assert cancelled
+        assert remaining == 0


### PR DESCRIPTION
## Summary
- implement `BackgroundTaskManager` for asyncio task handling
- add unit tests covering creation, running, error handling and cleanup

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*