### PR TITLE
Fix injectable event loop handling

### DIFF
--- a/tests/fixtures/event_loop.py
+++ b/tests/fixtures/event_loop.py
@@ -1,201 +1,53 @@
-"""Fixtures for managing asyncio event loops in tests.
-
-This module provides fixtures for working with asyncio event loops in tests, specifically
-for handling fastapi-injectable which requires an event loop for its async operations.
-
-The fixtures in this module are designed to be resilient in CI environments where
-multiple tests may run in parallel, as well as in local environments where the same
-event loop policies are not enforced.
-"""
+"""Asyncio event loop fixtures for injectable component tests."""
 
 import asyncio
-import threading
-import pytest
-import sys
-import warnings
 from contextlib import contextmanager
-from typing import Generator, Optional
+from typing import Generator
+
+import pytest
 from fastapi import FastAPI
-from fastapi_injectable import register_app, get_injected_obj, injectable
-
-
-# Thread local storage for tracking event loops per thread
-_thread_local = threading.local()
+from fastapi_injectable import register_app, get_injected_obj
 
 
 @contextmanager
 def _event_loop_context() -> Generator[asyncio.AbstractEventLoop, None, None]:
-    """Context manager that sets up a new event loop for the current thread.
-    
-    This function handles creating, setting, and cleaning up an event loop
-    in a thread-safe manner, ensuring proper resource cleanup.
-    
-    Yields:
-        The event loop instance for use within the context
-    """
-    # Get the current thread ID
-    thread_id = threading.get_ident()
-    
+    """Create a dedicated event loop and clean it up afterwards."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     try:
-        # First try to get a running loop
-        try:
-            # Use get_running_loop() to avoid deprecation warning in Python 3.10+
-            current_loop = asyncio.get_running_loop()
-            # Store it in thread local storage
-            _thread_local.loop = current_loop
-            yield current_loop
-            return
-        except RuntimeError:
-            # No running loop exists
-            pass
-            
-        # Try to get the existing loop (fallback for older Python versions)
-        try:
-            current_loop = asyncio.get_event_loop()
-            if not current_loop.is_closed():
-                # Store it in thread local storage
-                _thread_local.loop = current_loop
-                yield current_loop
-                return
-        except RuntimeError:
-            # No event loop exists for this thread
-            pass
-        
-        # Create a new event loop
-        new_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(new_loop)
-        
-        # Store it in thread local storage
-        _thread_local.loop = new_loop
-        
-        # Yield the new loop for use within the context
-        yield new_loop
-    
+        yield loop
     finally:
-        # Clean up: get the loop from thread local storage
-        loop = getattr(_thread_local, 'loop', None)
-        
-        if loop is not None and not loop.is_closed():
-            try:
-                # Cancel all pending tasks
-                pending = asyncio.all_tasks(loop=loop)
-                if pending:
-                    for task in pending:
-                        task.cancel()
-                    
-                    # Allow tasks to complete cancellation
-                    if sys.version_info >= (3, 7):
-                        # Python 3.7+ version with proper task gathering
-                        loop.run_until_complete(
-                            asyncio.gather(*pending, return_exceptions=True)
-                        )
-                    else:
-                        # Fallback for older Python versions
-                        for task in pending:
-                            try:
-                                loop.run_until_complete(task)
-                            except:  # noqa: E722
-                                pass
-                
-                # Close the loop
-                loop.close()
-            except Exception as e:
-                warnings.warn(f"Error cleaning up event loop: {e}")
+        pending = asyncio.all_tasks(loop)
+        for task in pending:
+            task.cancel()
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.close()
 
 
 @pytest.fixture
-def event_loop_fixture():
-    """Fixture to create and manage an asyncio event loop for tests.
-    
-    This fixture ensures that:
-    1. Each test gets a fresh event loop
-    2. The event loop is properly set for the current thread
-    3. Any pending tasks are cancelled and the loop is closed after the test
-    4. Event loops are managed in a thread-safe way
-    """
+def event_loop_fixture() -> Generator[asyncio.AbstractEventLoop, None, None]:
+    """Provide a fresh event loop for each test."""
     with _event_loop_context() as loop:
-        # Set a more permissive policy to avoid thread related issues
-        if not isinstance(asyncio.get_event_loop_policy(), asyncio.DefaultEventLoopPolicy):
-            asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
-        
         yield loop
 
 
 @pytest.fixture
 def injectable_app(event_loop_fixture):
-    """Fixture to setup a FastAPI app with proper fastapi-injectable registration.
-    
-    This fixture creates a FastAPI app and registers it with
-    fastapi-injectable using the provided event loop.
-    
-    Args:
-        event_loop_fixture: The event loop fixture to use for app registration
-        
-    Returns:
-        A FastAPI app instance registered with fastapi-injectable
-    """
+    """Create a FastAPI app registered with fastapi-injectable."""
     app = FastAPI()
-    
-    # Use our context manager to ensure a proper event loop is available
-    with _event_loop_context() as loop:
-        try:
-            # Try to register with the context loop first
-            loop.run_until_complete(register_app(app))
-        except Exception as e:
-            # Fall back to the fixture loop if there's an error
-            if "There is no current event loop" in str(e) and not event_loop_fixture.is_closed():
-                event_loop_fixture.run_until_complete(register_app(app))
-            else:
-                raise
-    
+    event_loop_fixture.run_until_complete(register_app(app))
     yield app
 
 
 @pytest.fixture
 def injectable_service_fixture(event_loop_fixture):
-    """Fixture to create and inject services with proper event loop management.
-    
-    This fixture provides a helper function to get injected services
-    with proper event loop handling, avoiding the common asyncio issues.
-    
-    Args:
-        event_loop_fixture: The event loop fixture to use for async operations
-        
-    Returns:
-        A function that can be used to get injected services
-    """
-    # Define helper function to inject a service
+    """Return a helper for injecting services using fastapi-injectable."""
+
     def get_injected_service(service_factory, *args, **kwargs):
-        """Get a service from an injectable provider with proper event loop handling.
-        
-        This function wraps the fastapi-injectable `get_injected_obj` function
-        to ensure it runs in a proper event loop, falling back to a thread-specific
-        event loop if needed.
-        
-        Args:
-            service_factory: The factory function to inject
-            *args: Positional arguments to pass to the factory
-            **kwargs: Keyword arguments to pass to the factory
-            
-        Returns:
-            The result of the injected factory function
-        """
         with _event_loop_context() as loop:
-            try:
-                # Run the async operation in the context-managed event loop
-                result = loop.run_until_complete(
-                    get_injected_obj(service_factory, args=list(args), kwargs=kwargs)
-                )
-                return result
-            except Exception as e:
-                # If the specific error is about event loops, try with the fixture's loop
-                if "There is no current event loop" in str(e):
-                    if event_loop_fixture and not event_loop_fixture.is_closed():
-                        result = event_loop_fixture.run_until_complete(
-                            get_injected_obj(service_factory, args=list(args), kwargs=kwargs)
-                        )
-                        return result
-                # Re-raise any other errors
-                raise
-    
+            return loop.run_until_complete(
+                get_injected_obj(service_factory, args=list(args), kwargs=kwargs)
+            )
+
     return get_injected_service

--- a/tests/tools/test_injectable_sentiment_tracker.py
+++ b/tests/tools/test_injectable_sentiment_tracker.py
@@ -6,35 +6,37 @@ from datetime import datetime, timezone
 
 # Import event loop fixture to handle fastapi-injectable async operations
 from tests.fixtures.event_loop import event_loop_fixture
-from tests.ci_skip_config import ci_skip_async, ci_skip_injectable
+from tests.ci_skip_config import ci_skip_async
 
 # Mock imports
-patch('spacy.load', MagicMock(return_value=MagicMock())).start()
-patch('textblob.TextBlob', MagicMock(return_value=MagicMock(
-    sentiment=MagicMock(polarity=0.5, subjectivity=0.7)
-))).start()
+patch("spacy.load", MagicMock(return_value=MagicMock())).start()
+patch(
+    "textblob.TextBlob",
+    MagicMock(
+        return_value=MagicMock(sentiment=MagicMock(polarity=0.5, subjectivity=0.7))
+    ),
+).start()
 
 # Mock fastapi-injectable to prevent dependency resolution issues in tests
 injectable_mock = MagicMock()
 injectable_mock.side_effect = lambda **kwargs: lambda f: f
-patch('fastapi_injectable.injectable', injectable_mock).start()
+patch("fastapi_injectable.injectable", injectable_mock).start()
 
 
 class TestInjectableSentimentTracker:
     """Test class for the injectable SentimentTracker pattern."""
-    
+
     @pytest.fixture(autouse=True)
     def setup_event_loop(self, event_loop_fixture):
         """Ensure every test in this class has access to the event loop fixture."""
         return event_loop_fixture
-    
+
     @pytest.fixture
     def mock_session(self):
         """Create a mock database session."""
         session = MagicMock()
         return session
-        
-    @ci_skip_injectable
+
     def test_provider_function(self, mock_session, event_loop_fixture):
         """Test that provider functions create a properly configured SentimentTracker.
 
