### PR TITLE
Add documentation for test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,16 @@ This document helps Codex locate developer guides and explains how to work with 
   - src/local_newsifier/di/CLAUDE.md
   - src/local_newsifier/flows/CLAUDE.md
   - src/local_newsifier/models/CLAUDE.md
-  - src/local_newsifier/services/CLAUDE.md
   - src/local_newsifier/tools/CLAUDE.md
+- Test guides:
+  - tests/CLAUDE.md
+  - tests/api/CLAUDE.md
+  - tests/cli/CLAUDE.md
+  - tests/flows/CLAUDE.md
+  - tests/tools/CLAUDE.md
+  - tests/services/CLAUDE.md
+  - tests/models/CLAUDE.md
+  - tests/crud/CLAUDE.md
 - Additional docs: all Markdown files under `docs/`, plus `FastAPI-Injectable-Migration-Plan.md`, `README.md`, and `README_CLI.md`.
 
 If a `CLAUDE.md` file is added or removed, update this list.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,11 @@
+# Local Newsifier Test Suite Guide
+
+This directory contains all automated tests. Tests are grouped by component type (API, CLI, flows, services, models, tools, and CRUD helpers).
+
+## Fixtures and Utilities
+- Common fixtures live in `tests/fixtures/` and `tests/utils/`.
+- `event_loop_fixture` helps manage async code when using fastapi-injectable.
+- Use the helpers in `conftest_injectable.py` to mock injectable dependencies.
+- Skip problematic tests in CI with decorators from `ci_skip_config.py`.
+
+Follow the testing guidance in `../claude.md` for additional details on coverage goals and patterns.

--- a/tests/api/CLAUDE.md
+++ b/tests/api/CLAUDE.md
@@ -1,0 +1,7 @@
+# API Tests Guide
+
+Tests in this folder verify FastAPI endpoints and dependency wiring.
+`conftest.py` defines any API specific fixtures. For mocking injectable
+providers, use the helpers in `tests/conftest_injectable.py`.
+
+See `../CLAUDE.md` for overall testing conventions.

--- a/tests/cli/CLAUDE.md
+++ b/tests/cli/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLI Tests Guide
+
+CLI tests cover the command line interface defined in `src/local_newsifier/cli`.
+`conftest.py` exposes fixtures for mocking session and feed services.
+
+Use mocks from `tests/utils` to replace providers when invoking CLI commands.
+Refer to `../CLAUDE.md` for the shared testing guidelines.

--- a/tests/crud/CLAUDE.md
+++ b/tests/crud/CLAUDE.md
@@ -1,0 +1,7 @@
+# CRUD Tests Guide
+
+CRUD tests validate the low level database helpers. All fixtures were moved
+to the root `tests/conftest.py` so this directory mostly contains pure unit
+tests.
+
+See `../CLAUDE.md` for shared guidance on fixtures and mocking.

--- a/tests/flows/CLAUDE.md
+++ b/tests/flows/CLAUDE.md
@@ -1,0 +1,7 @@
+# Flow Tests Guide
+
+Flow tests exercise the high level workflows such as entity tracking and
+article ingestion. Many tests use the event loop fixtures and injectable mocks
+from `tests/conftest_injectable.py`.
+
+See `../CLAUDE.md` for general guidance.

--- a/tests/models/CLAUDE.md
+++ b/tests/models/CLAUDE.md
@@ -1,0 +1,6 @@
+# Models Tests Guide
+
+This folder contains unit tests for SQLModel and Pydantic models. Database
+models are tested under `database/` while plain models have their own files.
+
+Refer to `../CLAUDE.md` for general test setup and fixtures.

--- a/tests/services/CLAUDE.md
+++ b/tests/services/CLAUDE.md
@@ -1,0 +1,7 @@
+# Services Tests Guide
+
+Service tests validate business logic and integrations. `conftest.py` mocks
+imports to avoid heavy dependencies like SQLite.
+
+Use the injectable helpers from `tests/conftest_injectable.py` when mocking
+providers. See `../CLAUDE.md` for global policies.

--- a/tests/tools/CLAUDE.md
+++ b/tests/tools/CLAUDE.md
@@ -1,0 +1,6 @@
+# Tools Tests Guide
+
+These tests cover helper utilities and analysis tools. Fixtures live in
+`tests/tools` and common mocks come from `tests/utils`.
+
+Refer to `../CLAUDE.md` for overall testing practices.


### PR DESCRIPTION
## Summary
- document overall test folder layout in `tests/CLAUDE.md`
- add `CLAUDE.md` guides under each major test subdirectory
- update `AGENTS.md` documentation map with new test guides

## Testing
- `make test` *(fails: Command not found: pytest)*