### PR TITLE
Remove state management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,14 +348,6 @@ The system implements comprehensive error handling:
 - Processing errors
 - State management issues
 
-## State Management
-
-Uses crew.ai's SQLite checkpointer for:
-- Workflow state persistence
-- Progress tracking
-- Error recovery
-- Flow resumption
-
 ## Monitoring
 
 - Comprehensive logging


### PR DESCRIPTION
## Summary
- delete the unused State Management section from README

## Testing
- `make test` *(fails: `pytest` not found)*