### PR TITLE
Add services return guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For details on the architecture and testing strategies see:
 - [DI Architecture Guide](docs/di_architecture.md)
 - [Dependency Injection Guide](docs/dependency_injection.md)
 - [fastapi-injectable Guide](docs/fastapi_injectable.md)
+- [Services Guide](docs/services_guide.md)
 - [Documentation Index](docs/README.md)
 
 ## Setup

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ This directory collects guides and references for Local Newsifier.
 - [fastapi_injectable.md](fastapi_injectable.md) - working with fastapi-injectable.
 - [injectable_examples.md](injectable_examples.md) - injectable pattern examples.
 - [injectable_patterns.md](injectable_patterns.md) - recommended injectable patterns.
+- [services_guide.md](services_guide.md) - service return standards.
 - [python_setup.md](python_setup.md) - offline Python setup instructions.
 - [test_execution.md](test_execution.md) - running tests.
 - [testing_apify.md](testing_apify.md) - tests involving Apify.

--- a/docs/services_guide.md
+++ b/docs/services_guide.md
@@ -1,0 +1,9 @@
+### Return values (updated May 2025)
+
+Services **must** return:
+* `<Model>Read` SQLModel DTOs for data
+* Primitive IDs when only an identifier is required
+
+They **must not** return:
+* Session-bound SQLModel table instances
+* Raw `dict` payloads


### PR DESCRIPTION
## Summary
- document how services should return `<Model>Read` DTOs and IDs
- link to services guide from README
- add the new guide to the documentation index

## Testing
- `pre-commit run --files docs/services_guide.md README.md docs/README.md` *(fails: command not found)*
- `make test` *(fails: Command not found: pytest)*