### PR TITLE
Add CLI helpers module and refactor Apify commands

### DIFF
--- a/src/local_newsifier/cli/helpers.py
+++ b/src/local_newsifier/cli/helpers.py
@@ -1,0 +1,54 @@
+import json
+import logging
+import os
+from typing import Any, Optional
+
+import click
+
+from local_newsifier.config.settings import settings
+
+
+def ensure_apify_token(token: Optional[str] = None) -> bool:
+    """Ensure the Apify token is available.
+
+    If ``token`` is provided it overrides environment or settings. In test mode a
+    dummy token is injected when missing.
+
+    Returns:
+        bool: ``True`` if a token is available, ``False`` otherwise.
+    """
+    if token:
+        settings.APIFY_TOKEN = token
+        return True
+
+    # Provide a default token when running tests
+    if os.environ.get("PYTEST_CURRENT_TEST") is not None:
+        if not settings.APIFY_TOKEN:
+            logging.warning("Running CLI in test mode with dummy APIFY_TOKEN")
+            settings.APIFY_TOKEN = "test_dummy_token"
+        return True
+
+    env_token = os.environ.get("APIFY_TOKEN")
+    if env_token:
+        settings.APIFY_TOKEN = env_token
+        return True
+
+    if settings.APIFY_TOKEN:
+        return True
+
+    click.echo(click.style("Error: APIFY_TOKEN is not set.", fg="red"), err=True)
+    click.echo("Please set it using one of these methods:")
+    click.echo("  1. Export as environment variable: export APIFY_TOKEN=your_token")
+    click.echo("  2. Add to .env file: APIFY_TOKEN=your_token")
+    click.echo("  3. Use --token option with this command")
+    return False
+
+
+def write_output(data: Any, path: Optional[str] = None) -> None:
+    """Write JSON output to a file or echo to the console."""
+    if path:
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+        click.echo(f"Output saved to {path}")
+    else:
+        click.echo(json.dumps(data, indent=2))

--- a/tests/cli/test_apify_commands.py
+++ b/tests/cli/test_apify_commands.py
@@ -8,10 +8,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from local_newsifier.cli.commands.apify import (_ensure_token,
-                                                get_actor, get_dataset, run_actor,
-                                                scrape_content, test_connection, 
-                                                web_scraper)
+from local_newsifier.cli.commands.apify import (
+    get_actor,
+    get_dataset,
+    run_actor,
+    scrape_content,
+    test_connection,
+    web_scraper,
+)
+from local_newsifier.cli.helpers import ensure_apify_token
 from local_newsifier.config.settings import settings
 from local_newsifier.services.apify_service import ApifyService
 
@@ -86,7 +91,7 @@ class TestApifyCommands:
     """Test the Apify CLI commands."""
 
     @patch('os.environ.get')
