### PR TITLE
Update wheels doc for testing note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ make build-linux-wheels-py312
 ```
 
 This requires Docker and builds all dependencies, including platform-specific ones like psycopg2-binary.
+After building wheels, run `make test-wheels` or
+`./scripts/test_offline_install.sh <python>` to verify that all required runtime and development packages are present before running tests.
 
 #### Organizing Existing Wheels
 


### PR DESCRIPTION
## Summary
- recommend running `make test-wheels` (or `./scripts/test_offline_install.sh <python>`) after building wheels
- clarify this confirms all runtime and dev packages are available

## Testing
- `make test` *(fails: command not found: pytest)*
- `make test-wheels` *(fails: dependency resolution conflict)*