### PR TITLE
Update apify_config CLI imports

### DIFF
--- a/src/local_newsifier/cli/commands/apify_config.py
+++ b/src/local_newsifier/cli/commands/apify_config.py
@@ -14,9 +14,17 @@ import click
 from datetime import datetime
 from tabulate import tabulate
 
+from typing import Annotated, Optional
+from fastapi import Depends
+from sqlmodel import Session
+
 from fastapi_injectable import get_injected_obj
 
-from local_newsifier.di.providers import get_apify_source_config_service
+from local_newsifier.di.providers import (
+    get_apify_source_config_crud,
+    get_apify_source_config_service,
+    get_session,
+)
 
 
 @click.group(name="apify-config")
@@ -33,8 +41,15 @@ def apify_config_group():
 @click.option("--source-type", help="Filter by source type (e.g., news, blog)")
 def list_configs(active_only, json_output, limit, skip, source_type):
     """List all Apify source configurations with optional filtering."""
-    # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    # Get the service using the injectable provider with session
+    session_gen = get_injected_obj(get_session)
+    session = next(session_gen)
+    apify_source_config_crud = get_injected_obj(get_apify_source_config_crud)
+    apify_source_config_service = get_injected_obj(
+        get_apify_source_config_service,
+        apify_source_config_crud=apify_source_config_crud,
+        session=session,
+    )
     
     # Get configs based on filters
     configs_dict = apify_source_config_service.list_configs(
@@ -94,8 +109,15 @@ def list_configs(active_only, json_output, limit, skip, source_type):
 @click.option("--input", "-i", help="JSON string or file path for actor input configuration")
 def add_config(name, actor_id, source_type, source_url, schedule, input):
     """Add a new Apify source configuration."""
-    # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    # Get the service using the injectable provider with session
+    session_gen = get_injected_obj(get_session)
+    session = next(session_gen)
+    apify_source_config_crud = get_injected_obj(get_apify_source_config_crud)
+    apify_source_config_service = get_injected_obj(
+        get_apify_source_config_service,
+        apify_source_config_crud=apify_source_config_crud,
+        session=session,
+    )
     
     # Parse input configuration if provided
     input_configuration = None
@@ -142,8 +164,15 @@ def add_config(name, actor_id, source_type, source_url, schedule, input):
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 def show_config(id, json_output):
     """Show Apify source configuration details."""
-    # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    # Get the service using the injectable provider with session
+    session_gen = get_injected_obj(get_session)
+    session = next(session_gen)
+    apify_source_config_crud = get_injected_obj(get_apify_source_config_crud)
+    apify_source_config_service = get_injected_obj(
+        get_apify_source_config_service,
+        apify_source_config_crud=apify_source_config_crud,
+        session=session,
+    )
     
     try:
         config = apify_source_config_service.get_config(id)
@@ -186,8 +215,15 @@ def show_config(id, json_output):
 @click.option("--force", is_flag=True, help="Skip confirmation")
 def remove_config(id, force):
     """Remove an Apify source configuration."""
-    # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    # Get the service using the injectable provider with session
+    session_gen = get_injected_obj(get_session)
+    session = next(session_gen)
+    apify_source_config_crud = get_injected_obj(get_apify_source_config_crud)
+    apify_source_config_service = get_injected_obj(
+        get_apify_source_config_service,
+        apify_source_config_crud=apify_source_config_crud,
+        session=session,
+    )
     
     try:
         config = apify_source_config_service.get_config(id)
@@ -220,8 +256,15 @@ def remove_config(id, force):
 @click.option("--input", "-i", help="JSON string or file path for actor input configuration")
 def update_config(id, name, actor_id, source_type, source_url, schedule, active, input):
     """Update Apify source configuration properties."""
-    # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    # Get the service using the injectable provider with session
+    session_gen = get_injected_obj(get_session)
+    session = next(session_gen)
+    apify_source_config_crud = get_injected_obj(get_apify_source_config_crud)
+    apify_source_config_service = get_injected_obj(
+        get_apify_source_config_service,
+        apify_source_config_crud=apify_source_config_crud,
+        session=session,
+    )
     
     try:
         # Check if at least one property to update was provided
@@ -287,8 +330,15 @@ def run_config(id, output):
         nf apify-config run 1
         nf apify-config run 2 --output result.json
     """
-    # Get the service using the injectable provider
-    apify_source_config_service = get_injected_obj(get_apify_source_config_service)
+    # Get the service using the injectable provider with session
+    session_gen = get_injected_obj(get_session)
+    session = next(session_gen)
+    apify_source_config_crud = get_injected_obj(get_apify_source_config_crud)
+    apify_source_config_service = get_injected_obj(
+        get_apify_source_config_service,
+        apify_source_config_crud=apify_source_config_crud,
+        session=session,
+    )
     
     try:
         # Run the configuration


### PR DESCRIPTION
## Summary
- ensure apify config CLI imports Annotated, Optional, Depends and Session
- obtain CRUD and session dependencies when calling ApifySourceConfig service

## Testing
- `make test` *(fails: Command not found: pytest)*