### PR TITLE
Add dev requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Copy the resulting `wheels/` directory and install from it locally:
 
 ```bash
 pip install --no-index --find-links=wheels -r requirements.txt
+pip install --no-index --find-links=wheels -r requirements-dev.txt
 ```
 
 ### Offline wheels directory

--- a/docs/python_setup.md
+++ b/docs/python_setup.md
@@ -80,6 +80,7 @@ On the target machine without internet access, install packages using the approp
 ```bash
 # For Python 3.12 on Linux x64
 python3.12 -m pip install --no-index --find-links=wheels/py312-linux-x64 -r requirements.txt
+python3.12 -m pip install --no-index --find-links=wheels/py312-linux-x64 -r requirements-dev.txt
 
 # If platform-specific directory isn't available, fall back to version directory
 python3.12 -m pip install --no-index --find-links=wheels/py312 -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+pytest
+pytest-mock
+pytest-cov
+pytest-asyncio
+pre-commit
+black
+isort
+flake8
+flake8-docstrings
+pytest-profiling
+pytest-xdist


### PR DESCRIPTION
## Summary
- add requirements-dev.txt listing dev dependencies
- mention dev requirements in setup instructions

## Testing
- `pip install --no-index --find-links=wheels/py312-linux-x64 -r requirements.txt`
- `pip install --no-index --find-links=wheels/py312-linux-x64 -r requirements-dev.txt` *(fails: No matching distribution found for coverage>=7.5)*
- `make test`