### PR TITLE
Refactor flow session handling

### DIFF
--- a/src/local_newsifier/flows/public_opinion_flow.py
+++ b/src/local_newsifier/flows/public_opinion_flow.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Optional, Any, Tuple
 from crewai import Flow
 from sqlmodel import Session
 
-from local_newsifier.database.engine import get_session, with_session
+
 from local_newsifier.crud.article import article as article_crud
 from local_newsifier.models.sentiment import SentimentVisualizationData
 from local_newsifier.tools.sentiment_analyzer import SentimentAnalyzer
@@ -35,11 +35,10 @@ class PublicOpinionFlow(Flow):
 
     def __init__(
         self,
+        session: Session,
         sentiment_analyzer: Optional[SentimentAnalyzer] = None,
         sentiment_tracker: Optional[SentimentTracker] = None,
         opinion_visualizer: Optional[OpinionVisualizerTool] = None,
-        session_factory: Optional[callable] = None,
-        session: Optional[Session] = None
     ):
         """
         Initialize the public opinion analysis flow.
@@ -48,39 +47,18 @@ class PublicOpinionFlow(Flow):
             sentiment_analyzer: Tool for sentiment analysis
             sentiment_tracker: Tool for tracking sentiment over time
             opinion_visualizer: Tool for generating visualizations
-            session_factory: Factory function for creating database sessions
-            session: Optional SQLModel session to use
+            session: Database session to use
         """
         super().__init__()
 
-        # Set up database connection if not provided
-        if session is None:
-            if session_factory:
-                self.session_generator = session_factory()
-            else:
-                self.session_generator = get_session()
-            self.session = next(self.session_generator)
-            self._owns_session = True
-        else:
-            self.session = session
-            self._owns_session = False
-            self.session_factory = lambda: session
+        self.session = session
 
         # Initialize tools or use provided ones
         self.sentiment_analyzer = sentiment_analyzer or SentimentAnalyzer(session=self.session)
         self.sentiment_tracker = sentiment_tracker or SentimentTracker(self.session)
         self.opinion_visualizer = opinion_visualizer or OpinionVisualizerTool(self.session)
 
-    def __del__(self):
-        """Clean up resources when the flow is deleted."""
-        if hasattr(self, "_owns_session") and self._owns_session:
-            if hasattr(self, "session") and self.session is not None:
-                try:
-                    next(self.session_generator, None)
-                except StopIteration:
-                    pass
 
-    @with_session
     def analyze_articles(
         self, article_ids: Optional[List[int]] = None, *, session: Optional[Session] = None
     ) -> Dict[int, Dict]:
@@ -122,7 +100,6 @@ class PublicOpinionFlow(Flow):
 
         return results
 
-    @with_session
     def analyze_topic_sentiment(
         self, topics: List[str], days_back: int = 30, interval: str = "day", *, session: Optional[Session] = None
     ) -> Dict[str, Dict]:
@@ -178,7 +155,6 @@ class PublicOpinionFlow(Flow):
 
         return results
 
-    @with_session
     def analyze_entity_sentiment(
         self, entity_names: List[str], days_back: int = 30, interval: str = "day", *, session: Optional[Session] = None
     ) -> Dict[str, Dict]:
@@ -227,7 +203,6 @@ class PublicOpinionFlow(Flow):
 
         return results
 
