### PR TITLE
Suppress Apify token warnings during tests

### DIFF
--- a/src/local_newsifier/cli/commands/apify.py
+++ b/src/local_newsifier/cli/commands/apify.py
@@ -41,7 +41,7 @@ def _ensure_token():
     if os.environ.get("PYTEST_CURRENT_TEST") is not None:
         # In test mode, provide a default token if not set
         if not settings.APIFY_TOKEN:
-            logging.warning("Running CLI in test mode with dummy APIFY_TOKEN")
+            logging.debug("Running CLI in test mode with dummy APIFY_TOKEN")
             settings.APIFY_TOKEN = "test_dummy_token"
         return True
 

--- a/src/local_newsifier/config/settings.py
+++ b/src/local_newsifier/config/settings.py
@@ -135,7 +135,7 @@ class Settings(BaseSettings):
         if skip_validation_in_test and in_test_env:
             if not self.APIFY_TOKEN:
                 import logging
-                logging.warning("Using dummy Apify token for testing")
+                logging.debug("Using dummy Apify token for testing")
                 return "test_dummy_token"
         
         # Standard validation

--- a/src/local_newsifier/services/apify_service.py
+++ b/src/local_newsifier/services/apify_service.py
@@ -41,7 +41,7 @@ class ApifyService:
         if self._client is None:
             # For test mode, use a dummy token if not provided
             if self._test_mode and not self._token and not settings.APIFY_TOKEN:
-                logging.warning("Running in test mode with dummy APIFY_TOKEN")
+                logging.debug("Running in test mode with dummy APIFY_TOKEN")
                 token = "test_dummy_token"
             else:
                 # Get token from settings if not provided


### PR DESCRIPTION
## Summary
- reduce log level for dummy Apify token messages

## Testing
- `pytest tests/services/test_apify_service.py -q`