### PR TITLE
Update celery app docs

### DIFF
--- a/src/local_newsifier/celery_app.py
+++ b/src/local_newsifier/celery_app.py
@@ -1,6 +1,7 @@
-"""
-Celery application configuration for the Local Newsifier project.
-This module sets up the Celery application using PostgreSQL as both the broker and result backend.
+"""Celery application configuration for the Local Newsifier project.
+
+This module sets up the Celery application using Redis as both the broker and
+result backend.
 """
 
 import os
@@ -12,7 +13,7 @@ from local_newsifier.config.settings import settings
 # Create the Celery application
 app = Celery("local_newsifier")
 
-# Configure Celery to use PostgreSQL as both broker and result backend
+# Configure Celery to use Redis as both the broker and result backend
 app.conf.update(
     broker_url=settings.CELERY_BROKER_URL,
     result_backend=settings.CELERY_RESULT_BACKEND,


### PR DESCRIPTION
## Summary
- clarify Redis is used for Celery broker and result backend in `celery_app`

## Testing
- `make test` *(fails: `Command not found: pytest`)*