### PR TITLE
Refactor EntityTracker tool to rely on EntityService

### DIFF
--- a/src/local_newsifier/di/providers.py
+++ b/src/local_newsifier/di/providers.py
@@ -10,7 +10,7 @@ Dependency injection approach:
 - use_cache=True (default): Could be used for purely functional utilities with no state
   that just transform inputs to outputs in a deterministic way
 
-Most of our components use use_cache=False for safety, since they either directly 
+Most of our components use use_cache=False for safety, since they either directly
 interact with the database or maintain state between operations.
 """
 
@@ -54,18 +54,19 @@ logger = logging.getLogger(__name__)
 
 # Database providers
 
+
 @injectable(use_cache=False)
 def get_session() -> Generator[Session, None, None]:
     """Provide a database session.
-    
+
     Returns a session from the session factory and ensures
     it's properly closed when done.
-    
+
     Yields:
         Database session
     """
     from local_newsifier.database.engine import get_session as get_db_session
-    
+
     session = next(get_db_session())
     try:
         yield session
@@ -79,144 +80,155 @@ def get_session() -> Generator[Session, None, None]:
 @injectable(use_cache=False)
 def get_article_crud():
     """Provide the article CRUD component.
-    
-    Uses use_cache=False to create new instances for each injection, as CRUD 
+
+    Uses use_cache=False to create new instances for each injection, as CRUD
     components interact with the database and should not share state between operations.
-    
+
     Returns:
         ArticleCRUD instance
     """
     from local_newsifier.crud.article import article
+
     return article
 
 
 @injectable(use_cache=False)
 def get_entity_crud():
     """Provide the entity CRUD component.
-    
-    Uses use_cache=False to create new instances for each injection, as CRUD 
+
+    Uses use_cache=False to create new instances for each injection, as CRUD
     components interact with the database and should not share state between operations.
-    
+
     Returns:
         EntityCRUD instance
     """
     from local_newsifier.crud.entity import entity
+
     return entity
 
 
 @injectable(use_cache=False)
 def get_entity_relationship_crud():
     """Provide the entity relationship CRUD component.
-    
-    Uses use_cache=False to create new instances for each injection, as CRUD 
+
+    Uses use_cache=False to create new instances for each injection, as CRUD
     components interact with the database and should not share state between operations.
-    
+
     Returns:
         EntityRelationshipCRUD instance
     """
     from local_newsifier.crud.entity_relationship import entity_relationship
+
     return entity_relationship
 
 
 @injectable(use_cache=False)
 def get_rss_feed_crud():
     """Provide the RSS feed CRUD component.
-    
-    Uses use_cache=False to create new instances for each injection, as CRUD 
+
+    Uses use_cache=False to create new instances for each injection, as CRUD
     components interact with the database and should not share state between operations.
-    
+
     Returns:
         RSSFeedCRUD instance
     """
     from local_newsifier.crud.rss_feed import rss_feed
+
     return rss_feed
 
 
 @injectable(use_cache=False)
 def get_analysis_result_crud():
     """Provide the analysis result CRUD component.
-    
-    Uses use_cache=False to create new instances for each injection, as CRUD 
+
+    Uses use_cache=False to create new instances for each injection, as CRUD
     components interact with the database and should not share state between operations.
-    
+
     Returns:
         AnalysisResultCRUD instance
     """
     from local_newsifier.crud.analysis_result import analysis_result
+
     return analysis_result
 
 
 @injectable(use_cache=False)
 def get_canonical_entity_crud():
     """Provide the canonical entity CRUD component.
-    
-    Uses use_cache=False to create new instances for each injection, as CRUD 
+
+    Uses use_cache=False to create new instances for each injection, as CRUD
     components interact with the database and should not share state between operations.
-    
+
     Returns:
         CanonicalEntityCRUD instance
     """
     from local_newsifier.crud.canonical_entity import canonical_entity
+
     return canonical_entity
 
 
 @injectable(use_cache=False)
 def get_entity_mention_context_crud():
     """Provide the entity mention context CRUD component.
-    
-    Uses use_cache=False to create new instances for each injection, as CRUD 
+
+    Uses use_cache=False to create new instances for each injection, as CRUD
     components interact with the database and should not share state between operations.
-    
+
     Returns:
         EntityMentionContextCRUD instance
     """
     from local_newsifier.crud.entity_mention_context import entity_mention_context
+
     return entity_mention_context
 
 
 @injectable(use_cache=False)
 def get_entity_profile_crud():
     """Provide the entity profile CRUD component.
-    
-    Uses use_cache=False to create new instances for each injection, as CRUD 
+
+    Uses use_cache=False to create new instances for each injection, as CRUD
     components interact with the database and should not share state between operations.
-    
+
     Returns:
         EntityProfileCRUD instance
     """
     from local_newsifier.crud.entity_profile import entity_profile
+
     return entity_profile
 
 
 @injectable(use_cache=False)
 def get_feed_processing_log_crud():
     """Provide the feed processing log CRUD component.
-    
-    Uses use_cache=False to create new instances for each injection, as CRUD 
+
+    Uses use_cache=False to create new instances for each injection, as CRUD
     components interact with the database and should not share state between operations.
-    
+
     Returns:
         FeedProcessingLogCRUD instance
     """
     from local_newsifier.crud.feed_processing_log import feed_processing_log
+
     return feed_processing_log
 
 
 @injectable(use_cache=False)
 def get_apify_source_config_crud():
     """Provide the Apify source config CRUD component.
-    
-    Uses use_cache=False to create new instances for each injection, as CRUD 
+
+    Uses use_cache=False to create new instances for each injection, as CRUD
     components interact with the database and should not share state between operations.
-    
+
     Returns:
         CRUDApifySourceConfig instance
     """
     from local_newsifier.crud.apify_source_config import apify_source_config
+
     return apify_source_config
 
 
 # Tool providers
+
 
 @injectable(use_cache=False)
 def get_nlp_model() -> Any:
@@ -230,11 +242,14 @@ def get_nlp_model() -> Any:
     """
     try:
         import spacy
+
         return spacy.load("en_core_web_lg")
     except (ImportError, OSError) as e:
         import logging
+
         logging.warning(f"Failed to load NLP model: {str(e)}")
         return None
+
 
 @injectable(use_cache=False)
 def get_web_scraper_tool():
@@ -250,6 +265,7 @@ def get_web_scraper_tool():
 
     # Create a new requests session for this instance
     import requests
+
     session = requests.Session()
 
     # Set a standard user agent
@@ -262,7 +278,7 @@ def get_web_scraper_tool():
     return WebScraperTool(
         session=session,
         web_driver=None,  # WebDriver will be created lazily when needed
-        user_agent=user_agent
+        user_agent=user_agent,
     )
 
 
@@ -276,9 +292,8 @@ def get_sentiment_analyzer_config():
     Returns:
         Configuration dictionary with model_name
     """
-    return {
-        "model_name": "en_core_web_sm"
-    }
+    return {"model_name": "en_core_web_sm"}
+
 
 @injectable(use_cache=False)
 def get_sentiment_analyzer_tool():
@@ -291,13 +306,12 @@ def get_sentiment_analyzer_tool():
         SentimentAnalyzer instance
     """
     from local_newsifier.tools.sentiment_analyzer import SentimentAnalyzer
+
     return SentimentAnalyzer(nlp_model=get_nlp_model())
 
 
 @injectable(use_cache=False)
-def get_sentiment_tracker_tool(
-    session=Depends(get_session)
-):
+def get_sentiment_tracker_tool(session=Depends(get_session)):
     """Provide the sentiment tracker tool.
 
     Uses use_cache=False to create new instances for each injection, as it
@@ -310,13 +324,12 @@ def get_sentiment_tracker_tool(
         SentimentTracker instance
     """
     from local_newsifier.tools.sentiment_tracker import SentimentTracker
+
     return SentimentTracker(session_factory=lambda: session)
 
 
 @injectable(use_cache=False)
-def get_opinion_visualizer_tool(
-    session: Annotated[Session, Depends(get_session)]
-):
+def get_opinion_visualizer_tool(session: Annotated[Session, Depends(get_session)]):
     """Provide the opinion visualizer tool.
 
     Uses use_cache=False to create new instances for each injection, as it
@@ -329,6 +342,7 @@ def get_opinion_visualizer_tool(
         OpinionVisualizerTool instance
     """
     from local_newsifier.tools.opinion_visualizer import OpinionVisualizerTool
+
     return OpinionVisualizerTool(session=session)
 
 
@@ -342,9 +356,8 @@ def get_trend_analyzer_config():
     Returns:
         Configuration dictionary with model_name
     """
-    return {
-        "model_name": "en_core_web_lg"
-    }
+    return {"model_name": "en_core_web_lg"}
+
 
 @injectable(use_cache=False)
 def get_trend_analyzer_tool():
@@ -357,20 +370,22 @@ def get_trend_analyzer_tool():
         TrendAnalyzer instance
     """
     from local_newsifier.tools.analysis.trend_analyzer import TrendAnalyzer
+
     return TrendAnalyzer(nlp_model=get_nlp_model())
 
 
 @injectable(use_cache=False)
 def get_trend_reporter_tool():
     """Provide the trend reporter tool.
-    
+
     Uses use_cache=False to create new instances for each injection, as it
     maintains state during report generation and handles file operations.
-    
+
     Returns:
         TrendReporter instance
     """
     from local_newsifier.tools.trend_reporter import TrendReporter
