### PR TITLE
Centralize not-found phrases

### DIFF
--- a/src/local_newsifier/tools/web_scraper.py
+++ b/src/local_newsifier/tools/web_scraper.py
@@ -15,6 +15,17 @@ from webdriver_manager.chrome import ChromeDriverManager
 from fastapi import Depends
 from fastapi_injectable import injectable
 
+# Common phrases indicating that an article was not found or is behind a paywall
+NOT_FOUND_PHRASES = [
+    "404 not found",
+    "page not found",
+    "article not found",
+    "content no longer available",
+    "article has expired",
+    "subscription required",
+    "please subscribe",
+]
+
 from ..models.state import AnalysisStatus, NewsAnalysisState
 
 
@@ -91,18 +102,7 @@ class WebScraperTool:
             response.raise_for_status()
 
             # Check if we got a 404-like page
-            if any(
-                term in response.text.lower()
-                for term in [
-                    "404 not found",
-                    "page not found",
-                    "article not found",
-                    "content no longer available",
-                    "article has expired",
-                    "subscription required",
-                    "please subscribe",
-                ]
-            ):
+            if any(term in response.text.lower() for term in NOT_FOUND_PHRASES):
                 print("Found 404-like content in response")
                 raise requests.exceptions.HTTPError(
                     "Page appears to be a 404 or requires subscription"
@@ -140,18 +140,7 @@ class WebScraperTool:
 
                 # Check for 404-like content
                 page_text = driver.page_source.lower()
-                if any(
-                    term in page_text
-                    for term in [
-                        "404 not found",
-                        "page not found",
-                        "article not found",
-                        "content no longer available",
-                        "article has expired",
-                        "subscription required",
-                        "please subscribe",
-                    ]
-                ):
+                if any(term in page_text for term in NOT_FOUND_PHRASES):
                     print("Found 404-like content in Selenium response")
                     raise ValueError(
                         "Page appears to be a 404 or requires subscription"


### PR DESCRIPTION
## Summary
- create `NOT_FOUND_PHRASES` constant in `web_scraper`
- reuse the constant in `_fetch_url` and Selenium fallback

## Testing
- `pip install --no-index --find-links=wheels -r requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy>=2.0.27)*
- `pytest -k "not"` *(fails: command not found)*