### PR TITLE
Add async database wrapper

### DIFF
--- a/src/local_newsifier/database/__init__.py
+++ b/src/local_newsifier/database/__init__.py
@@ -13,7 +13,7 @@ from local_newsifier.database.engine import (
     SessionManager,
     with_session,
 )
-from local_newsifier.database.async_engine import AsyncDatabase
+from local_newsifier.database.async_engine import AsyncDatabase, get_async_database
 
 __all__ = [
     # Database engine and session management
@@ -24,4 +24,5 @@ __all__ = [
     "SessionManager",
     "with_session",
     "AsyncDatabase",
+    "get_async_database",
 ]

--- a/src/local_newsifier/database/async_engine.py
+++ b/src/local_newsifier/database/async_engine.py
@@ -1,43 +1,97 @@
 import asyncio
-from contextlib import asynccontextmanager
-from typing import AsyncGenerator, Callable, Any
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+from typing import Any, Callable, Optional
 
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
-from sqlmodel import SQLModel
+from sqlmodel import Session
+
+from local_newsifier.database.engine import get_engine
 
 
 class AsyncDatabase:
-    """Minimal asynchronous database wrapper for tests."""
+    """Asynchronous wrapper around the synchronous SQLModel engine."""
 
-    def __init__(self, url: str):
-        self._engine = create_async_engine(url, echo=False, future=True)
-        self._sessionmaker = sessionmaker(
-            self._engine, class_=AsyncSession, expire_on_commit=False
-        )
+    def __init__(self, database_url: Optional[str] = None, max_workers: Optional[int] = None):
+        self.database_url = database_url
+        self.executor = ThreadPoolExecutor(max_workers=max_workers or 10)
+        self._engine = None
+
+    def _initialize_engine(self) -> None:
+        """Initialize the underlying synchronous engine."""
+        self._engine = get_engine(self.database_url, test_mode=True)
 
     async def initialize(self) -> None:
-        """Initialize the database (no-op for SQLite)."""
-        # For SQLite memory DB nothing extra is required
-        pass
-
-    async def run_sync(self, func: Callable[[Any], Any]) -> Any:
-        """Run a synchronous function in an async engine context."""
-        async with self._engine.begin() as conn:
-            return await conn.run_sync(func)
+        """Asynchronously initialize the database engine."""
+        await self.run_sync(self._initialize_engine)
 
     async def dispose(self) -> None:
-        await self._engine.dispose()
+        """Dispose the engine and shutdown the executor."""
+        if self._engine is not None:
+            await self.run_sync(self._engine.dispose)
+        self.executor.shutdown(wait=True)
 
-    @asynccontextmanager
-    async def get_session(self) -> AsyncGenerator[AsyncSession, None]:
-        """Provide an async session context manager."""
-        async with self._sessionmaker() as session:
-            try:
-                yield session
-                await session.commit()
-            except Exception:
-                await session.rollback()
-                raise
+    async def run_sync(self, func: Callable[..., Any], *args, **kwargs) -> Any:
+        """Run a synchronous function in a background thread."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            self.executor,
+            partial(func, *args, **kwargs)
+        )
+
+    async def get_session(self) -> "AsyncSession":
+        """Return an asynchronous session context manager."""
+        return AsyncSession(self)
 
 
+class AsyncSession:
+    """Async context manager for SQLModel Session."""
+
+    def __init__(self, db: AsyncDatabase):
+        self.db = db
+        self.session: Optional[Session] = None
+
+    async def __aenter__(self) -> "AsyncSession":
+        self.session = await self.db.run_sync(lambda: Session(self.db._engine))
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        if exc_type is not None:
+            await self.async_rollback()
+        await self.close()
+
+    async def async_execute_query(self, query: Any) -> Any:
+        return await self.db.run_sync(lambda q=query: self.session.exec(q))
+
+    async def async_fetch_one(self, query: Any) -> Any:
+        return await self.db.run_sync(lambda q=query: self.session.exec(q).one())
+
+    async def async_fetch_all(self, query: Any) -> Any:
+        return await self.db.run_sync(lambda q=query: self.session.exec(q).all())
+
+    async def async_commit(self) -> None:
+        await self.db.run_sync(self.session.commit)
+
+    async def async_rollback(self) -> None:
+        await self.db.run_sync(self.session.rollback)
+
+    async def commit(self) -> None:
+        await self.async_commit()
+
+    async def rollback(self) -> None:
+        await self.async_rollback()
+
+    async def close(self) -> None:
+        if self.session is not None:
+            await self.db.run_sync(self.session.close)
+
+
+_async_db: Optional[AsyncDatabase] = None
+
+
+async def get_async_database() -> AsyncDatabase:
+    """Return a global AsyncDatabase instance."""
+    global _async_db
+    if _async_db is None:
+        _async_db = AsyncDatabase()
+        await _async_db.initialize()
+    return _async_db

--- a/tests/database/test_async_engine.py
+++ b/tests/database/test_async_engine.py
@@ -1,0 +1,96 @@
+import asyncio
+import threading
+from typing import Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Field, Session, select
+
+from local_newsifier.database.async_engine import AsyncDatabase
+
+
+class Item(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+
+
+@pytest.mark.asyncio
+async def test_thread_isolation(isolated_event_loop):
+    db = AsyncDatabase("sqlite:///:memory:")
+    await db.initialize()
+    await db.run_sync(lambda: SQLModel.metadata.create_all(db._engine))
+
+    loop_thread = threading.get_ident()
+    worker_thread = await db.run_sync(threading.get_ident)
+    assert worker_thread != loop_thread
+
+    await db.dispose()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_operations(isolated_event_loop):
+    db = AsyncDatabase("sqlite:///:memory:")
+    await db.initialize()
+    await db.run_sync(lambda: SQLModel.metadata.create_all(db._engine))
+
+    async def insert_one(value: str):
+        async with db.get_session() as session:
+            await session.db.run_sync(lambda: session.session.add(Item(name=value)))
+            await session.async_commit()
+
+    await asyncio.gather(*(insert_one(f"item{i}") for i in range(5)))
+
+    async with db.get_session() as session:
+        items = await session.async_fetch_all(select(Item))
+    assert len(items) == 5
+
+    await db.dispose()
+
+
+@pytest.mark.asyncio
+async def test_error_handling_and_cleanup(isolated_event_loop):
+    db = AsyncDatabase("sqlite:///:memory:")
+    await db.initialize()
+    await db.run_sync(lambda: SQLModel.metadata.create_all(db._engine))
+
+    with pytest.raises(ValueError):
+        async with db.get_session() as session:
+            await session.db.run_sync(lambda: session.session.add(Item(name="bad")))
+            raise ValueError("boom")
+
+    async with db.get_session() as session:
+        items = await session.async_fetch_all(select(Item))
+    assert items == []
+
+    await db.dispose()
+
+
+@pytest.mark.asyncio
+async def test_fastapi_compatibility(isolated_event_loop):
+    db = AsyncDatabase("sqlite:///:memory:")
+    await db.initialize()
+    await db.run_sync(lambda: SQLModel.metadata.create_all(db._engine))
+
+    async def add_item():
+        def _add():
+            with Session(db._engine) as s:
+                s.add(Item(name="foo"))
+                s.commit()
+        return await db.run_sync(_add)
+
+    await add_item()
+
+    app = FastAPI()
+
+    @app.get("/items")
+    async def get_items():
+        async with db.get_session() as session:
+            return await session.async_fetch_all(select(Item))
+
+    with TestClient(app) as client:
+        response = client.get("/items")
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+
+    await db.dispose()

--- a/tests/fixtures/async_utils.py
+++ b/tests/fixtures/async_utils.py
@@ -25,7 +25,7 @@ async def async_test_db():
     from local_newsifier.database.async_engine import AsyncDatabase
     from sqlmodel import SQLModel
 
-    db = AsyncDatabase("sqlite+aiosqlite:///:memory:")
+    db = AsyncDatabase("sqlite:///:memory:")
     await db.initialize()
     await db.run_sync(lambda: SQLModel.metadata.create_all(db._engine))
     yield db


### PR DESCRIPTION
## Summary

Add async database wrapper to support modern FastAPI async endpoints and background processing.

**Addresses Issue #676: Add async database infrastructure**

## Changes
- Implement `AsyncDatabase` that wraps synchronous SQLModel engine in a thread pool
- Expose `get_async_database` helper for dependency injection
- Update fixtures to use the new async wrapper
- Create comprehensive tests for the async wrapper

## Problem Solved
- FastAPI async endpoints need async database operations
- Current synchronous SQLModel operations block async event loop
- Need proper async context management for database sessions
- Testing async database code requires special infrastructure

## Technical Approach
- Thread pool wrapper for synchronous SQLModel operations
- Proper async context manager implementation
- Integration with existing session management patterns
- Async-safe fixtures for testing

## Impact
- Foundation for async API endpoints
- Non-blocking database operations in async contexts
- Better performance for concurrent requests
- Proper async testing infrastructure

This enables the development of modern async FastAPI endpoints while maintaining compatibility with existing SQLModel patterns.

🤖 Generated with [Claude Code](https://claude.ai/code)