+
     return TrendReporter(output_dir="trend_output")
 
 
@@ -384,9 +399,8 @@ def get_context_analyzer_config():
     Returns:
         Configuration dictionary with model_name
     """
-    return {
-        "model_name": "en_core_web_lg"
-    }
+    return {"model_name": "en_core_web_lg"}
+
 
 @injectable(use_cache=False)
 def get_context_analyzer_tool():
@@ -399,31 +413,33 @@ def get_context_analyzer_tool():
         ContextAnalyzer instance
     """
     from local_newsifier.tools.analysis.context_analyzer import ContextAnalyzer
+
     return ContextAnalyzer(nlp_model=get_nlp_model())
 
 
 @injectable(use_cache=False)
 def get_entity_extractor():
     """Provide the entity extractor tool.
-    
-    Uses use_cache=False to create new instances for each injection, as NLP 
+
+    Uses use_cache=False to create new instances for each injection, as NLP
     tools may have stateful caches or models.
-    
+
     Returns:
         EntityExtractor instance
     """
     from local_newsifier.tools.extraction.entity_extractor import EntityExtractor
+
     return EntityExtractor()
 
 
 @injectable(use_cache=False)
 def get_entity_extractor_tool():
     """Provide the entity extractor tool (alias with _tool suffix).
-    
+
     This provides the same entity extractor with a consistent naming pattern.
-    Uses use_cache=False to create new instances for each injection, as NLP 
+    Uses use_cache=False to create new instances for each injection, as NLP
     tools may have stateful caches or models.
-    
+
     Returns:
         EntityExtractor instance
     """
@@ -440,14 +456,11 @@ def get_entity_resolver_config():
     Returns:
         Configuration dictionary with similarity_threshold
     """
-    return {
-        "similarity_threshold": 0.85
-    }
+    return {"similarity_threshold": 0.85}
+
 
 @injectable(use_cache=False)
-def get_entity_resolver(
-    config: Annotated[Dict, Depends(get_entity_resolver_config)]
-):
+def get_entity_resolver(config: Annotated[Dict, Depends(get_entity_resolver_config)]):
     """Provide the entity resolver tool.
 
     Uses use_cache=False to create new instances for each injection, as this tool
