### PR TITLE
Enable pytest parallelization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test-wheels:
 
 # Testing
 test:
-	poetry run pytest
+	poetry run pytest -n auto
 
 # Run tests serially (non-parallel) if needed for debugging
 test-serial:

--- a/docs/test_execution.md
+++ b/docs/test_execution.md
@@ -19,7 +19,7 @@ There are several ways to run tests in this project:
 Run all tests in parallel (using all available CPU cores):
 
 ```bash
-make test  # Runs: poetry run pytest
+make test  # Runs: poetry run pytest -n auto
 ```
 
 This is the default behavior and provides the fastest execution, especially on multi-core machines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,7 @@ python_files = ["test_*.py", "*_test.py"]
 
 # Configure parallel test execution with xdist
 # Run tests in parallel by default (auto-detect CPU count)
-# Temporarily disabled: addopts = "-n auto -vs"
-addopts = "-vs"
+addopts = "-n auto -vs"
 
 # Define custom markers for test categorization
 markers = [


### PR DESCRIPTION
## Summary
- run pytest with `-n auto` in Makefile
- document parallel test execution in `docs/test_execution.md`
- enable parallel tests by default in `pyproject.toml`

## Testing
- `make test` *(fails: Command not found: pytest)*