### PR TITLE
Update Python version to 3.12.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "local_newsifier", from = "src"}]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = "3.12.10"
 crewai = "^0.114.0"
 pydantic = "^2.11.3"
 pydantic-settings = "^2.2.1"


### PR DESCRIPTION
This PR updates the Python version constraint in pyproject.toml to specifically target Python 3.12.10.

## Summary
* Changed Python version requirement from >=3.10,<3.13 to 3.12.10
* Tested with pytest and confirmed basic functionality works

🤖 Generated with [Claude Code](https://claude.ai/code)