### PR TITLE
Fix async fixture registration

### DIFF
--- a/tests/api/test_async_endpoints.py
+++ b/tests/api/test_async_endpoints.py
@@ -1,9 +1,14 @@
-from tests.fixtures.async_utils import isolated_event_loop, async_test, async_session
+import pytest
+
+from tests.fixtures.async_utils import (
+    isolated_event_loop,
+    async_session,
+    async_test_db,
+)
 
 
-@async_test
+@pytest.mark.asyncio
 async def test_async_endpoint(isolated_event_loop, async_session):
     """Test async endpoint with proper isolation."""
-    # Example async test logic
     assert True
 


### PR DESCRIPTION
## Summary
- fix async endpoint test using pytest async/fixture pattern

## Testing
- `python3 -m pytest -n auto`
