### PR TITLE
Update docs for offline test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ For details on the architecture and testing strategies see:
 curl -sSL https://install.python-poetry.org | python3 -
 ```
 
-2. Install dependencies:
+2. Install dependencies from the local wheels directory (required before running tests):
 ```bash
-poetry install
+make setup-poetry -- --no-index --find-links=wheels
 ```
+If you have internet access you can simply run `poetry install` instead.
 
 If your environment lacks internet access, generate the wheels directory on a
 connected machine first:
@@ -58,6 +59,10 @@ Copy the resulting `wheels/` directory and install from it locally:
 ```bash
 pip install --no-index --find-links=wheels -r requirements.txt
 ```
+
+### Offline wheels directory
+
+The `wheels/` directory stores pre-built wheels for all runtime and development packages. Running `make setup-poetry -- --no-index --find-links=wheels` installs these packages without contacting PyPI. `make test` expects these dependencies to be present before execution.
 
 3. Download spaCy model:
 ```bash

--- a/docs/python_setup.md
+++ b/docs/python_setup.md
@@ -14,7 +14,7 @@ We use Poetry for dependency management:
 
 ```bash
 # Install dependencies using Poetry
-make setup-poetry
+make setup-poetry -- --no-index --find-links=wheels
 
 # Activate the Poetry environment
 poetry shell
@@ -23,9 +23,19 @@ poetry shell
 make setup-spacy
 ```
 
+Running `make setup-poetry -- --no-index --find-links=wheels` installs all
+packages from the `wheels/` directory and is required before executing
+`make test` in an offline environment.
+
 ### Offline Installation
 
-If your deployment environment cannot reach PyPI, the repository includes pre-built wheels for offline installation. If you need to build new wheels on a machine with internet access:
+If your deployment environment cannot reach PyPI, the repository includes pre-built wheels for offline installation.
+
+#### Wheels directory
+
+All wheels live under the `wheels/` directory, organized by Python version and platform. This directory allows Poetry and pip to install packages without internet access.
+
+If you need to build new wheels on a machine with internet access:
 
 ```bash
 # Build wheels for the current Python version on the current platform


### PR DESCRIPTION
## Summary
- clarify offline setup steps in README
- mention wheels directory and `make setup-poetry` in python setup docs

## Testing
- `make test` *(fails: Command not found: pytest)*