### PR TITLE
Fix hidden dependencies in EntityTracker

### DIFF
--- a/src/local_newsifier/di/providers.py
+++ b/src/local_newsifier/di/providers.py
@@ -598,8 +598,7 @@ def get_entity_service(
 
 @injectable(use_cache=False)
 def get_entity_tracker_tool(
-    entity_service: Annotated["EntityService", Depends(get_entity_service)],
-    session: Annotated[Session, Depends(get_session)]
+    entity_service: Annotated["EntityService", Depends(get_entity_service)]
 ):
     """Provide the entity tracker tool.
 
@@ -608,13 +607,12 @@ def get_entity_tracker_tool(
     
     Args:
         entity_service: Service for entity operations
-        session: Database session
 
     Returns:
         EntityTracker instance
     """
     from local_newsifier.tools.entity_tracker_service import EntityTracker
-    return EntityTracker(entity_service=entity_service, session=session)
+    return EntityTracker(entity_service=entity_service)
 
 
 @injectable(use_cache=False)
@@ -1022,8 +1020,7 @@ def get_public_opinion_flow(
 
 @injectable(use_cache=False)
 def get_injectable_entity_tracker(
-    entity_service: Annotated["EntityService", Depends(get_entity_service)],
-    session: Annotated[Session, Depends(get_session)]
+    entity_service: Annotated["EntityService", Depends(get_entity_service)]
 ):
     """Provide the injectable entity tracker tool.
     
@@ -1032,13 +1029,12 @@ def get_injectable_entity_tracker(
     
     Args:
         entity_service: Service for entity operations
-        session: Database session
     
     Returns:
         InjectableEntityTracker instance with injected dependencies
     """
     from local_newsifier.tools.entity_tracker_service import EntityTracker
-    return EntityTracker(entity_service=entity_service, session=session)
+    return EntityTracker(entity_service=entity_service)
 
 
 @injectable(use_cache=False)

--- a/src/local_newsifier/flows/entity_tracking_flow.py
+++ b/src/local_newsifier/flows/entity_tracking_flow.py
@@ -51,18 +51,16 @@ class EntityTrackingFlow(Flow):
         """
         super().__init__()
         self.session = session
-        
-        # Use provided dependencies or create defaults for backward compatibility
-        self._entity_tracker = entity_tracker or EntityTracker()
+
+        # Use provided tool dependencies or create defaults
         self._entity_extractor = entity_extractor or EntityExtractor()
         self._context_analyzer = context_analyzer or ContextAnalyzer()
         self._entity_resolver = entity_resolver or EntityResolver()
-        
+
         # Use provided entity service or create one with dependencies
         if entity_service:
             self.entity_service = entity_service
         else:
-            # Create service with injected or default dependencies
             self.entity_service = EntityService(
                 entity_crud=entity_crud,
                 canonical_entity_crud=canonical_entity_crud,
@@ -74,6 +72,11 @@ class EntityTrackingFlow(Flow):
                 entity_resolver=self._entity_resolver,
                 session_factory=session_factory
             )
+
+        # Entity tracker depends on the entity service
+        self._entity_tracker = entity_tracker or EntityTracker(
+            entity_service=self.entity_service
+        )
 
     def process(self, state: EntityTrackingState) -> EntityTrackingState:
         """Process a single article for entity tracking.

--- a/src/local_newsifier/tools/entity_tracker_service.py
+++ b/src/local_newsifier/tools/entity_tracker_service.py
@@ -1,57 +1,24 @@
 """Entity tracker tool that uses the EntityService."""
 
-import os
 from datetime import datetime
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Any
 
 from sqlmodel import Session
 
-from local_newsifier.database.engine import with_session, get_session
+from local_newsifier.database.engine import with_session
 from local_newsifier.services.entity_service import EntityService
-from local_newsifier.crud.entity import entity as entity_crud
-from local_newsifier.crud.canonical_entity import canonical_entity as canonical_entity_crud
-from local_newsifier.crud.entity_mention_context import entity_mention_context as entity_mention_context_crud
-from local_newsifier.crud.entity_profile import entity_profile as entity_profile_crud
-from local_newsifier.crud.article import article as article_crud
-from local_newsifier.tools.extraction.entity_extractor import EntityExtractor
-from local_newsifier.tools.analysis.context_analyzer import ContextAnalyzer
-from local_newsifier.tools.resolution.entity_resolver import EntityResolver
 
 
 class EntityTracker:
     """Tool for tracking entities across news articles using the EntityService."""
-    
-    def __init__(self, entity_service=None, session=None):
-        """Initialize with dependencies.
+
+    def __init__(self, entity_service: EntityService) -> None:
+        """Initialize the tracker with an entity service.
 
         Args:
             entity_service: Service for entity operations
-            session: Database session
         """
         self.entity_service = entity_service
-        self.session = session
-
-        # Initialize dependencies if needed
-        self._ensure_dependencies()
-    
-    def _ensure_dependencies(self):
-        """Ensure all dependencies are available."""
-        if self.entity_service is None:
-            self.entity_service = self._create_default_service()
-    
-    def _create_default_service(self):
-        """Create default entity service with all dependencies."""
-        return EntityService(
-            entity_crud=entity_crud,
-            canonical_entity_crud=canonical_entity_crud,
-            entity_mention_context_crud=entity_mention_context_crud,
-            entity_profile_crud=entity_profile_crud,
-            article_crud=article_crud,
-            entity_extractor=EntityExtractor(),
-            context_analyzer=ContextAnalyzer(),
-            entity_resolver=EntityResolver(),
-            session_factory=get_session
-        )
     
     @with_session
     def process_article(
@@ -75,9 +42,6 @@ class EntityTracker:
         Returns:
             List of processed entity mentions
         """
-        # Ensure dependencies are available
-        self._ensure_dependencies()
-        
         # Delegate to the service
         return self.entity_service.process_article_entities(
             article_id=article_id,


### PR DESCRIPTION
## Summary

Fix hidden dependencies in EntityTracker by removing default service creation and using proper dependency injection.

**Part of Issue #674: Complete dependency injection migration across codebase**

## Changes
- Remove default service creation from `EntityTracker`
- Inject `EntityService` via providers
- Update `EntityTrackingFlow` to build tracker after service injection

## Problem Solved
- EntityTracker had hidden dependencies that made testing difficult
- Manual service creation violated DI principles
- Dependencies were not explicit or mockable

## Impact
- Explicit dependency declarations
- Better testability through proper injection
- Consistent with Issue #674 DI migration goals
- Eliminates hidden coupling in entity tracking

🤖 Generated with [Claude Code](https://claude.ai/code)