### PR TITLE
Fix db inspect command provider

### DIFF
--- a/src/local_newsifier/di/providers.py
+++ b/src/local_newsifier/di/providers.py
@@ -1111,7 +1111,7 @@ def get_db_inspect_command():
         Function to execute db inspect command
     """
     from local_newsifier.cli.commands.db import inspect_record
-    return db_inspect_command
+    return inspect_record
 
 
 @injectable(use_cache=False)

--- a/tests/di/test_db_inspect_command_provider.py
+++ b/tests/di/test_db_inspect_command_provider.py
@@ -1,0 +1,10 @@
+"""Tests for get_db_inspect_command provider."""
+
+from local_newsifier.di.providers import get_db_inspect_command
+from local_newsifier.cli.commands.db import inspect_record
+
+
+def test_get_db_inspect_command_returns_inspect_record():
+    """Ensure provider returns the inspect_record function."""
+    result = get_db_inspect_command()
+    assert result is inspect_record


### PR DESCRIPTION
## Summary
- return `inspect_record` from `get_db_inspect_command`
- test provider returns the correct CLI function

## Testing
- `make test` *(fails: Command not found: pytest)*