### PR TITLE
Fix heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Project Chronicle Persistence
+# Local Newsifier
 
 [![Tests](https://github.com/alexrockwell/local_newsifier/actions/workflows/test.yml/badge.svg)](https://github.com/alexrockwell/local_newsifier/actions/workflows/test.yml)
 


### PR DESCRIPTION
## Summary
- rename the project heading at the top of README

## Testing
- `make test` *(fails: Command not found: pytest)*