### PR TITLE
Update docs: mention offline setup for tests

### DIFF
--- a/docs/test_execution.md
+++ b/docs/test_execution.md
@@ -2,6 +2,15 @@
 
 This document provides information on how to effectively run tests for the Local Newsifier project, with special focus on parallel test execution.
 
+Before running tests, install all dependencies from the `wheels/` directory and
+download the required spaCy models:
+
+```bash
+make setup-poetry -- --no-index --find-links=wheels
+make setup-spacy
+```
+
+
 ## Test Configuration
 
 The Local Newsifier project uses pytest with the following components:

--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -2,6 +2,15 @@
 
 This document explains how to effectively run and optimize tests in the Local Newsifier project.
 
+Before running tests, install dependencies and spaCy models using:
+
+```bash
+make setup-poetry -- --no-index --find-links=wheels
+make setup-spacy
+```
+
+See [Python Setup](python_setup.md) for full environment preparation details.
+
 ## Running Tests
 
 ### Basic Test Run


### PR DESCRIPTION
## Summary
- mention `make setup-poetry` and `make setup-spacy` before running tests in the execution guide
- add the same note with link to `python_setup.md` near the start of the testing guide

## Testing
- `make test` *(fails: Command not found: pytest)*