### PR TITLE
Fix NameError in apify-config list command (Issue #467)

### DIFF
--- a/src/local_newsifier/services/apify_source_config_service.py
+++ b/src/local_newsifier/services/apify_source_config_service.py
@@ -75,7 +75,8 @@ class ApifySourceConfigService:
                 )
             
             # Convert to dictionaries
-            return [config.model_dump() for config in configs]
+            # Add exclude_none=True to prevent issues with optional fields
+            return [config.model_dump(exclude_none=True) for config in configs]
     
     @handle_service_error(service="apify")
     def get_config(self, config_id: int) -> Optional[Dict[str, Any]]:
@@ -91,7 +92,7 @@ class ApifySourceConfigService:
             config = self.apify_source_config_crud.get(session, id=config_id)
             if not config:
                 return None
-            return config.model_dump()
+            return config.model_dump(exclude_none=True)
     
     @handle_service_error(service="apify")
     def create_config(
@@ -142,7 +143,7 @@ class ApifySourceConfigService:
                 config = self.apify_source_config_crud.create(
                     session, obj_in=config_data
                 )
-                return config.model_dump()
+                return config.model_dump(exclude_none=True)
             except ServiceError as e:
                 # Re-raise ServiceError
                 raise e
@@ -213,7 +214,7 @@ class ApifySourceConfigService:
                 updated_config = self.apify_source_config_crud.update(
                     session, db_obj=db_config, obj_in=update_data
                 )
-                return updated_config.model_dump()
+                return updated_config.model_dump(exclude_none=True)
             except ServiceError as e:
                 # Re-raise ServiceError
                 raise e
@@ -275,7 +276,7 @@ class ApifySourceConfigService:
             )
             if not updated_config:
                 return None
-            return updated_config.model_dump()
+            return updated_config.model_dump(exclude_none=True)
     
     @handle_service_error(service="apify")
     def run_configuration(self, config_id: int) -> Dict[str, Any]:
@@ -363,4 +364,4 @@ class ApifySourceConfigService:
             configs = self.apify_source_config_crud.get_scheduled_configs(
                 session, enabled_only=enabled_only
             )
-            return [config.model_dump() for config in configs]
+            return [config.model_dump(exclude_none=True) for config in configs]


### PR DESCRIPTION
## Summary
- Fixed the bug where 'nf apify-config list' command fails with a NameError ('name environment is not defined')
- The issue was in the model_dump() method from SQLModel/Pydantic, which needed the exclude_none=True parameter
- Added this parameter to all calls of model_dump() in the ApifySourceConfigService

## Test plan
1. Run the 'nf apify-config list' command to verify it works correctly
2. Check that other commands using the service (add, show, update, etc.) continue to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)