### PR TITLE
Restore pytest parallelism

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,7 @@ python_files = ["test_*.py", "*_test.py"]
 
 # Configure parallel test execution with xdist
 # Run tests in parallel by default (auto-detect CPU count)
-# Temporarily disabled: addopts = "-n auto -vs"
-addopts = "-vs"
+addopts = "-n auto -vs"
 
 # Define custom markers for test categorization
 markers = [


### PR DESCRIPTION
## Summary
- revert default pytest addopts to run with `-n auto -vs`
- confirm tests spawn multiple workers

## Testing
- `poetry run pytest` *(fails: ProxyError to telemetry service)*