### PR TITLE
Add .env.cursor to .gitignore

### DIFF
--- a/.env.cursor
+++ b/.env.cursor
@@ -1,1 +1,0 @@
-export CURSOR_DB_ID=f707879b

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ venv.bak/
 # Environment files
 .env
 .env.test
+.env.cursor
 
 **/.claude/settings.local.json
 


### PR DESCRIPTION
## Summary
- Adds `.env.cursor` to `.gitignore` to prevent tracking of developer-specific database IDs
- Removes the currently tracked `.env.cursor` file from git history while preserving it locally
- Ensures each developer can maintain their own unique `CURSOR_DB_ID` for database isolation

## Test plan
- [x] Verify `.env.cursor` is no longer tracked by git
- [x] Confirm local `.env.cursor` file still exists for current developer
- [x] Pre-commit hooks pass successfully
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)