### PR TITLE
Add formatter configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ lint:
 
 # Formatting
 format:
+	poetry run isort src tests
 	poetry run black src tests
 
 # Cleaning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,13 @@ filterwarnings = [
     "ignore::DeprecationWarning:litellm.utils:",
 ]
 
+[tool.black]
+line-length = 100
+
+[tool.isort]
+line_length = 100
+known_first_party = ["local_newsifier"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- configure Black and isort with shared line length
- run both tools from the Makefile

## Testing
- `make test` *(fails: Command not found: pytest)*