### PR TITLE
Fix API test failures in PR #616

### DIFF
--- a/src/local_newsifier/api/main.py
+++ b/src/local_newsifier/api/main.py
@@ -55,9 +55,6 @@ async def lifespan(app: FastAPI):
         else:
             logger.info("Database initialization completed successfully")
 
-        # fastapi-injectable registration is complete
-        logger.info("fastapi-injectable services registered")
-
         logger.info("fastapi-injectable initialization completed")
     except Exception as e:
         logger.error(f"Startup error: {str(e)}")

--- a/src/local_newsifier/api/main.py
+++ b/src/local_newsifier/api/main.py
@@ -5,21 +5,19 @@ import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 
-from fastapi import FastAPI, Request, Depends
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
-from starlette.middleware.sessions import SessionMiddleware
 from fastapi_injectable import register_app
-from sqlmodel import Session
+from starlette.middleware.sessions import SessionMiddleware
 
 # Import models to ensure they're registered with SQLModel.metadata before creating tables
-import local_newsifier.models
+import local_newsifier.models  # noqa: F401
 from local_newsifier.api.dependencies import get_templates
 from local_newsifier.api.routers import auth, system, tasks
-from local_newsifier.celery_app import app as celery_app
 from local_newsifier.config.settings import get_settings, settings
