### PR TITLE
Add CLI tests for apify config list

### DIFF
--- a/tests/cli/test_apify_config_commands.py
+++ b/tests/cli/test_apify_config_commands.py
@@ -1,0 +1,87 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from local_newsifier.cli.main import cli
+
+
+# Example configurations used across tests
+EXAMPLE_CONFIGS = [
+    {
+        "id": 1,
+        "name": "News Scraper",
+        "actor_id": "actor1",
+        "source_type": "news",
+        "is_active": True,
+        "last_run_at": "2024-01-01T10:00:00",
+        "input_configuration": {"foo": "bar"},
+    },
+    {
+        "id": 2,
+        "name": "Blog Scraper",
+        "actor_id": "actor2",
+        "source_type": "blog",
+        "is_active": False,
+        "last_run_at": None,
+        "input_configuration": {},
+    },
+]
+
+
+@patch("local_newsifier.cli.commands.apify_config.get_injected_obj")
+def test_list_configs_table_output(mock_get_injected_obj):
+    """Verify table output of the list command."""
+    mock_service = MagicMock()
+    mock_service.list_configs.return_value = EXAMPLE_CONFIGS
+    mock_get_injected_obj.return_value = mock_service
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["apify-config", "list"])
+
+    assert result.exit_code == 0
+    assert "News Scraper" in result.output
+    assert "Blog Scraper" in result.output
+    assert "actor1" in result.output
+    assert "actor2" in result.output
+    mock_service.list_configs.assert_called_once_with(
+        skip=0, limit=100, active_only=False, source_type=None
+    )
+
+
+@patch("local_newsifier.cli.commands.apify_config.get_injected_obj")
+def test_list_configs_json_output(mock_get_injected_obj):
+    """Verify JSON output of the list command."""
+    mock_service = MagicMock()
+    mock_service.list_configs.return_value = EXAMPLE_CONFIGS
+    mock_get_injected_obj.return_value = mock_service
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["apify-config", "list", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data) == 2
+    assert data[0]["name"] == "News Scraper"
+    assert data[1]["name"] == "Blog Scraper"
+
+
+@patch("local_newsifier.cli.commands.apify_config.get_injected_obj")
+def test_list_configs_filters(mock_get_injected_obj):
+    """Verify filtering options call the service with correct parameters."""
+    mock_service = MagicMock()
+    mock_service.list_configs.return_value = EXAMPLE_CONFIGS[:1]
+    mock_get_injected_obj.return_value = mock_service
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["apify-config", "list", "--active-only", "--source-type", "news"],
+    )
+
+    assert result.exit_code == 0
+    mock_service.list_configs.assert_called_once_with(
+        skip=0, limit=100, active_only=True, source_type="news"
+    )
+    assert "News Scraper" in result.output
+

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -47,7 +47,14 @@ def test_apify_group():
     assert "web-scraper" in result.output
 
 
-@pytest.mark.skip(reason="apify-config has been removed")
 def test_apify_config_group():
-    """Test skipped as apify-config command group has been removed."""
-    pass
+    """Test that the apify-config command group loads without errors."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["apify-config", "--help"])
+    assert result.exit_code == 0
+    assert "list" in result.output
+    assert "add" in result.output
+    assert "show" in result.output
+    assert "remove" in result.output
+    assert "update" in result.output
+    assert "run" in result.output


### PR DESCRIPTION
## Summary

Add coverage for apify-config list command and ensure apify-config group loads in CLI tests.

**Part of Issue #675: Improve test infrastructure and coverage**

## Changes
- Add test coverage for `apify-config list` command
- Ensure apify-config group loads properly in CLI tests
- Improve CLI command test reliability

## Problem Solved
- Missing test coverage for apify-config CLI commands
- CLI command group loading was not tested
- Need comprehensive CLI test coverage

## Impact
- Better CLI command test coverage
- Improved reliability of CLI tests
- Contributes to Issue #675 test infrastructure goals

🤖 Generated with [Claude Code](https://claude.ai/code)