-    @with_session
     def detect_opinion_shifts(
         self,
         topics: List[str],
@@ -279,7 +254,6 @@ class PublicOpinionFlow(Flow):
 
         return shifts_by_topic
 
-    @with_session
     def correlate_topics(
         self,
         topic_pairs: List[Tuple[str, str]],
@@ -324,7 +298,6 @@ class PublicOpinionFlow(Flow):
 
         return correlations
 
-    @with_session
     def generate_topic_report(
         self,
         topic: str,
@@ -386,7 +359,6 @@ class PublicOpinionFlow(Flow):
             logger.error(f"Error generating report: {str(e)}")
             return f"Error generating report: {str(e)}"
 
-    @with_session
     def generate_comparison_report(
         self,
         topics: List[str],

--- a/tests/flows/analysis/test_headline_trend_flow.py
+++ b/tests/flows/analysis/test_headline_trend_flow.py
@@ -51,36 +51,13 @@ def test_init_with_session(mock_session, mock_analysis_service):
     
     assert flow.session is mock_session
     assert flow.analysis_service is mock_analysis_service
-    assert flow._owns_session is False
 
 
-def test_init_without_session():
-    """Test initialization without session."""
-    # Set up necessary patches to prevent database access
-    with patch('local_newsifier.flows.analysis.headline_trend_flow.get_session') as mock_get_session, \
-         patch('local_newsifier.database.engine.get_engine', return_value=MagicMock()), \
-         patch('local_newsifier.services.analysis_service.AnalysisService') as mock_analysis_service, \
-         patch('fastapi_injectable.concurrency.run_coroutine_sync', return_value=None):
-        # Create a proper mock session that the flow can use
-        mock_session = MagicMock()
-        # Make the get_session mock return a generator that yields our mock session
-        mock_session_generator = MagicMock()
-        mock_session_generator.__next__ = MagicMock(return_value=mock_session)
-        mock_get_session.return_value = mock_session_generator
-        
-        # Create a mock analysis service
-        mock_service = MagicMock()
-        mock_analysis_service.return_value = mock_service
-        
-        # Now create the flow without providing a session
-        flow = HeadlineTrendFlow(analysis_service=mock_service)
-        
-        # Patch any async methods if they exist
-        if hasattr(flow, 'process_async'):
-            flow.process_async = AsyncMock()
-        
-        # Verify the flow owns the session
-        assert flow._owns_session
+def test_init_without_session(mock_session):
+    """Test initialization with an injected session only."""
+    with patch('local_newsifier.services.analysis_service.AnalysisService') as mock_analysis_service:
+        flow = HeadlineTrendFlow(session=mock_session, analysis_service=mock_analysis_service.return_value)
+
         assert flow.session is mock_session
 
 
@@ -221,35 +198,15 @@ def test_generate_report_with_error(flow_with_mocks):
 
 def test_cleanup_on_delete(mock_session):
     """Test that the session is closed when the flow is deleted."""
-    # Set up necessary patches to prevent database access
-    with patch('local_newsifier.flows.analysis.headline_trend_flow.get_session') as mock_get_session, \
-         patch('local_newsifier.database.engine.get_engine', return_value=MagicMock()), \
-         patch('local_newsifier.services.analysis_service.AnalysisService') as mock_analysis_service, \
-         patch('fastapi_injectable.concurrency.run_coroutine_sync', return_value=None):
-            
-        # Create a mock session with close method for __del__ to call
+    with patch('local_newsifier.services.analysis_service.AnalysisService') as mock_analysis_service:
+
         session = MagicMock()
-        session.close = MagicMock()
-        
-        # Make the get_session mock return a generator that yields our mock session
-        mock_session_generator = MagicMock()
-        mock_session_generator.__next__ = MagicMock(return_value=session)
-        mock_get_session.return_value = mock_session_generator
-        
-        # Create a mock analysis service
-        mock_service = MagicMock()
-        mock_analysis_service.return_value = mock_service
-        
-        # Now create the flow without providing a session
-        flow = HeadlineTrendFlow(analysis_service=mock_service)
-        
-        # Set owned session flag manually
-        flow._owns_session = True
-        
+
+        flow = HeadlineTrendFlow(session=session, analysis_service=mock_analysis_service.return_value)
+
         # Explicitly trigger __del__
         # Note: This approach won't actually call the real __del__ but we can simulate it
         if hasattr(flow, '__del__'):
             flow.__del__()
-            
-            # Verify session was closed
+
             session.close.assert_called_once()

--- a/tests/flows/test_public_opinion_flow.py
+++ b/tests/flows/test_public_opinion_flow.py
@@ -45,34 +45,16 @@ class TestPublicOpinionFlow:
             return flow
 
     def test_init_without_session(self):
-        """Test initialization without a database session."""
+        """Test initialization with an injected session."""
         mock_session = MagicMock()
-        
-        # Create a mock context manager for the session
-        mock_context_manager = MagicMock()
-        mock_context_manager.__enter__.return_value = mock_session
-        mock_context_manager.__exit__.return_value = None
-        
-        # Patch all the dependencies including any async code
-        with patch('local_newsifier.database.engine.get_session', return_value=mock_context_manager), \
-             patch('local_newsifier.flows.public_opinion_flow.SentimentAnalyzer'), \
+
+        with patch('local_newsifier.flows.public_opinion_flow.SentimentAnalyzer'), \
              patch('local_newsifier.flows.public_opinion_flow.SentimentTracker'), \
-             patch('local_newsifier.flows.public_opinion_flow.OpinionVisualizerTool'), \
-             patch('local_newsifier.tools.sentiment_analyzer.spacy.load', return_value=MagicMock()), \
-             patch('fastapi_injectable.concurrency.run_coroutine_sync', return_value=None):
-            
-            # Initialize flow without session
-            flow = PublicOpinionFlow()
-            
-            # Since we've mocked get_session to return our mock session
-            # directly set the session to simulate what would happen if PublicOpinionFlow
-            # had successfully called get_session
-            flow.session = mock_session
-            flow._owns_session = True
-            
-            # Verify session was created
-            assert flow.session is not None
-            assert flow._owns_session is True
+             patch('local_newsifier.flows.public_opinion_flow.OpinionVisualizerTool'):
+
+            flow = PublicOpinionFlow(session=mock_session)
+
+            assert flow.session is mock_session
 
     def test_analyze_articles_with_ids(self, flow):
         """Test analyzing sentiment for specific articles."""


### PR DESCRIPTION
## Summary
- inject SQLModel sessions into flows instead of using `with_session`
- adapt public opinion flow and headline trend flow to use provided sessions
- update related unit tests

## Testing
- `poetry run pytest -n auto -q`