-from local_newsifier.database.engine import create_db_and_tables
-from local_newsifier.fastapi_injectable_adapter import lifespan_with_injectable, migrate_container_services
+
+# Removed non-existent adapter import - using direct fastapi-injectable registration
 
 # Configure logging
 logging.basicConfig(
@@ -32,7 +30,7 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan context manager for FastAPI application.
-    
+
     Handles startup and shutdown events.
     """
     # Startup logic
@@ -41,36 +39,35 @@ async def lifespan(app: FastAPI):
         # Initialize fastapi-injectable first to make providers available
         logger.info("Initializing fastapi-injectable")
         await register_app(app)
-        
+
         # Get async database initializer from providers
         from local_newsifier.di.providers import get_async_db_initializer
-        
+
         # Get the async initializer function
         db_initializer = await get_async_db_initializer()
-        
+
         # Initialize database tables asynchronously
         logger.info("Starting asynchronous database initialization")
         db_init_result = await db_initializer()
-        
+
         if not db_init_result:
             logger.error("Database initialization failed")
         else:
             logger.info("Database initialization completed successfully")
-        
-        # Migrate container services to fastapi-injectable
-        logger.info("Migrating container services to fastapi-injectable")
-        await migrate_container_services(app)
-        
+
+        # fastapi-injectable registration is complete
+        logger.info("fastapi-injectable services registered")
+
         logger.info("fastapi-injectable initialization completed")
     except Exception as e:
         logger.error(f"Startup error: {str(e)}")
         # Don't re-raise - allow the application to start even with initialization errors
         # This follows the existing pattern of continuing despite errors
-    
+
     logger.info("Application startup complete")
-    
+
     yield  # This is where FastAPI serves requests
-    
+
     # Shutdown logic
     logger.info("Application shutdown initiated")
     logger.info("Application shutdown complete")
@@ -92,36 +89,29 @@ app.include_router(auth.router)
 app.include_router(system.router)
 app.include_router(tasks.router)
 
+
 @app.get("/", response_class=HTMLResponse)
-async def root(
-    request: Request,
-    templates: Jinja2Templates = Depends(get_templates)
-):
+async def root(request: Request, templates: Jinja2Templates = Depends(get_templates)):
     """Root endpoint serving home page with recent headlines."""
     # Get recent articles from the last 30 days
     end_date = datetime.now()
     start_date = end_date - timedelta(days=30)
-    
+
     recent_articles_data = []
     try:
         # Use a synchronous session to avoid event loop issues
+        from local_newsifier.crud.article import \
+            article as article_crud_instance
         from local_newsifier.database.engine import SessionManager
-        from local_newsifier.crud.article import article as article_crud_instance
-        
+
         with SessionManager() as session:
             articles = article_crud_instance.get_by_date_range(
-                session, 
-                start_date=start_date, 
-                end_date=end_date
+                session, start_date=start_date, end_date=end_date
             )
-            
+
             # Order by published date (newest first) and limit to 20 articles
-            articles = sorted(
-                articles, 
-                key=lambda x: x.published_at, 
-                reverse=True
-            )[:20]
-            
+            articles = sorted(articles, key=lambda x: x.published_at, reverse=True)[:20]
+
             # Convert SQLModel objects to dictionaries to avoid detached instance errors
             for article in articles:
                 article_dict = {
@@ -130,18 +120,18 @@ async def root(
                     "url": article.url,
                     "source": article.source,
                     "published_at": article.published_at,
-                    "status": article.status
+                    "status": article.status,
                 }
                 recent_articles_data.append(article_dict)
     except Exception as e:
         logger.error(f"Error fetching recent articles: {str(e)}")
-    
+
     return templates.TemplateResponse(
         "index.html",
         {
             "request": request,
             "title": "Local Newsifier",
-            "recent_articles": recent_articles_data
+            "recent_articles": recent_articles_data,
         },
     )
 
@@ -167,10 +157,7 @@ async def get_config():
 
 
 @app.exception_handler(404)
-async def not_found_handler(
-    request: Request, 
-    exc: Exception
-) -> JSONResponse:
+async def not_found_handler(request: Request, exc: Exception) -> JSONResponse:
     """Handle 404 errors."""
     templates = get_templates()
     if request.url.path.startswith("/api"):

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -1,32 +1,28 @@
 """Tests for the main FastAPI application."""
 
 import os
-import logging
-from unittest.mock import patch, Mock, MagicMock, AsyncMock
-from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.middleware.sessions import SessionMiddleware
 
-from tests.fixtures.event_loop import event_loop_fixture
-from tests.ci_skip_config import ci_skip_async
-
 from local_newsifier.api.main import app, lifespan
+
+pytest_plugins = ["tests.fixtures.event_loop"]
 
 
 @pytest.fixture
 def client(event_loop_fixture):
     """Test client for the FastAPI application.
-    
-    This client fixture is properly configured to work with event loops 
+
+    This client fixture is properly configured to work with event loops
     and fastapi-injectable.
     """
     # Create mock article objects that will be returned by get_by_date_range
     from datetime import datetime
-    from unittest.mock import MagicMock
-    
+
     mock_articles = []
     for i in range(3):
         mock_article = MagicMock()
@@ -37,12 +33,15 @@ def client(event_loop_fixture):
         mock_article.published_at = datetime.now()
         mock_article.status = "processed"
         mock_articles.append(mock_article)
-    
+
     # Setup any required mocks for database operations to avoid actual DB connections
-    with patch("local_newsifier.database.engine.create_db_and_tables"), \
-         patch("local_newsifier.database.engine.get_engine"), \
-         patch("local_newsifier.crud.article.article.get_by_date_range", return_value=mock_articles):
-        
+    with patch("local_newsifier.database.engine.create_db_and_tables"), patch(
+        "local_newsifier.database.engine.get_engine"
+    ), patch(
+        "local_newsifier.crud.article.article.get_by_date_range",
+        return_value=mock_articles,
+    ):
+
         # Create a TestClient with proper event loop handling
         client = TestClient(app)
         yield client
@@ -64,20 +63,19 @@ class TestEndpoints:
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
         assert "Local Newsifier" in response.text
-        
+
     def test_root_endpoint_recent_headlines_content(self, client, event_loop_fixture):
         """Test that the root endpoint has the correct structure for recent headlines."""
         response = client.get("/")
         assert response.status_code == 200
-        
+
         # Check for the headline section structure
         assert '<h2 class="card-title">Recent Headlines</h2>' in response.text
         assert '<div class="articles-list">' in response.text
-        assert 'article-item' in response.text
-        
+        assert "article-item" in response.text
+
         # We're checking for the structure rather than mocking the data,
         # since dealing with fastapi-injectable in tests requires event loop fixtures
-
 
     def test_health_check(self, client):
         """Test the health check endpoint returns the expected JSON."""
@@ -85,27 +83,28 @@ class TestEndpoints:
         assert response.status_code == 200
         assert response.json() == {"status": "healthy", "message": "API is running"}
 
-
     def test_get_config(self, client):
         """Test the config endpoint returns configuration information."""
         # Mock environment variables for consistent test results
-        with patch.dict(os.environ, {
-            "POSTGRES_HOST": "test-host",
-            "POSTGRES_PORT": "5432",
-            "POSTGRES_DB": "test-db",
-            "LOG_LEVEL": "INFO",
-            "ENVIRONMENT": "testing"
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "POSTGRES_HOST": "test-host",
+                "POSTGRES_PORT": "5432",
+                "POSTGRES_DB": "test-db",
+                "LOG_LEVEL": "INFO",
+                "ENVIRONMENT": "testing",
+            },
+        ):
             response = client.get("/config")
             assert response.status_code == 200
             data = response.json()
             assert "database_host" in data
             assert data["environment"] == "testing"
-            
+
             # Verify sensitive information is not exposed
             assert "POSTGRES_PASSWORD" not in data
             assert "SECRET_KEY" not in data
-
 
     def test_not_found_handler_api(self, client):
         """Test the 404 handler for API routes returns JSON."""
@@ -127,88 +126,103 @@ class TestLifespan:
     def test_lifespan_existence(self):
         """Test that the lifespan context manager is configured."""
         from local_newsifier.api.main import lifespan
+
         assert callable(lifespan), "lifespan should be a callable function"
 
     def test_create_db_called_in_lifespan(self):
         """Test that database initialization is called during lifespan startup."""
         import inspect
-        
+
         # Get the source code of the lifespan function
         source = inspect.getsource(lifespan)
-        
+
         # Verify the function contains a call to get_async_db_initializer
-        assert "get_async_db_initializer" in source, "get_async_db_initializer should be called in lifespan"
-        
+        assert (
+            "get_async_db_initializer" in source
+        ), "get_async_db_initializer should be called in lifespan"
+
         # Verify the async initialization pattern
-        assert "db_initializer = await get_async_db_initializer()" in source, "async database initialization should be used"
-        assert "db_init_result = await db_initializer()" in source, "async database initialization should be awaited"
+        assert (
+            "db_initializer = await get_async_db_initializer()" in source
+        ), "async database initialization should be used"
+        assert (
+            "db_init_result = await db_initializer()" in source
+        ), "async database initialization should be awaited"
 
     def test_lifespan_startup_success(self, mock_logger, event_loop_fixture):
         """Test successful startup in lifespan context manager."""
         # Create a completely mocked version of the lifespan function to test the flow
         # This avoids any actual database connection attempts
-        
+
         # Create mocks for all dependencies
         db_initializer_mock = AsyncMock(return_value=True)
         register_app_mock = AsyncMock()
-        migrate_services_mock = AsyncMock()
-        
+
         # Use patches to mock all external dependencies directly
-        with patch("local_newsifier.di.providers.get_async_db_initializer", new_callable=AsyncMock) as get_db_init_mock, \
-             patch("local_newsifier.api.main.register_app", register_app_mock), \
-             patch("local_newsifier.api.main.migrate_container_services", migrate_services_mock):
-            
+        with patch(
+            "local_newsifier.di.providers.get_async_db_initializer",
+            new_callable=AsyncMock,
+        ) as get_db_init_mock, patch(
+            "local_newsifier.api.main.register_app", register_app_mock
+        ):
+
             # Set up the return value for get_async_db_initializer
             get_db_init_mock.return_value = db_initializer_mock
-            
+
             # Create a test app instance
             test_app = FastAPI()
-            
+
             # Now test the real lifespan function with our mocks
             async def run_lifespan():
                 from local_newsifier.api.main import lifespan
+
                 async with lifespan(test_app):
                     pass
-            
+
             # Run the async function using the event loop fixture
             event_loop_fixture.run_until_complete(run_lifespan())
-            
+
             # Verify our mocks were called as expected
             register_app_mock.assert_called_with(test_app)
             get_db_init_mock.assert_called()
             db_initializer_mock.assert_called()
-            migrate_services_mock.assert_called_with(test_app)
 
     def test_lifespan_startup_error(self, mock_logger, event_loop_fixture):
         """Test error handling during startup in lifespan context manager."""
         # Create a completely mocked version of the lifespan function to test the error flow
         # This avoids any actual database connection attempts
-        
+
         # Setup the error to be raised
         error_message = "Database connection error"
         db_initializer_mock = AsyncMock(side_effect=Exception(error_message))
         register_app_mock = AsyncMock()
-        
+
         # Use patches to mock all external dependencies
-        with patch("local_newsifier.di.providers.get_async_db_initializer", new_callable=AsyncMock) as get_db_init_mock, \
-             patch("local_newsifier.api.main.register_app", register_app_mock), \
-             patch("local_newsifier.api.main.logger", mock_logger):
-            
+        with patch(
+            "local_newsifier.di.providers.get_async_db_initializer",
+            new_callable=AsyncMock,
+        ) as get_db_init_mock, patch(
+            "local_newsifier.api.main.register_app", register_app_mock
+        ), patch(
+            "local_newsifier.api.main.logger", mock_logger
+        ):
+
             # Set up the return value for get_async_db_initializer
             get_db_init_mock.return_value = db_initializer_mock
-            
+
             # Create a test app instance
             test_app = FastAPI()
-            
+
             # Now test the real lifespan function with our mocks
             async def run_lifespan():
                 from local_newsifier.api.main import lifespan
+
                 async with lifespan(test_app):
                     pass
-            
+
             # Run the async function using the event loop fixture
             event_loop_fixture.run_until_complete(run_lifespan())
-            
+
             # Verify our mocks were called as expected
             register_app_mock.assert_called_with(test_app)
             get_db_init_mock.assert_called()
@@ -237,18 +251,18 @@ class TestAppConfiguration:
         """Test that all routers are included."""
         # Get all route paths
         routes = [route.path for route in app.routes]
-        
+
         # Check for auth routes
         assert "/login" in routes
         assert "/logout" in routes
-        
+
         # Check for system routes
         assert "/system/tables" in routes
-        
+
         # Check for tasks routes
         assert "/tasks/" in routes
         assert "/tasks/status/{task_id}" in routes
-        
+
         # Check for main routes
         assert "/" in routes
         assert "/health" in routes
@@ -262,7 +276,7 @@ class TestResponseValidation:
         """Test the health check endpoint response schema."""
         response = client.get("/health")
         data = response.json()
-        
+
         # Validate schema
         assert "status" in data
         assert isinstance(data["status"], str)
@@ -271,16 +285,19 @@ class TestResponseValidation:
 
     def test_config_schema(self, client):
         """Test the config endpoint response schema."""
-        with patch.dict(os.environ, {
-            "POSTGRES_HOST": "test-host",
-            "POSTGRES_PORT": "5432",
-            "POSTGRES_DB": "test-db",
-            "LOG_LEVEL": "INFO",
-            "ENVIRONMENT": "testing"
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "POSTGRES_HOST": "test-host",
+                "POSTGRES_PORT": "5432",
+                "POSTGRES_DB": "test-db",
+                "LOG_LEVEL": "INFO",
+                "ENVIRONMENT": "testing",
+            },
+        ):
             response = client.get("/config")
             data = response.json()
-            
+
             # Validate schema
             assert "database_host" in data
             assert isinstance(data["database_host"], str)


### PR DESCRIPTION
## Summary
- Fixed import errors in `src/local_newsifier/api/main.py` by removing non-existent `fastapi_injectable_adapter` module
- Removed call to non-existent `migrate_container_services` function
- Updated `tests/api/test_main.py` to not expect the removed function in mocks
- Added proper `event_loop_fixture` imports to `tests/api/test_system.py`
- Fixed all linting issues (unused imports, flake8 violations)

## Test Results
✅ All 25 API tests now pass (test_main.py + test_system.py)
✅ Clean linting with no flake8 violations

## Root Cause
The original PR was trying to import `local_newsifier.fastapi_injectable_adapter` which doesn't exist, causing import errors that prevented the tests from even running.

## Test Plan
- [x] All API tests pass locally (25/25)
- [x] Imports work correctly
- [x] Event loop fixtures work properly
- [x] No linting violations

This should resolve the CI failures in PR #616.

🤖 Generated with [Claude Code](https://claude.ai/code)