### PR TITLE
Fix async engine tests

### DIFF
--- a/tests/api/test_async_endpoints.py
+++ b/tests/api/test_async_endpoints.py
@@ -1,4 +1,9 @@
-from tests.fixtures.async_utils import isolated_event_loop, async_test, async_session
+from tests.fixtures.async_utils import (
+    isolated_event_loop,
+    async_test,
+    async_session,
+    async_test_db,
+)
 
 
 @async_test

--- a/tests/database/test_async_engine.py
+++ b/tests/database/test_async_engine.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Field, Session, select
 
 from local_newsifier.database.async_engine import AsyncDatabase
+from tests.fixtures.async_utils import isolated_event_loop
 
 
 class Item(SQLModel, table=True):

--- a/tests/fixtures/async_utils.py
+++ b/tests/fixtures/async_utils.py
@@ -81,6 +81,11 @@ def async_test(func):
     def wrapper(*args, **kwargs):
         loop = next((arg for arg in args if isinstance(arg, asyncio.AbstractEventLoop)), None)
         if loop is None:
+            loop = next(
+                (val for val in kwargs.values() if isinstance(val, asyncio.AbstractEventLoop)),
+                None,
+            )
+        if loop is None:
             pytest.fail("async_test requires isolated_event_loop fixture")
         return loop.run_until_complete(func(*args, **kwargs))
 


### PR DESCRIPTION
## Summary
- relax Python version requirement
- adjust AsyncDatabase so in-memory SQLite works with async contexts
- ensure async fixtures are imported
- support async_test decorator when fixtures are passed by keyword
- revert Python version relaxation

## Testing
- `python -m pytest -n auto -q`