@@ -460,17 +473,18 @@ def get_entity_resolver(
         EntityResolver instance
     """
     from local_newsifier.tools.resolution.entity_resolver import EntityResolver
+
     return EntityResolver(similarity_threshold=config["similarity_threshold"])
 
 
 @injectable(use_cache=False)
 def get_entity_resolver_tool():
     """Provide the entity resolver tool (alias with _tool suffix).
-    
+
     This provides the same entity resolver with a consistent naming pattern.
     Uses use_cache=False to create new instances for each injection, as this tool
     may have state during the resolution process.
-    
+
     Returns:
         EntityResolver instance
     """
@@ -490,13 +504,12 @@ def get_rss_parser_config():
     return {
         "cache_dir": "cache",
         "request_timeout": 30,
-        "user_agent": "Local Newsifier RSS Parser"
+        "user_agent": "Local Newsifier RSS Parser",
     }
 
+
 @injectable(use_cache=False)
-def get_rss_parser(
-    config: Annotated[Dict, Depends(get_rss_parser_config)]
-):
+def get_rss_parser(config: Annotated[Dict, Depends(get_rss_parser_config)]):
     """Provide the RSS parser tool.
 
     Uses use_cache=False to create new instances for each injection, as parsers
@@ -509,10 +522,11 @@ def get_rss_parser(
         RSSParser instance
     """
     from local_newsifier.tools.rss_parser import RSSParser
+
     return RSSParser(
         cache_dir=config["cache_dir"],
         request_timeout=config["request_timeout"],
-        user_agent=config["user_agent"]
+        user_agent=config["user_agent"],
     )
 
 
@@ -526,14 +540,11 @@ def get_file_writer_config():
     Returns:
         Configuration dictionary with output_dir
     """
-    return {
-        "output_dir": "output"
-    }
+    return {"output_dir": "output"}
+
 
 @injectable(use_cache=False)
-def get_file_writer_tool(
-    config: Annotated[Dict, Depends(get_file_writer_config)]
-):
+def get_file_writer_tool(config: Annotated[Dict, Depends(get_file_writer_config)]):
     """Provide the file writer tool.
 
     Uses use_cache=False to create new instances for each injection, as this tool
@@ -546,6 +557,7 @@ def get_file_writer_tool(
         FileWriterTool instance
     """
     from local_newsifier.tools.file_writer import FileWriterTool
+
     return FileWriterTool(output_dir=config["output_dir"])
 
 
@@ -553,20 +565,26 @@ def get_file_writer_tool(
 @injectable(use_cache=False)
 def get_entity_service(
     entity_crud: Annotated["CRUDEntity", Depends(get_entity_crud)],
-    canonical_entity_crud: Annotated["CRUDCanonicalEntity", Depends(get_canonical_entity_crud)],
-    entity_mention_context_crud: Annotated["CRUDEntityMentionContext", Depends(get_entity_mention_context_crud)],
-    entity_profile_crud: Annotated["CRUDEntityProfile", Depends(get_entity_profile_crud)],
+    canonical_entity_crud: Annotated[
+        "CRUDCanonicalEntity", Depends(get_canonical_entity_crud)
+    ],
+    entity_mention_context_crud: Annotated[
+        "CRUDEntityMentionContext", Depends(get_entity_mention_context_crud)
+    ],
+    entity_profile_crud: Annotated[
+        "CRUDEntityProfile", Depends(get_entity_profile_crud)
+    ],
     article_crud: Annotated["CRUDArticle", Depends(get_article_crud)],
     entity_extractor: Annotated["EntityExtractor", Depends(get_entity_extractor)],
     context_analyzer: Annotated["ContextAnalyzer", Depends(get_context_analyzer_tool)],
     entity_resolver: Annotated["EntityResolver", Depends(get_entity_resolver)],
-    session: Annotated[Session, Depends(get_session)]
+    session: Annotated[Session, Depends(get_session)],
 ):
     """Provide the entity service.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         entity_crud: Entity CRUD component
         canonical_entity_crud: Canonical entity CRUD component
@@ -577,12 +595,12 @@ def get_entity_service(
         context_analyzer: Context analyzer tool
         entity_resolver: Entity resolver tool
         session: Database session
-        
+
     Returns:
         EntityService instance
     """
     from local_newsifier.services.entity_service import EntityService
-    
+
     return EntityService(
         entity_crud=entity_crud,
         canonical_entity_crud=canonical_entity_crud,
@@ -592,78 +610,82 @@ def get_entity_service(
         entity_extractor=entity_extractor,
         context_analyzer=context_analyzer,
         entity_resolver=entity_resolver,
-        session_factory=lambda: session
+        session_factory=lambda: session,
     )
 
 
 @injectable(use_cache=False)
 def get_entity_tracker_tool(
     entity_service: Annotated["EntityService", Depends(get_entity_service)],
-    session: Annotated[Session, Depends(get_session)]
 ):
     """Provide the entity tracker tool.
 
     Uses use_cache=False to create new instances for each injection, as this tool
     maintains state during the entity tracking process.
-    
+
     Args:
         entity_service: Service for entity operations
-        session: Database session
 
     Returns:
         EntityTracker instance
     """
     from local_newsifier.tools.entity_tracker_service import EntityTracker
-    return EntityTracker(entity_service=entity_service, session=session)
+
+    return EntityTracker(entity_service=entity_service)
 
 
 @injectable(use_cache=False)
 def get_apify_service():
     """Provide the Apify service.
-    
+
     Uses use_cache=False to create new instances for each injection, as it
     interacts with external APIs that require fresh client instances.
-    
+
     Returns:
         ApifyService instance
     """
     from local_newsifier.services.apify_service import ApifyService
+
     return ApifyService()
 
 
 @injectable(use_cache=False)
 def get_apify_schedule_manager(
     apify_service: Annotated["ApifyService", Depends(get_apify_service)],
-    apify_source_config_crud: Annotated["CRUDApifySourceConfig", Depends(get_apify_source_config_crud)],
-    session: Annotated[Session, Depends(get_session)]
+    apify_source_config_crud: Annotated[
+        "CRUDApifySourceConfig", Depends(get_apify_source_config_crud)
+    ],
+    session: Annotated[Session, Depends(get_session)],
 ):
     """Provide the Apify schedule manager service.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         apify_service: Apify service for API interactions
         apify_source_config_crud: CRUD for Apify source configurations
         session: Database session
-        
+
     Returns:
         ApifyScheduleManager instance
     """
     from local_newsifier.services.apify_schedule_manager import ApifyScheduleManager
-    
+
     return ApifyScheduleManager(
         apify_service=apify_service,
         apify_source_config_crud=apify_source_config_crud,
-        session_factory=lambda: session
+        session_factory=lambda: session,
     )
 
 
 @injectable(use_cache=False)
 def get_apify_source_config_service(
-    apify_source_config_crud: Annotated["CRUDApifySourceConfig", Depends(get_apify_source_config_crud)],
+    apify_source_config_crud: Annotated[
+        "CRUDApifySourceConfig", Depends(get_apify_source_config_crud)
+    ],
     apify_service: Annotated["ApifyService", Depends(get_apify_service)],
-    session: Annotated[Session, Depends(get_session)]
+    session: Annotated[Session, Depends(get_session)],
 ):
     """Provide the ApifySourceConfigService for CLI commands.
 
@@ -678,77 +700,83 @@ def get_apify_source_config_service(
     Returns:
         ApifySourceConfigService instance
     """
-    from local_newsifier.services.apify_source_config_service import ApifySourceConfigService
+    from local_newsifier.services.apify_source_config_service import (
+        ApifySourceConfigService,
+    )
 
     return ApifySourceConfigService(
         apify_source_config_crud=apify_source_config_crud,
         apify_service=apify_service,
-        session_factory=lambda: session
+        session_factory=lambda: session,
     )
 
 
 @injectable(use_cache=False)
 def get_analysis_service(
-    analysis_result_crud: Annotated["CRUDAnalysisResult", Depends(get_analysis_result_crud)],
+    analysis_result_crud: Annotated[
+        "CRUDAnalysisResult", Depends(get_analysis_result_crud)
+    ],
     article_crud: Annotated["CRUDArticle", Depends(get_article_crud)],
     entity_crud: Annotated["CRUDEntity", Depends(get_entity_crud)],
     trend_analyzer: Annotated["TrendAnalyzer", Depends(get_trend_analyzer_tool)],
-    session: Annotated[Session, Depends(get_session)]
+    session: Annotated[Session, Depends(get_session)],
 ):
     """Provide the analysis service.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         analysis_result_crud: Analysis result CRUD component
         article_crud: Article CRUD component
         entity_crud: Entity CRUD component
         trend_analyzer: Trend analyzer tool
         session: Database session
-        
+
     Returns:
         AnalysisService instance
     """
     from local_newsifier.services.analysis_service import AnalysisService
-    
+
     return AnalysisService(
         analysis_result_crud=analysis_result_crud,
         article_crud=article_crud,
         entity_crud=entity_crud,
         trend_analyzer=trend_analyzer,
-        session_factory=lambda: session
+        session_factory=lambda: session,
     )
 
 
 @injectable(use_cache=False)
 def get_article_service(
     article_crud: Annotated["CRUDArticle", Depends(get_article_crud)],
-    analysis_result_crud: Annotated["CRUDAnalysisResult", Depends(get_analysis_result_crud)],
+    analysis_result_crud: Annotated[
+        "CRUDAnalysisResult", Depends(get_analysis_result_crud)
+    ],
     entity_service: Annotated["EntityService", Depends(get_entity_service)],
-    session: Annotated[Session, Depends(get_session)]
+    session: Annotated[Session, Depends(get_session)],
 ):
     """Provide the article service.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         article_crud: Article CRUD component
         analysis_result_crud: Analysis result CRUD component
         entity_service: Entity service
         session: Database session
-        
+
     Returns:
         ArticleService instance
     """
     from local_newsifier.services.article_service import ArticleService
-    
+
     return ArticleService(
         article_crud=article_crud,
         analysis_result_crud=analysis_result_crud,
         entity_service=entity_service,
-        session_factory=lambda: session
+        session_factory=lambda: session,
     )
 
 
@@ -757,125 +785,123 @@ def get_news_pipeline_service(
     article_service: Annotated[Any, Depends(get_article_service)],
     web_scraper: Annotated[Any, Depends(get_web_scraper_tool)],
     file_writer: Annotated[Any, Depends(get_file_writer_tool)],
-    session: Annotated[Session, Depends(get_session)]
+    session: Annotated[Session, Depends(get_session)],
 ):
     """Provide the news pipeline service.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         article_service: Article service
         web_scraper: Web scraper tool
         file_writer: File writer tool
         session: Database session
-        
+
     Returns:
         NewsPipelineService instance
     """
     from local_newsifier.services.news_pipeline_service import NewsPipelineService
-    
+
     return NewsPipelineService(
         article_service=article_service,
         web_scraper=web_scraper,
         file_writer=file_writer,
-        session_factory=lambda: session
+        session_factory=lambda: session,
     )
 
 
 @injectable(use_cache=False)
 def get_rss_feed_service(
     rss_feed_crud: Annotated["CRUDRSSFeed", Depends(get_rss_feed_crud)],
-    feed_processing_log_crud: Annotated["CRUDFeedProcessingLog", Depends(get_feed_processing_log_crud)],
+    feed_processing_log_crud: Annotated[
+        "CRUDFeedProcessingLog", Depends(get_feed_processing_log_crud)
+    ],
     article_service: Annotated["ArticleService", Depends(get_article_service)],
-    session: Annotated[Session, Depends(get_session)]
+    session: Annotated[Session, Depends(get_session)],
 ):
     """Provide the RSS feed service.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         rss_feed_crud: RSS feed CRUD component
         feed_processing_log_crud: Feed processing log CRUD component
         article_service: Article service
         session: Database session
-        
+
     Returns:
         RSSFeedService instance
     """
     from local_newsifier.services.rss_feed_service import RSSFeedService
-    
+
     return RSSFeedService(
         rss_feed_crud=rss_feed_crud,
         feed_processing_log_crud=feed_processing_log_crud,
         article_service=article_service,
-        session_factory=lambda: session
+        session_factory=lambda: session,
     )
 
 
 # Flow providers
 
+
 @injectable(use_cache=False)
 def get_entity_tracking_flow(
     entity_service: Annotated["EntityService", Depends(get_entity_service)],
-    entity_tracker: Annotated["EntityTracker", Depends(get_entity_tracker_tool)],
     entity_extractor: Annotated["EntityExtractor", Depends(get_entity_extractor_tool)],
     context_analyzer: Annotated["ContextAnalyzer", Depends(get_context_analyzer_tool)],
     entity_resolver: Annotated["EntityResolver", Depends(get_entity_resolver_tool)],
-    session: Annotated[Session, Depends(get_session)]
+    session: Annotated[Session, Depends(get_session)],
 ) -> "EntityTrackingFlow":
     """Provide the entity tracking flow with injectable dependencies.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         entity_service: Entity service
-        entity_tracker: Entity tracker tool
         entity_extractor: Entity extractor tool
         context_analyzer: Context analyzer tool
         entity_resolver: Entity resolver tool
         session: Database session
-        
+
     Returns:
         EntityTrackingFlow instance
     """
     from local_newsifier.flows.entity_tracking_flow import EntityTrackingFlow
+
     return EntityTrackingFlow(
         entity_service=entity_service,
-        entity_tracker=entity_tracker,
         entity_extractor=entity_extractor,
         context_analyzer=context_analyzer,
         entity_resolver=entity_resolver,
         session=session,
-        session_factory=lambda: session
+        session_factory=lambda: session,
     )
 
 
 @injectable(use_cache=False)
 def get_headline_trend_flow(
     analysis_service: Annotated[Any, Depends(get_analysis_service)],
-    session: Annotated[Session, Depends(get_session)]
+    session: Annotated[Session, Depends(get_session)],
 ) -> "HeadlineTrendFlow":
     """Provide the headline trend flow.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         analysis_service: Analysis service
         session: Database session
-        
+
     Returns:
         HeadlineTrendFlow instance
     """
     from local_newsifier.flows.analysis.headline_trend_flow import HeadlineTrendFlow
-    
-    return HeadlineTrendFlow(
-        analysis_service=analysis_service,
-        session=session
-    )
+
+    return HeadlineTrendFlow(analysis_service=analysis_service, session=session)
 
 
 @injectable(use_cache=False)
@@ -884,32 +910,32 @@ def get_rss_scraping_flow(
     article_service: Annotated[Any, Depends(get_article_service)],
     rss_parser: Annotated[Any, Depends(get_rss_parser)],
     web_scraper: Annotated[Any, Depends(get_web_scraper_tool)],
-    session: Annotated[Session, Depends(get_session)]
+    session: Annotated[Session, Depends(get_session)],
 ) -> "RSSScrapingFlow":
     """Provide the RSS scraping flow with injectable dependencies.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         rss_feed_service: RSS feed service
         article_service: Article service
         rss_parser: RSS parser tool
         web_scraper: Web scraper tool
         session: Database session
-        
+
     Returns:
         RSSScrapingFlow instance
     """
     from local_newsifier.flows.rss_scraping_flow import RSSScrapingFlow
-    
+
     return RSSScrapingFlow(
         rss_feed_service=rss_feed_service,
         article_service=article_service,
         rss_parser=rss_parser,
         web_scraper=web_scraper,
         cache_dir="cache",
-        session_factory=lambda: session
+        session_factory=lambda: session,
     )
 
 
@@ -923,13 +949,13 @@ def get_news_pipeline_flow(
     entity_extractor: Annotated[Any, Depends(get_entity_extractor_tool)],
     context_analyzer: Annotated[Any, Depends(get_context_analyzer_tool)],
     entity_resolver: Annotated[Any, Depends(get_entity_resolver_tool)],
-    session: Annotated[Session, Depends(get_session)]
+    session: Annotated[Session, Depends(get_session)],
 ) -> "NewsPipelineFlow":
     """Provide the news pipeline flow with injectable dependencies.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         article_service: Article service
         entity_service: Entity service
@@ -940,11 +966,12 @@ def get_news_pipeline_flow(
         context_analyzer: Context analyzer tool
         entity_resolver: Entity resolver tool
         session: Database session
-        
+
     Returns:
         NewsPipelineFlow instance
     """
     from local_newsifier.flows.news_pipeline import NewsPipelineFlow
+
     return NewsPipelineFlow(
         article_service=article_service,
         entity_service=entity_service,
@@ -955,7 +982,7 @@ def get_news_pipeline_flow(
         context_analyzer=context_analyzer,
         entity_resolver=entity_resolver,
         session=session,
-        session_factory=lambda: session
+        session_factory=lambda: session,
     )
 
 
@@ -963,208 +990,225 @@ def get_news_pipeline_flow(
 def get_trend_analysis_flow(
     analysis_service: Annotated["AnalysisService", Depends(get_analysis_service)],
     trend_reporter: Annotated["TrendReporter", Depends(get_trend_reporter_tool)],
-    session: Annotated[Session, Depends(get_session)]
+    session: Annotated[Session, Depends(get_session)],
 ) -> "NewsTrendAnalysisFlow":
     """Provide the trend analysis flow with injectable dependencies.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         analysis_service: Analysis service
         trend_reporter: Trend reporter tool
         session: Database session
-        
+
     Returns:
         NewsTrendAnalysisFlow instance
     """
     from local_newsifier.flows.trend_analysis_flow import NewsTrendAnalysisFlow
     from local_newsifier.models.trend import TrendAnalysisConfig
+
     return NewsTrendAnalysisFlow(
         analysis_service=analysis_service,
         trend_reporter=trend_reporter,
         session=session,
-        config=TrendAnalysisConfig()
+        config=TrendAnalysisConfig(),
     )
 
 
 @injectable(use_cache=False)
 def get_public_opinion_flow(
-    sentiment_analyzer: Annotated["SentimentAnalyzer", Depends(get_sentiment_analyzer_tool)],
-    sentiment_tracker: Annotated["SentimentTracker", Depends(get_sentiment_tracker_tool)],
-    opinion_visualizer: Annotated["OpinionVisualizerTool", Depends(get_opinion_visualizer_tool)],
-    session: Annotated[Session, Depends(get_session)]
+    sentiment_analyzer: Annotated[
+        "SentimentAnalyzer", Depends(get_sentiment_analyzer_tool)
+    ],
+    sentiment_tracker: Annotated[
+        "SentimentTracker", Depends(get_sentiment_tracker_tool)
+    ],
+    opinion_visualizer: Annotated[
+        "OpinionVisualizerTool", Depends(get_opinion_visualizer_tool)
+    ],
+    session: Annotated[Session, Depends(get_session)],
 ) -> "PublicOpinionFlow":
     """Provide the public opinion flow with injectable dependencies.
-    
+
     Uses use_cache=False to create new instances for each injection,
     preventing state leakage between operations.
-    
+
     Args:
         sentiment_analyzer: Sentiment analysis tool
         sentiment_tracker: Sentiment tracker tool
         opinion_visualizer: Opinion visualizer tool
         session: Database session
-        
+
     Returns:
         PublicOpinionFlow instance
     """
     from local_newsifier.flows.public_opinion_flow import PublicOpinionFlow
+
     return PublicOpinionFlow(
         sentiment_analyzer=sentiment_analyzer,
         sentiment_tracker=sentiment_tracker,
         opinion_visualizer=opinion_visualizer,
-        session=session
+        session=session,
     )
 
 
 # CLI command providers
 
+
 @injectable(use_cache=False)
 def get_injectable_entity_tracker(
     entity_service: Annotated["EntityService", Depends(get_entity_service)],
-    session: Annotated[Session, Depends(get_session)]
 ):
     """Provide the injectable entity tracker tool.
-    
+
     Uses use_cache=False to create new instances for each injection, as this tool
     maintains state during the entity tracking process.
-    
+
     Args:
         entity_service: Service for entity operations
-        session: Database session
-    
+
     Returns:
         InjectableEntityTracker instance with injected dependencies
     """
     from local_newsifier.tools.entity_tracker_service import EntityTracker
-    return EntityTracker(entity_service=entity_service, session=session)
+
+    return EntityTracker(entity_service=entity_service)
 
 
 @injectable(use_cache=False)
 def get_apify_service_cli(token: Optional[str] = None):
     """Provide the Apify service for CLI commands.
-    
+
     This is a special provider for the CLI that allows passing a token from
     command-line arguments, environment variables, or settings.
-    
+
     Args:
         token: Optional Apify token to use (overrides settings)
-        
+
     Returns:
         ApifyService instance
     """
     from local_newsifier.services.apify_service import ApifyService
+
     return ApifyService(token=token)
 
 
 @injectable(use_cache=False)
 def get_db_stats_command():
     """Provide the database stats command function.
-    
+
     Uses use_cache=False to create a new instance for each injection,
     preventing session leakage between operations.
-    
+
     Returns:
         Function to execute db stats command
     """
     from local_newsifier.cli.commands.db import db_stats
+
     return db_stats
 
 
 @injectable(use_cache=False)
 def get_db_duplicates_command():
     """Provide the database duplicates command function.
-    
+
     Uses use_cache=False to create a new instance for each injection,
     preventing session leakage between operations.
-    
+
     Returns:
         Function to execute db duplicates command
     """
     from local_newsifier.cli.commands.db import check_duplicates
+
     return check_duplicates
 
 
 @injectable(use_cache=False)
 def get_db_articles_command():
     """Provide the database articles command function.
-    
+
     Uses use_cache=False to create a new instance for each injection,
     preventing session leakage between operations.
-    
+
     Returns:
         Function to execute db articles command
     """
     from local_newsifier.cli.commands.db import list_articles
+
     return list_articles
 
 
 @injectable(use_cache=False)
 def get_db_inspect_command():
     """Provide the database inspect command function.
-    
+
     Uses use_cache=False to create a new instance for each injection,
     preventing session leakage between operations.
-    
+
     Returns:
         Function to execute db inspect command
     """
     from local_newsifier.cli.commands.db import inspect_record
+
     return db_inspect_command
 
 
 @injectable(use_cache=False)
 def get_feeds_list_command():
     """Provide the feeds list command function.
-    
+
     Uses use_cache=False to create a new instance for each injection,
     preventing session leakage between operations.
-    
+
     Returns:
         Function to execute feeds list command
     """
     from local_newsifier.cli.commands.feeds import list_feeds
+
     return list_feeds
 
 
 @injectable(use_cache=False)
 def get_feeds_add_command():
     """Provide the feeds add command function.
-    
+
     Uses use_cache=False to create a new instance for each injection,
     preventing session leakage between operations.
-    
+
     Returns:
         Function to execute feeds add command
     """
     from local_newsifier.cli.commands.feeds import add_feed
+
     return add_feed
 
 
 @injectable(use_cache=False)
 def get_feeds_show_command():
     """Provide the feeds show command function.
-    
+
     Uses use_cache=False to create a new instance for each injection,
     preventing session leakage between operations.
-    
+
     Returns:
         Function to execute feeds show command
     """
     from local_newsifier.cli.commands.feeds import show_feed
+
     return show_feed
 
 
 @injectable(use_cache=False)
 def get_feeds_process_command():
     """Provide the feeds process command function.
-    
+
     Uses use_cache=False to create a new instance for each injection,
     preventing session leakage between operations.
-    
+
     Returns:
         Function to execute feeds process command
     """
     from local_newsifier.cli.commands.feeds import process_feed
+
     return process_feed

--- a/src/local_newsifier/flows/entity_tracking_flow.py
+++ b/src/local_newsifier/flows/entity_tracking_flow.py
@@ -9,17 +9,23 @@ from fastapi_injectable import injectable
 from sqlmodel import Session
 
 from local_newsifier.crud.article import article as article_crud
-from local_newsifier.crud.canonical_entity import canonical_entity as canonical_entity_crud
+from local_newsifier.crud.canonical_entity import (
+    canonical_entity as canonical_entity_crud,
+)
 from local_newsifier.crud.entity import entity as entity_crud
-from local_newsifier.crud.entity_mention_context import entity_mention_context as entity_mention_context_crud
+from local_newsifier.crud.entity_mention_context import (
+    entity_mention_context as entity_mention_context_crud,
+)
 from local_newsifier.crud.entity_profile import entity_profile as entity_profile_crud
 from local_newsifier.models.entity_tracking import CanonicalEntity
 from local_newsifier.models.state import (
-    EntityTrackingState, EntityBatchTrackingState, 
-    EntityDashboardState, EntityRelationshipState, TrackingStatus
+    EntityTrackingState,
+    EntityBatchTrackingState,
+    EntityDashboardState,
+    EntityRelationshipState,
+    TrackingStatus,
 )
 from local_newsifier.services.entity_service import EntityService
-from local_newsifier.tools.entity_tracker_service import EntityTracker
 from local_newsifier.tools.extraction.entity_extractor import EntityExtractor
 from local_newsifier.tools.analysis.context_analyzer import ContextAnalyzer
 from local_newsifier.tools.resolution.entity_resolver import EntityResolver
@@ -29,20 +35,18 @@ class EntityTrackingFlow(Flow):
     """Flow for tracking entities across news articles using state-based pattern."""
 
     def __init__(
-        self, 
+        self,
         entity_service: Optional[EntityService] = None,
-        entity_tracker: Optional[EntityTracker] = None,
         entity_extractor: Optional[EntityExtractor] = None,
         context_analyzer: Optional[ContextAnalyzer] = None,
         entity_resolver: Optional[EntityResolver] = None,
         session_factory: Optional[callable] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ):
         """Initialize the entity tracking flow.
-        
+
         Args:
             entity_service: Service for entity operations
-            entity_tracker: Service for tracking entities
             entity_extractor: Tool for extracting entities
             context_analyzer: Tool for analyzing context
             entity_resolver: Tool for resolving entities
@@ -51,13 +55,12 @@ class EntityTrackingFlow(Flow):
         """
         super().__init__()
         self.session = session
-        
+
         # Use provided dependencies or create defaults for backward compatibility
-        self._entity_tracker = entity_tracker or EntityTracker()
         self._entity_extractor = entity_extractor or EntityExtractor()
         self._context_analyzer = context_analyzer or ContextAnalyzer()
         self._entity_resolver = entity_resolver or EntityResolver()
-        
+
         # Use provided entity service or create one with dependencies
         if entity_service:
             self.entity_service = entity_service
@@ -72,15 +75,15 @@ class EntityTrackingFlow(Flow):
                 entity_extractor=self._entity_extractor,
                 context_analyzer=self._context_analyzer,
                 entity_resolver=self._entity_resolver,
-                session_factory=session_factory
+                session_factory=session_factory,
             )
 
     def process(self, state: EntityTrackingState) -> EntityTrackingState:
         """Process a single article for entity tracking.
-        
+
         Args:
             state: EntityTrackingState containing article info
-            
+
         Returns:
             Updated state with processed entities
         """
@@ -93,96 +96,87 @@ class EntityTrackingFlow(Flow):
             state.add_log(f"Error processing article: {str(e)}")
             return state
 
-    def process_new_articles(self, state: Optional[EntityBatchTrackingState] = None) -> EntityBatchTrackingState:
+    def process_new_articles(
+        self, state: Optional[EntityBatchTrackingState] = None
+    ) -> EntityBatchTrackingState:
         """Process all new articles for entity tracking.
-        
+
         Args:
             state: Optional EntityBatchTrackingState (if not provided, a new one is created)
-            
+
         Returns:
             EntityBatchTrackingState with processed article results
         """
         # Create state if not provided
         if state is None:
             state = EntityBatchTrackingState(status_filter="analyzed")
-            
+
         return self.entity_service.process_articles_batch(state)
 
     def process_article(self, article_id: int) -> List[Dict]:
         """Legacy method for processing a single article by ID.
-        
+
         Args:
             article_id: ID of the article to process
-            
+
         Returns:
             List of processed entity mentions
         """
         with self.entity_service.session_factory() as session:
             # Get article
             article = article_crud.get(session, id=article_id)
-                
+
             if not article:
                 raise ValueError(f"Article with ID {article_id} not found")
-            
+
             # Create state for processing
             state = EntityTrackingState(
                 article_id=article.id,
                 content=article.content,
                 title=article.title,
-                published_at=article.published_at or datetime.now(timezone.utc)
+                published_at=article.published_at or datetime.now(timezone.utc),
             )
-            
+
             # Process article
             result_state = self.process(state)
-            
+
             # Return processed entities
             return result_state.entities
 
-    def get_entity_dashboard(
-        self, days: int = 30, entity_type: str = "PERSON"
-    ) -> Dict:
+    def get_entity_dashboard(self, days: int = 30, entity_type: str = "PERSON") -> Dict:
         """Generate entity tracking dashboard data.
-        
+
         Args:
             days: Number of days to include in the dashboard
             entity_type: Type of entities to include
-            
+
         Returns:
             Dashboard data with entity statistics
         """
         # Create state for dashboard generation
-        state = EntityDashboardState(
-            days=days,
-            entity_type=entity_type
-        )
-        
+        state = EntityDashboardState(days=days, entity_type=entity_type)
+
         # Generate dashboard
         result_state = self.entity_service.generate_entity_dashboard(state)
-        
+
         # Return dashboard data
         return result_state.dashboard_data
 
-    def find_entity_relationships(
-        self, entity_id: int, days: int = 30
-    ) -> Dict:
+    def find_entity_relationships(self, entity_id: int, days: int = 30) -> Dict:
         """Find relationships between entities based on co-occurrence.
-        
+
         Args:
             entity_id: ID of the canonical entity
             days: Number of days to include
-            
+
         Returns:
             Entity relationships data
         """
         # Create state for relationship analysis
-        state = EntityRelationshipState(
-            entity_id=entity_id,
-            days=days
-        )
-        
+        state = EntityRelationshipState(entity_id=entity_id, days=days)
+
         # Find relationships
         result_state = self.entity_service.find_entity_relationships(state)
-        
+
         # Return relationship data
         return result_state.relationship_data
-        

--- a/src/local_newsifier/tools/entity_tracker_service.py
+++ b/src/local_newsifier/tools/entity_tracker_service.py
@@ -1,87 +1,29 @@
-"""Entity tracker tool that uses the EntityService."""
+"""Entity tracker tool that delegates to :class:`EntityService`."""
 
-import os
 from datetime import datetime
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Any
 
-from sqlmodel import Session
-
-from local_newsifier.database.engine import with_session, get_session
 from local_newsifier.services.entity_service import EntityService
-from local_newsifier.crud.entity import entity as entity_crud
-from local_newsifier.crud.canonical_entity import canonical_entity as canonical_entity_crud
-from local_newsifier.crud.entity_mention_context import entity_mention_context as entity_mention_context_crud
-from local_newsifier.crud.entity_profile import entity_profile as entity_profile_crud
-from local_newsifier.crud.article import article as article_crud
-from local_newsifier.tools.extraction.entity_extractor import EntityExtractor
-from local_newsifier.tools.analysis.context_analyzer import ContextAnalyzer
-from local_newsifier.tools.resolution.entity_resolver import EntityResolver
 
 
 class EntityTracker:
-    """Tool for tracking entities across news articles using the EntityService."""
-    
-    def __init__(self, entity_service=None, session=None):
-        """Initialize with dependencies.
+    """Thin wrapper around :class:`EntityService`."""
 
-        Args:
-            entity_service: Service for entity operations
-            session: Database session
-        """
+    def __init__(self, entity_service: EntityService) -> None:
+        """Store the injected :class:`EntityService`."""
         self.entity_service = entity_service
-        self.session = session
 
-        # Initialize dependencies if needed
-        self._ensure_dependencies()
-    
-    def _ensure_dependencies(self):
-        """Ensure all dependencies are available."""
-        if self.entity_service is None:
-            self.entity_service = self._create_default_service()
-    
-    def _create_default_service(self):
-        """Create default entity service with all dependencies."""
-        return EntityService(
-            entity_crud=entity_crud,
-            canonical_entity_crud=canonical_entity_crud,
-            entity_mention_context_crud=entity_mention_context_crud,
-            entity_profile_crud=entity_profile_crud,
-            article_crud=article_crud,
-            entity_extractor=EntityExtractor(),
-            context_analyzer=ContextAnalyzer(),
-            entity_resolver=EntityResolver(),
-            session_factory=get_session
-        )
-    
-    @with_session
     def process_article(
-        self, 
+        self,
         article_id: int,
         content: str,
         title: str,
         published_at: datetime,
-        *,
-        session: Session = None
     ) -> List[Dict[str, Any]]:
-        """Process an article to track entity mentions.
-        
-        Args:
-            article_id: ID of the article being processed
-            content: Article content
-            title: Article title
-            published_at: Article publication date
-            session: Database session
-            
-        Returns:
-            List of processed entity mentions
-        """
-        # Ensure dependencies are available
-        self._ensure_dependencies()
-        
-        # Delegate to the service
+        """Process an article and return tracked entities."""
         return self.entity_service.process_article_entities(
             article_id=article_id,
             content=content,
             title=title,
-            published_at=published_at
+            published_at=published_at,
         )

--- a/tests/flows/entity_tracking_flow_test.py
+++ b/tests/flows/entity_tracking_flow_test.py
@@ -5,14 +5,23 @@ from unittest.mock import Mock, patch, MagicMock
 import asyncio
 
 # Mock spaCy and TextBlob before imports
-patch('spacy.load', MagicMock(return_value=MagicMock())).start()
-patch('textblob.TextBlob', MagicMock(return_value=MagicMock(
-    sentiment=MagicMock(polarity=0.5, subjectivity=0.7)
-))).start()
-patch('spacy.language.Language', MagicMock()).start()
+patch("spacy.load", MagicMock(return_value=MagicMock())).start()
+patch(
+    "textblob.TextBlob",
+    MagicMock(
+        return_value=MagicMock(sentiment=MagicMock(polarity=0.5, subjectivity=0.7))
+    ),
+).start()
+patch("spacy.language.Language", MagicMock()).start()
 
 from local_newsifier.flows.entity_tracking_flow import EntityTrackingFlow
-from local_newsifier.models.state import EntityTrackingState, EntityBatchTrackingState, EntityDashboardState, EntityRelationshipState, TrackingStatus
+from local_newsifier.models.state import (
+    EntityTrackingState,
+    EntityBatchTrackingState,
+    EntityDashboardState,
+    EntityRelationshipState,
+    TrackingStatus,
+)
 from local_newsifier.services.entity_service import EntityService
 from tests.fixtures.event_loop import event_loop_fixture
 
@@ -20,39 +29,33 @@ from tests.fixtures.event_loop import event_loop_fixture
 @patch("local_newsifier.flows.entity_tracking_flow.EntityExtractor")
 @patch("local_newsifier.flows.entity_tracking_flow.ContextAnalyzer")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityResolver")
-@patch("local_newsifier.flows.entity_tracking_flow.EntityTracker")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityService")
 def test_entity_tracking_flow_init(
-    mock_entity_service_class, 
-    mock_tracker_class,
-    mock_resolver_class, 
-    mock_context_analyzer_class, 
-    mock_extractor_class
+    mock_entity_service_class,
+    mock_resolver_class,
+    mock_context_analyzer_class,
+    mock_extractor_class,
 ):
     """Test initializing the entity tracking flow with defaults."""
     # Setup mocks
     mock_entity_service = Mock(spec=EntityService)
     mock_entity_service_class.return_value = mock_entity_service
-    
-    mock_tracker = Mock()
-    mock_tracker_class.return_value = mock_tracker
-    
+
     mock_extractor = Mock()
     mock_extractor_class.return_value = mock_extractor
-    
+
     mock_analyzer = Mock()
     mock_context_analyzer_class.return_value = mock_analyzer
-    
+
     mock_resolver = Mock()
     mock_resolver_class.return_value = mock_resolver
-    
+
     # Initialize flow
     flow = EntityTrackingFlow()
-    
+
     # Verify service and tools were created
     assert flow.entity_service is not None
     assert flow.session is None
-    assert flow._entity_tracker is not None
     assert flow._entity_extractor is not None
     assert flow._context_analyzer is not None
     assert flow._entity_resolver is not None
@@ -61,32 +64,32 @@ def test_entity_tracking_flow_init(
 @patch("local_newsifier.flows.entity_tracking_flow.EntityExtractor")
 @patch("local_newsifier.flows.entity_tracking_flow.ContextAnalyzer")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityResolver")
-@patch("local_newsifier.flows.entity_tracking_flow.EntityTracker")
-def test_entity_tracking_flow_init_with_dependencies(mock_tracker_class, mock_resolver_class, mock_context_analyzer_class, mock_extractor_class):
+def test_entity_tracking_flow_init_with_dependencies(
+    mock_resolver_class,
+    mock_context_analyzer_class,
+    mock_extractor_class,
+):
     """Test initializing the entity tracking flow with provided dependencies."""
     # Setup mocks
     mock_entity_service = Mock(spec=EntityService)
-    mock_entity_tracker = Mock()
     mock_entity_extractor = Mock()
     mock_context_analyzer = Mock()
     mock_entity_resolver = Mock()
     mock_session_factory = Mock()
     mock_session = Mock()
-    
+
     # Initialize flow with mock dependencies
     flow = EntityTrackingFlow(
         entity_service=mock_entity_service,
-        entity_tracker=mock_entity_tracker,
         entity_extractor=mock_entity_extractor,
         context_analyzer=mock_context_analyzer,
         entity_resolver=mock_entity_resolver,
         session_factory=mock_session_factory,
-        session=mock_session
+        session=mock_session,
     )
-    
+
     # Verify dependencies were used
     assert flow.entity_service is mock_entity_service
-    assert flow._entity_tracker is mock_entity_tracker
     assert flow._entity_extractor is mock_entity_extractor
     assert flow._context_analyzer is mock_context_analyzer
     assert flow._entity_resolver is mock_entity_resolver
@@ -96,23 +99,23 @@ def test_entity_tracking_flow_init_with_dependencies(mock_tracker_class, mock_re
 @patch("local_newsifier.flows.entity_tracking_flow.EntityExtractor")
 @patch("local_newsifier.flows.entity_tracking_flow.ContextAnalyzer")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityResolver")
-@patch("local_newsifier.flows.entity_tracking_flow.EntityTracker")
-def test_process_method(mock_tracker_class, mock_resolver_class, mock_context_analyzer_class, mock_extractor_class, event_loop_fixture):
-    """Test the process method."""
+def test_process_method(
+    mock_resolver_class,
+    mock_context_analyzer_class,
+    mock_extractor_class,
+    event_loop_fixture,
+):
     # Setup mocks
     mock_entity_service = Mock(spec=EntityService)
-    mock_entity_tracker = Mock()
     mock_entity_extractor = Mock()
     mock_context_analyzer = Mock()
     mock_entity_resolver = Mock()
-    
+
     mock_state = Mock(spec=EntityTrackingState)
     mock_result_state = Mock(spec=EntityTrackingState)
     mock_entity_service.process_article_with_state.return_value = mock_result_state
-    
+
     # Set up component mocks
-    mock_tracker = Mock()
-    mock_tracker_class.return_value = mock_tracker
     mock_extractor = Mock()
     mock_extractor_class.return_value = mock_extractor
     mock_analyzer = Mock()
@@ -123,15 +126,14 @@ def test_process_method(mock_tracker_class, mock_resolver_class, mock_context_an
     # Initialize flow with mock dependencies to avoid loading spaCy models
     flow = EntityTrackingFlow(
         entity_service=mock_entity_service,
-        entity_tracker=mock_entity_tracker,
         entity_extractor=mock_entity_extractor,
         context_analyzer=mock_context_analyzer,
-        entity_resolver=mock_entity_resolver
+        entity_resolver=mock_entity_resolver,
     )
-    
+
     # Call process method
     result = flow.process(mock_state)
-    
+
     # Verify service method was called
     mock_entity_service.process_article_with_state.assert_called_once_with(mock_state)
     assert result is mock_result_state
@@ -143,31 +145,32 @@ def test_process_method(mock_tracker_class, mock_resolver_class, mock_context_an
 @patch("local_newsifier.flows.entity_tracking_flow.EntityExtractor")
 @patch("local_newsifier.flows.entity_tracking_flow.ContextAnalyzer")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityResolver")
-@patch("local_newsifier.flows.entity_tracking_flow.EntityTracker")
-def test_process_new_articles_method(mock_tracker_class, mock_resolver_class, mock_context_analyzer_class, mock_extractor_class, event_loop_fixture):
+def test_process_new_articles_method(
+    mock_resolver_class,
+    mock_context_analyzer_class,
+    mock_extractor_class,
+    event_loop_fixture,
+):
     """Test the process_new_articles method."""
-    # Setup mocks
     mock_entity_service = Mock(spec=EntityService)
-    mock_entity_tracker = Mock()
     mock_entity_extractor = Mock()
     mock_context_analyzer = Mock()
     mock_entity_resolver = Mock()
-    
+
     mock_result_state = Mock(spec=EntityBatchTrackingState)
     mock_entity_service.process_articles_batch.return_value = mock_result_state
-    
+
     # Initialize flow with mock dependencies to avoid loading spaCy models
     flow = EntityTrackingFlow(
         entity_service=mock_entity_service,
-        entity_tracker=mock_entity_tracker,
         entity_extractor=mock_entity_extractor,
         context_analyzer=mock_context_analyzer,
-        entity_resolver=mock_entity_resolver
+        entity_resolver=mock_entity_resolver,
     )
-    
+
     # Call process_new_articles method
     result = flow.process_new_articles()
-    
+
     # Verify service method was called with correct state
     mock_entity_service.process_articles_batch.assert_called_once()
     # Verify the state passed to process_articles_batch is EntityBatchTrackingState with status_filter="analyzed"
@@ -184,52 +187,54 @@ def test_process_new_articles_method(mock_tracker_class, mock_resolver_class, mo
 @patch("local_newsifier.flows.entity_tracking_flow.EntityExtractor")
 @patch("local_newsifier.flows.entity_tracking_flow.ContextAnalyzer")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityResolver")
-@patch("local_newsifier.flows.entity_tracking_flow.EntityTracker")
-def test_process_article_method(mock_tracker_class, mock_resolver_class, mock_context_analyzer_class, mock_extractor_class, mock_article_crud, event_loop_fixture):
+def test_process_article_method(
+    mock_resolver_class,
+    mock_context_analyzer_class,
+    mock_extractor_class,
+    mock_article_crud,
+    event_loop_fixture,
+):
     """Test the process_article method (legacy)."""
     # Setup mocks
-    mock_entity_service = Mock()  # Don't use spec to avoid attribute constraints
-    mock_entity_tracker = Mock()
     mock_entity_extractor = Mock()
     mock_context_analyzer = Mock()
     mock_entity_resolver = Mock()
-    
+
     mock_session = Mock()
     mock_article = Mock()
     mock_article.id = 123
     mock_article.content = "Test content"
     mock_article.title = "Test title"
     mock_article.published_at = datetime.now(timezone.utc)
-    
+
     # Setup session context manager mock properly
     mock_context_manager = MagicMock()
     mock_context_manager.__enter__.return_value = mock_session
     mock_context_manager.__exit__.return_value = None
     mock_entity_service.session_factory.return_value = mock_context_manager
-    
+
     # Configure article crud mock
     mock_article_crud.get.return_value = mock_article
-    
+
     # Configure result state
     mock_result_state = Mock(spec=EntityTrackingState)
     mock_result_state.entities = [{"entity": "test"}]
     mock_entity_service.process_article_with_state.return_value = mock_result_state
-    
+
     # Initialize flow with mock dependencies to avoid loading spaCy models
     flow = EntityTrackingFlow(
         entity_service=mock_entity_service,
-        entity_tracker=mock_entity_tracker,
         entity_extractor=mock_entity_extractor,
         context_analyzer=mock_context_analyzer,
-        entity_resolver=mock_entity_resolver
+        entity_resolver=mock_entity_resolver,
     )
-    
+
     # Call process_article method
     result = flow.process_article(article_id=123)
-    
+
     # Verify article was retrieved
     mock_article_crud.get.assert_called_once_with(mock_session, id=123)
-    
+
     # Verify process was called with correct state
     mock_entity_service.process_article_with_state.assert_called_once()
     called_state = mock_entity_service.process_article_with_state.call_args[0][0]
@@ -246,32 +251,34 @@ def test_process_article_method(mock_tracker_class, mock_resolver_class, mock_co
 @patch("local_newsifier.flows.entity_tracking_flow.EntityExtractor")
 @patch("local_newsifier.flows.entity_tracking_flow.ContextAnalyzer")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityResolver")
-@patch("local_newsifier.flows.entity_tracking_flow.EntityTracker")
-def test_get_entity_dashboard_method(mock_tracker_class, mock_resolver_class, mock_context_analyzer_class, mock_extractor_class, event_loop_fixture):
+def test_get_entity_dashboard_method(
+    mock_resolver_class,
+    mock_context_analyzer_class,
+    mock_extractor_class,
+    event_loop_fixture,
+):
     """Test the get_entity_dashboard method."""
     # Setup mocks
     mock_entity_service = Mock(spec=EntityService)
-    mock_entity_tracker = Mock()
     mock_entity_extractor = Mock()
     mock_context_analyzer = Mock()
     mock_entity_resolver = Mock()
-    
+
     mock_result_state = Mock(spec=EntityDashboardState)
     mock_result_state.dashboard_data = {"dashboard": "data"}
     mock_entity_service.generate_entity_dashboard.return_value = mock_result_state
-    
+
     # Initialize flow with mock dependencies to avoid loading spaCy models
     flow = EntityTrackingFlow(
         entity_service=mock_entity_service,
-        entity_tracker=mock_entity_tracker,
         entity_extractor=mock_entity_extractor,
         context_analyzer=mock_context_analyzer,
-        entity_resolver=mock_entity_resolver
+        entity_resolver=mock_entity_resolver,
     )
-    
+
     # Call get_entity_dashboard method
     result = flow.get_entity_dashboard(days=30, entity_type="PERSON")
-    
+
     # Verify service method was called with correct state
     mock_entity_service.generate_entity_dashboard.assert_called_once()
     called_state = mock_entity_service.generate_entity_dashboard.call_args[0][0]
@@ -289,32 +296,33 @@ def test_get_entity_dashboard_method(mock_tracker_class, mock_resolver_class, mo
 @patch("local_newsifier.flows.entity_tracking_flow.EntityExtractor")
 @patch("local_newsifier.flows.entity_tracking_flow.ContextAnalyzer")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityResolver")
-@patch("local_newsifier.flows.entity_tracking_flow.EntityTracker")
-def test_find_entity_relationships_method(mock_tracker_class, mock_resolver_class, mock_context_analyzer_class, mock_extractor_class, event_loop_fixture):
+def test_find_entity_relationships_method(
+    mock_resolver_class,
+    mock_context_analyzer_class,
+    mock_extractor_class,
+    event_loop_fixture,
+):
     """Test the find_entity_relationships method."""
     # Setup mocks
     mock_entity_service = Mock(spec=EntityService)
-    mock_entity_tracker = Mock()
-    mock_entity_extractor = Mock()
     mock_context_analyzer = Mock()
     mock_entity_resolver = Mock()
-    
+
     mock_result_state = Mock(spec=EntityRelationshipState)
     mock_result_state.relationship_data = {"relationship": "data"}
     mock_entity_service.find_entity_relationships.return_value = mock_result_state
-    
+
     # Initialize flow with mock dependencies to avoid loading spaCy models
     flow = EntityTrackingFlow(
         entity_service=mock_entity_service,
-        entity_tracker=mock_entity_tracker,
         entity_extractor=mock_entity_extractor,
         context_analyzer=mock_context_analyzer,
-        entity_resolver=mock_entity_resolver
+        entity_resolver=mock_entity_resolver,
     )
-    
+
     # Call find_entity_relationships method
     result = flow.find_entity_relationships(entity_id=456, days=15)
-    
+
     # Verify service method was called with correct state
     mock_entity_service.find_entity_relationships.assert_called_once()
     called_state = mock_entity_service.find_entity_relationships.call_args[0][0]

--- a/tests/flows/entity_tracking_flow_test_basic.py
+++ b/tests/flows/entity_tracking_flow_test_basic.py
@@ -6,16 +6,18 @@ from datetime import datetime, timezone, timedelta
 import pytest
 
 # Mock spaCy and TextBlob before imports
-patch('spacy.load', MagicMock(return_value=MagicMock())).start()
-patch('textblob.TextBlob', MagicMock(return_value=MagicMock(
-    sentiment=MagicMock(polarity=0.5, subjectivity=0.7)
-))).start()
-patch('spacy.language.Language', MagicMock()).start()
+patch("spacy.load", MagicMock(return_value=MagicMock())).start()
+patch(
+    "textblob.TextBlob",
+    MagicMock(
+        return_value=MagicMock(sentiment=MagicMock(polarity=0.5, subjectivity=0.7))
+    ),
+).start()
+patch("spacy.language.Language", MagicMock()).start()
 
 from local_newsifier.flows.entity_tracking_flow import EntityTrackingFlow
 
 
-@patch("local_newsifier.flows.entity_tracking_flow.EntityTracker")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityExtractor")
 @patch("local_newsifier.flows.entity_tracking_flow.ContextAnalyzer")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityResolver")
@@ -25,23 +27,16 @@ def test_entity_tracking_flow_init_basic(
     mock_entity_resolver_class,
     mock_context_analyzer_class,
     mock_entity_extractor_class,
-    mock_entity_tracker_class
 ):
     """Test initializing the entity tracking flow."""
     # Setup mocks
-    mock_tracker = Mock()
-    mock_entity_tracker_class.return_value = mock_tracker
-    
+
     mock_service = Mock()
     mock_entity_service_class.return_value = mock_service
-    
+
     # Test with session and without session
     flow1 = EntityTrackingFlow()
     flow2 = EntityTrackingFlow(session=MagicMock())
-    
-    assert flow1._entity_tracker is not None
-    assert flow2._entity_tracker is not None
-    assert mock_entity_tracker_class.call_count == 2
 
 
 @patch("local_newsifier.flows.entity_tracking_flow.article_crud")
@@ -49,26 +44,28 @@ def test_process_article_basic(mock_article_crud):
     """Test process_article method with mocked service."""
     # Setup mocks to bypass session handling
     mock_session = MagicMock()
-    mock_article = MagicMock(id=1, title="Test article", content="Test content", url="http://example.com")
+    mock_article = MagicMock(
+        id=1, title="Test article", content="Test content", url="http://example.com"
+    )
     mock_article.published_at = datetime.now(timezone.utc)
     mock_article_crud.get.return_value = mock_article
-    
+
     # Mock the entity service
     mock_entity_service = Mock()
     mock_result_state = Mock()
     mock_result_state.entities = [{"entity_id": 1, "entity_name": "Entity"}]
     mock_entity_service.process_article_with_state.return_value = mock_result_state
-    
+
     # Setup session factory
     mock_context_manager = MagicMock()
     mock_context_manager.__enter__.return_value = mock_session
     mock_context_manager.__exit__.return_value = None
     mock_entity_service.session_factory.return_value = mock_context_manager
-    
+
     # Test process_article
     flow = EntityTrackingFlow(entity_service=mock_entity_service)
     result = flow.process_article(article_id=1)
-    
+
     # Basic assertions
     assert isinstance(result, list)
     mock_article_crud.get.assert_called_once()
@@ -83,17 +80,17 @@ def test_get_entity_dashboard_basic():
     mock_result_state.dashboard_data = {
         "entities": [
             {"id": 1, "name": "Entity 1", "type": "PERSON", "count": 10},
-            {"id": 2, "name": "Entity 2", "type": "ORGANIZATION", "count": 5}
+            {"id": 2, "name": "Entity 2", "type": "ORGANIZATION", "count": 5},
         ],
         "timeline": [{"date": "2023-01-01", "count": 5}],
-        "sentiment_trend": [{"date": "2023-01-01", "sentiment": 0.8}]
+        "sentiment_trend": [{"date": "2023-01-01", "sentiment": 0.8}],
     }
     mock_entity_service.generate_entity_dashboard.return_value = mock_result_state
-    
+
     # Test get_entity_dashboard
     flow = EntityTrackingFlow(entity_service=mock_entity_service)
     result = flow.get_entity_dashboard(entity_type="PERSON", days=30)
-    
+
     # Basic assertions
     assert isinstance(result, dict)
     assert "entities" in result
@@ -108,11 +105,11 @@ def test_process_new_articles_basic():
     mock_result_state.articles_processed = 2
     mock_result_state.entities_found = 5
     mock_entity_service.process_articles_batch.return_value = mock_result_state
-    
+
     # Test process_new_articles
     flow = EntityTrackingFlow(entity_service=mock_entity_service)
     result = flow.process_new_articles()
-    
+
     # Basic assertions
     assert result is mock_result_state
     mock_entity_service.process_articles_batch.assert_called_once()
@@ -129,20 +126,20 @@ def test_find_entity_relationships_basic():
     mock_result_state.relationship_data = {
         "relationships": [
             {"source": 1, "target": 2, "weight": 5},
-            {"source": 1, "target": 3, "weight": 3}
+            {"source": 1, "target": 3, "weight": 3},
         ],
         "entities": [
             {"id": 1, "name": "Entity 1"},
             {"id": 2, "name": "Entity 2"},
-            {"id": 3, "name": "Entity 3"}
-        ]
+            {"id": 3, "name": "Entity 3"},
+        ],
     }
     mock_entity_service.find_entity_relationships.return_value = mock_result_state
-    
+
     # Test find_entity_relationships
     flow = EntityTrackingFlow(entity_service=mock_entity_service)
     result = flow.find_entity_relationships(entity_id=1, days=30)
-    
+
     # Basic assertions
     assert result is mock_result_state.relationship_data
     mock_entity_service.find_entity_relationships.assert_called_once()

--- a/tests/flows/test_entity_tracking_flow_service.py
+++ b/tests/flows/test_entity_tracking_flow_service.py
@@ -5,11 +5,14 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch, AsyncMock
 
 # Mock spaCy and TextBlob before imports
-patch('spacy.load', MagicMock(return_value=MagicMock())).start()
-patch('textblob.TextBlob', MagicMock(return_value=MagicMock(
-    sentiment=MagicMock(polarity=0.5, subjectivity=0.7)
-))).start()
-patch('spacy.language.Language', MagicMock()).start()
+patch("spacy.load", MagicMock(return_value=MagicMock())).start()
+patch(
+    "textblob.TextBlob",
+    MagicMock(
+        return_value=MagicMock(sentiment=MagicMock(polarity=0.5, subjectivity=0.7))
+    ),
+).start()
+patch("spacy.language.Language", MagicMock()).start()
 
 from local_newsifier.models.state import EntityTrackingState, TrackingStatus
 from local_newsifier.flows.entity_tracking_flow import EntityTrackingFlow
@@ -22,19 +25,16 @@ from tests.ci_skip_config import ci_skip
 @patch("local_newsifier.flows.entity_tracking_flow.EntityExtractor")
 @patch("local_newsifier.flows.entity_tracking_flow.ContextAnalyzer")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityResolver")
-@patch("local_newsifier.flows.entity_tracking_flow.EntityTracker")
 def test_entity_tracking_flow_uses_service(
-    mock_tracker_class, mock_resolver_class, mock_analyzer_class, 
-    mock_extractor_class, mock_service_class
+    mock_resolver_class, mock_analyzer_class, mock_extractor_class, mock_service_class
 ):
     """Test that EntityTrackingFlow uses the EntityService."""
     # Arrange
     mock_service = MagicMock(spec=EntityService)
-    mock_entity_tracker = MagicMock()
     mock_entity_extractor = MagicMock()
     mock_context_analyzer = MagicMock()
     mock_entity_resolver = MagicMock()
-    
+
     mock_result_state = MagicMock(spec=EntityTrackingState)
     mock_result_state.status = TrackingStatus.SUCCESS
     mock_result_state.entities = [
@@ -44,44 +44,42 @@ def test_entity_tracking_flow_uses_service(
             "canonical_id": 1,
             "context": "John Doe visited the city.",
             "sentiment_score": 0.5,
-            "framing_category": "neutral"
+            "framing_category": "neutral",
         }
     ]
     mock_service.process_article_with_state.return_value = mock_result_state
     mock_service_class.return_value = mock_service
-    
+
     # Create mocks for required components
     mock_extractor = MagicMock()
     mock_extractor_class.return_value = mock_extractor
-    
+
     mock_analyzer = MagicMock()
     mock_analyzer_class.return_value = mock_analyzer
-    
+
     mock_resolver = MagicMock()
     mock_resolver_class.return_value = mock_resolver
-    
+
     mock_tracker = MagicMock()
-    mock_tracker_class.return_value = mock_tracker
-    
+
     # Create test state
     state = EntityTrackingState(
         article_id=1,
         content="John Doe visited the city.",
         title="Test Article",
-        published_at=datetime(2025, 1, 1)
+        published_at=datetime(2025, 1, 1),
     )
 
     # Create flow with mock service and dependencies to avoid loading spaCy models
     flow = EntityTrackingFlow(
         entity_service=mock_service,
-        entity_tracker=mock_entity_tracker,
         entity_extractor=mock_entity_extractor,
         context_analyzer=mock_context_analyzer,
-        entity_resolver=mock_entity_resolver
+        entity_resolver=mock_entity_resolver,
     )
 
     # If the class has an async method, replace it with the mock result
-    if hasattr(flow, 'process_async'):
+    if hasattr(flow, "process_async"):
         flow.process_async = AsyncMock(return_value=mock_result_state)
 
     # Act - call the synchronous method
@@ -99,102 +97,93 @@ def test_entity_tracking_flow_uses_service(
 @patch("local_newsifier.flows.entity_tracking_flow.EntityExtractor")
 @patch("local_newsifier.flows.entity_tracking_flow.ContextAnalyzer")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityResolver")
-@patch("local_newsifier.flows.entity_tracking_flow.EntityTracker")
 def test_entity_tracking_flow_creates_default_service(
-    mock_tracker_class, mock_resolver_class, mock_analyzer_class, mock_extractor_class, mock_service_class
+    mock_resolver_class, mock_analyzer_class, mock_extractor_class, mock_service_class
 ):
     """Test that EntityTrackingFlow creates a default service if none is provided."""
     # Setup mocks
     mock_service = MagicMock()
     mock_service_class.return_value = mock_service
-    
+
     mock_extractor = MagicMock()
     mock_extractor_class.return_value = mock_extractor
-    
+
     mock_analyzer = MagicMock()
     mock_analyzer_class.return_value = mock_analyzer
-    
+
     mock_resolver = MagicMock()
     mock_resolver_class.return_value = mock_resolver
-    
+
     mock_tracker = MagicMock()
-    mock_tracker_class.return_value = mock_tracker
-    
+
     # Create flow without providing a service
     flow = EntityTrackingFlow()
-    
+
     # Verify the service and tools were created
     mock_service_class.assert_called_once()
     mock_extractor_class.assert_called_once()
     mock_analyzer_class.assert_called_once()
     mock_resolver_class.assert_called_once()
-    mock_tracker_class.assert_called_once()
-    
+
     assert flow.entity_service is mock_service
     assert flow._entity_extractor is mock_extractor
     assert flow._context_analyzer is mock_analyzer
     assert flow._entity_resolver is mock_resolver
-    assert flow._entity_tracker is mock_tracker
 
 
 @patch("local_newsifier.flows.entity_tracking_flow.EntityService")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityExtractor")
 @patch("local_newsifier.flows.entity_tracking_flow.ContextAnalyzer")
 @patch("local_newsifier.flows.entity_tracking_flow.EntityResolver")
-@patch("local_newsifier.flows.entity_tracking_flow.EntityTracker")
 def test_entity_tracking_flow_handles_errors(
-    mock_tracker_class, mock_resolver_class, mock_analyzer_class, 
-    mock_extractor_class, mock_service_class
+    mock_resolver_class, mock_analyzer_class, mock_extractor_class, mock_service_class
 ):
     """Test that EntityTrackingFlow properly handles errors during processing."""
     # Arrange
     mock_service = MagicMock(spec=EntityService)
-    mock_entity_tracker = MagicMock()
     mock_entity_extractor = MagicMock()
     mock_context_analyzer = MagicMock()
     mock_entity_resolver = MagicMock()
-    
+
     mock_service.process_article_with_state.side_effect = Exception("Test error")
     mock_service_class.return_value = mock_service
-    
+
     # Create mocks for required components
     mock_extractor = MagicMock()
     mock_extractor_class.return_value = mock_extractor
-    
+
     mock_analyzer = MagicMock()
     mock_analyzer_class.return_value = mock_analyzer
-    
+
     mock_resolver = MagicMock()
     mock_resolver_class.return_value = mock_resolver
-    
+
     mock_tracker = MagicMock()
-    mock_tracker_class.return_value = mock_tracker
-    
+
     # Create test state
     state = EntityTrackingState(
         article_id=1,
         content="John Doe visited the city.",
         title="Test Article",
-        published_at=datetime(2025, 1, 1)
+        published_at=datetime(2025, 1, 1),
     )
-    
+
     # Create flow with mock service and dependencies to avoid loading spaCy models
     flow = EntityTrackingFlow(
         entity_service=mock_service,
-        entity_tracker=mock_entity_tracker,
         entity_extractor=mock_entity_extractor,
         context_analyzer=mock_context_analyzer,
-        entity_resolver=mock_entity_resolver
+        entity_resolver=mock_entity_resolver,
     )
-    
+
     # If the class has an async method, make sure it doesn't interfere with our test
-    if hasattr(flow, 'process_async'):
+    if hasattr(flow, "process_async"):
         # Set it to a mock that won't be called (we're testing the sync path)
         flow.process_async = AsyncMock()
-    
+
     # Act - The flow should catch the exception and return the state with error
     result_state = flow.process(state)
-    
+
     # Assert
     mock_service.process_article_with_state.assert_called_once_with(state)
     assert result_state.status == TrackingStatus.FAILED
@@ -209,13 +198,13 @@ def test_entity_tracking_state_logs():
         article_id=1,
         content="Test content",
         title="Test Article",
-        published_at=datetime(2025, 1, 1)
+        published_at=datetime(2025, 1, 1),
     )
-    
+
     # Add some logs
     state.add_log("Test log 1")
     state.add_log("Test log 2")
-    
+
     # Verify logs
     assert len(state.run_logs) == 2
     assert "Test log 1" in state.run_logs[0]


### PR DESCRIPTION
## Summary
- simplify `EntityTracker` so it only delegates to `EntityService`
- adjust provider signatures and flows to use the simpler tool
- update entity tracking flow tests for new API

## Testing
- `make test` *(fails: Command not found: pytest)*