@@ -42,12 +44,14 @@ class TestInjectableSentimentTracker:
         dependency resolution that causes event loop errors.
         """
         # Import here after patching
-        with patch('local_newsifier.di.providers.get_session', return_value=mock_session):
+        with patch(
+            "local_newsifier.di.providers.get_session", return_value=mock_session
+        ):
             from local_newsifier.di.providers import get_sentiment_tracker_tool
             from local_newsifier.tools.sentiment_tracker import SentimentTracker
 
             # Mock the Depends function to avoid event loop issues
-            with patch('fastapi.Depends', return_value=mock_session):
+            with patch("fastapi.Depends", return_value=mock_session):
                 # Get tracker from provider function - directly call without using Depends
                 tracker = get_sentiment_tracker_tool(session=mock_session)
 
@@ -55,7 +59,7 @@ class TestInjectableSentimentTracker:
                 assert isinstance(tracker, SentimentTracker)
                 assert tracker.session_factory is not None
                 assert tracker.session_factory() is mock_session
-            
+
     def test_session_injection(self, mock_session):
         """Test that the session is properly injected and used."""
         # Import the class directly to test in isolation
@@ -70,28 +74,34 @@ class TestInjectableSentimentTracker:
 
         # Test the _get_session method directly
         retrieved_session = tracker._get_session()
-        assert retrieved_session is mock_session, "Session factory should provide the mock session"
-                
+        assert (
+            retrieved_session is mock_session
+        ), "Session factory should provide the mock session"
+
     def test_session_priority(self, mock_session):
         """Test that the session priority logic works correctly."""
         from local_newsifier.tools.sentiment_tracker import SentimentTracker
-        
+
         # Create different sessions for testing priority
         session1 = MagicMock(name="session1")
         session2 = MagicMock(name="session2")
         factory_session = MagicMock(name="factory_session")
-        
+
         # Create tracker with factory session
-        tracker = SentimentTracker(session=session1, session_factory=lambda: factory_session)
-        
+        tracker = SentimentTracker(
+            session=session1, session_factory=lambda: factory_session
+        )
+
         # Test case 1: Explicitly provided session has highest priority
         result1 = tracker._get_session(session=session2)
-        assert result1 is session2, "Explicitly provided session should have highest priority"
-        
+        assert (
+            result1 is session2
+        ), "Explicitly provided session should have highest priority"
+
         # Test case 2: Factory session has second priority
         result2 = tracker._get_session()
         assert result2 is factory_session, "Factory session should have second priority"
-        
+
         # Test case 3: Instance session has lowest priority
         tracker_no_factory = SentimentTracker(session=session1)
         result3 = tracker_no_factory._get_session()

--- a/tests/tools/test_injectable_trend_reporter.py
+++ b/tests/tools/test_injectable_trend_reporter.py
@@ -13,14 +13,13 @@ from local_newsifier.models.trend import TrendAnalysis, TrendType, TrendStatus
 from local_newsifier.tools.trend_reporter import TrendReporter, ReportFormat
 
 
-@pytest.mark.skip(reason="Known issue with event loop in CI - Fixed in parallel PR")
 def test_injectable_trend_reporter_with_event_loop(event_loop_fixture):
     """Test that trend reporter works with event loop integration."""
     # Create a reporter
     with patch("os.makedirs") as mock_makedirs:
         reporter = TrendReporter(output_dir="test_output")
         mock_makedirs.assert_called_with("test_output", exist_ok=True)
-    
+
     # Create a sample trend
     now = datetime.now(timezone.utc)
     trend = TrendAnalysis(
@@ -31,16 +30,16 @@ def test_injectable_trend_reporter_with_event_loop(event_loop_fixture):
         confidence_score=0.85,
         start_date=now,
     )
-    
+
     # Test that the reporter can generate a summary
     with patch.object(reporter, "generate_trend_summary") as mock_generate:
         mock_generate.return_value = "Test report content"
-        
+
         # Call method
         reporter.generate_trend_summary([trend], format=ReportFormat.TEXT)
-        
+
         # Verify call
         mock_generate.assert_called_once()
-        
+
     # Ensure the test passes
     assert True


### PR DESCRIPTION
## Summary
- refine event loop fixtures for injectable tests
- enable injectable trend reporter test
- enable injectable sentiment tracker test

## Testing
- `make test` *(fails: Command not found: pytest)*