### PR TITLE
Add ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,11 @@ repos:
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-docstrings]
+
+-   repo: local
+    hooks:
+    -   id: ruff
+        name: ruff (E501 and W291)
+        entry: ruff
+        language: system
+        args: [check, --select, "E501,W291"]


### PR DESCRIPTION
## Summary
- run ruff in pre-commit to check for line length and trailing whitespace

## Testing
- `pre-commit run --config ruff_precommit.yaml --files conftest.py`
- `make test` *(fails: Command not found: pytest)*