### PR TITLE
Improve quick setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,28 @@ This system automatically fetches local news articles, performs Named Entity Rec
 - Comprehensive logging and monitoring
 - Dependency injection for modular and testable code
 
+## Quick Setup
+
+If you just need to install the dependencies and run the tests, follow these
+steps. They assume you already have a `wheels/` directory created on a machine
+with internet access. See [docs/python_setup.md](docs/python_setup.md) for the
+full details.
+
+```bash
+# Install all packages from the wheels directory
+make setup-poetry -- --no-index --find-links=wheels
+
+# (Optional) Install spaCy models if they are available locally
+make setup-spacy
+
+# Run the full test suite
+make test
+```
+
+If you don't have the wheels directory yet, run `make build-wheels` on a
+connected machine and copy the resulting `wheels/` directory here before running
+these commands.
+
 ## Architecture
 
 ### Dependency Injection

--- a/docs/python_setup.md
+++ b/docs/python_setup.md
@@ -2,6 +2,20 @@
 
 This guide provides instructions for setting up the Python environment for Local Newsifier using Poetry.
 
+## Quick Setup
+
+If you already have the `wheels/` directory from a machine with internet access,
+you can install dependencies and run the tests with just a few commands:
+
+```bash
+make setup-poetry -- --no-index --find-links=wheels
+make setup-spacy  # optional if spaCy models are available
+make test
+```
+
+For more details on building wheels and troubleshooting offline installation,
+read the remainder of this guide.
+
 ## Python Version
 
 The project requires Python 3.10-3.13, with Python 3.12 recommended to match our CI environment.


### PR DESCRIPTION
## Summary
- add Quick Setup section to README
- document Quick Setup steps in docs/python_setup.md

## Testing
- `make setup-poetry` *(fails: All attempts to connect to pypi.org failed)*
