### PR TITLE
Add test for worker readiness logging

### DIFF
--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -418,3 +418,10 @@ class TestFetchRssFeeds:
                 assert result["feeds_processed"] == 1
                 assert result["articles_found"] == 2
                 assert result["articles_added"] == 1
+
+
+def test_on_worker_ready_logs_info():
+    """Verify that on_worker_ready logs an informational message."""
+    with patch("local_newsifier.tasks.logger") as mock_logger:
+        on_worker_ready(sender=None)
+        mock_logger.info.assert_called_once_with("Celery worker is ready")


### PR DESCRIPTION
## Summary
- add new test verifying `on_worker_ready` logs to module logger

## Testing
- `make test` *(fails: Command not found: pytest)*