-    def test_ensure_token_with_env_var(self, mock_environ_get, original_token):
+    def test_ensure_apify_token_with_env_var(self, mock_environ_get, original_token):
         """Test ensuring the token with the env var."""
         # Mock environment to not detect pytest
         mock_environ_get.side_effect = lambda key, default=None: {
@@ -96,11 +101,11 @@ class TestApifyCommands:
         
         # Ensure token is set for the test
         os.environ["APIFY_TOKEN"] = "test_token"
-        assert _ensure_token() is True
+        assert ensure_apify_token() is True
         assert settings.APIFY_TOKEN == "test_token"
 
     @patch('os.environ.get')
-    def test_ensure_token_with_settings(self, mock_environ_get, original_token):
+    def test_ensure_apify_token_with_settings(self, mock_environ_get, original_token):
         """Test ensuring the token with settings."""
         # Mock environment to not detect pytest
         mock_environ_get.side_effect = lambda key, default=None: {
@@ -111,10 +116,10 @@ class TestApifyCommands:
         if "APIFY_TOKEN" in os.environ:
             del os.environ["APIFY_TOKEN"]
         settings.APIFY_TOKEN = "settings_token"
-        assert _ensure_token() is True
+        assert ensure_apify_token() is True
 
     @patch('os.environ.get')
-    def test_ensure_token_missing(self, mock_environ_get, runner, original_token):
+    def test_ensure_apify_token_missing(self, mock_environ_get, runner, original_token):
         """Test ensuring the token when it's missing."""
         # Mock environment to not detect pytest
         mock_environ_get.side_effect = lambda key, default=None: {
@@ -125,7 +130,7 @@ class TestApifyCommands:
         if "APIFY_TOKEN" in os.environ:
             del os.environ["APIFY_TOKEN"]
         settings.APIFY_TOKEN = None
-        assert _ensure_token() is False
+        assert ensure_apify_token() is False
 
     @patch("local_newsifier.cli.commands.apify.get_injected_obj")
     def test_test_connection(

--- a/tests/cli/test_apify_schedule_commands.py
+++ b/tests/cli/test_apify_schedule_commands.py
@@ -100,7 +100,7 @@ class TestApifyScheduleCommands:
     """Test the Apify schedule CLI commands."""
 
     @patch("local_newsifier.cli.commands.apify._get_schedule_manager")
-    @patch("local_newsifier.cli.commands.apify._ensure_token")
+    @patch("local_newsifier.cli.helpers.ensure_apify_token")
     @patch("local_newsifier.cli.commands.apify.config_crud.get_scheduled_configs")
     @patch("local_newsifier.cli.commands.apify.get_session")
     def test_list_schedules(
@@ -127,7 +127,7 @@ class TestApifyScheduleCommands:
         assert "Inactive" in result.output
         
     @patch("local_newsifier.cli.commands.apify._get_schedule_manager")
-    @patch("local_newsifier.cli.commands.apify._ensure_token")
+    @patch("local_newsifier.cli.helpers.ensure_apify_token")
     @patch("local_newsifier.cli.commands.apify.config_crud.get_scheduled_configs")
     @patch("local_newsifier.cli.commands.apify.get_session")
     def test_list_schedules_with_apify(
@@ -153,7 +153,7 @@ class TestApifyScheduleCommands:
         assert "Synced" in result.output
 
     @patch("local_newsifier.cli.commands.apify._get_schedule_manager")
-    @patch("local_newsifier.cli.commands.apify._ensure_token")
+    @patch("local_newsifier.cli.helpers.ensure_apify_token")
     @patch("local_newsifier.cli.commands.apify.config_crud.get_scheduled_configs")
     @patch("local_newsifier.cli.commands.apify.get_session")
     def test_list_schedules_json_format(
@@ -182,7 +182,7 @@ class TestApifyScheduleCommands:
         assert "0 0 * * 0" in result.output
 
     @patch("local_newsifier.cli.commands.apify._get_schedule_manager")
-    @patch("local_newsifier.cli.commands.apify._ensure_token")
+    @patch("local_newsifier.cli.helpers.ensure_apify_token")
     def test_sync_schedules(
         self, mock_ensure_token, mock_get_schedule_manager, 
         runner, mock_schedule_manager
@@ -206,7 +206,7 @@ class TestApifyScheduleCommands:
         mock_schedule_manager.sync_schedules.assert_called_once()
 
     @patch("local_newsifier.cli.commands.apify._get_schedule_manager")
-    @patch("local_newsifier.cli.commands.apify._ensure_token")
+    @patch("local_newsifier.cli.helpers.ensure_apify_token")
     def test_create_schedule(
         self, mock_ensure_token, mock_get_schedule_manager, 
         runner, mock_schedule_manager
@@ -226,7 +226,7 @@ class TestApifyScheduleCommands:
         mock_schedule_manager.create_schedule_for_config.assert_called_once_with(1)
 
     @patch("local_newsifier.cli.commands.apify._get_schedule_manager")
-    @patch("local_newsifier.cli.commands.apify._ensure_token")
+    @patch("local_newsifier.cli.helpers.ensure_apify_token")
     def test_update_schedule(
         self, mock_ensure_token, mock_get_schedule_manager, 
         runner, mock_schedule_manager
@@ -246,7 +246,7 @@ class TestApifyScheduleCommands:
         mock_schedule_manager.update_schedule_for_config.assert_called_once_with(1)
 
     @patch("local_newsifier.cli.commands.apify._get_schedule_manager")
-    @patch("local_newsifier.cli.commands.apify._ensure_token")
+    @patch("local_newsifier.cli.helpers.ensure_apify_token")
     def test_delete_schedule(
         self, mock_ensure_token, mock_get_schedule_manager, 
         runner, mock_schedule_manager
@@ -266,7 +266,7 @@ class TestApifyScheduleCommands:
         mock_schedule_manager.delete_schedule_for_config.assert_called_once_with(1)
 
     @patch("local_newsifier.cli.commands.apify._get_schedule_manager")
-    @patch("local_newsifier.cli.commands.apify._ensure_token")
+    @patch("local_newsifier.cli.helpers.ensure_apify_token")
     def test_schedule_status(
         self, mock_ensure_token, mock_get_schedule_manager, 
         runner, mock_schedule_manager
@@ -291,7 +291,7 @@ class TestApifyScheduleCommands:
         mock_schedule_manager.verify_schedule_status.assert_called_once_with(1)
 
     @patch("local_newsifier.cli.commands.apify._get_schedule_manager")
-    @patch("local_newsifier.cli.commands.apify._ensure_token")
+    @patch("local_newsifier.cli.helpers.ensure_apify_token")
     def test_schedule_status_not_synced(
         self, mock_ensure_token, mock_get_schedule_manager, 
         runner, mock_schedule_manager
@@ -322,7 +322,7 @@ class TestApifyScheduleCommands:
         assert "Run 'nf apify schedules update CONFIG_ID' to synchronize" in result.output
 
     @patch("local_newsifier.cli.commands.apify._get_schedule_manager")
-    @patch("local_newsifier.cli.commands.apify._ensure_token")
+    @patch("local_newsifier.cli.helpers.ensure_apify_token")
     def test_schedule_status_not_exists(
         self, mock_ensure_token, mock_get_schedule_manager, 
         runner, mock_schedule_manager


### PR DESCRIPTION
## Summary
- add `cli/helpers.py` with helper utilities
- refactor `apify` CLI commands to use new helpers
- update CLI tests to import and patch helpers

## Testing
- `pip install --no-index --find-links=wheels -r requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy>=2.0.27)*