### PR TITLE
Fix event loop issue in db inspect command provider test

### DIFF
--- a/tests/di/test_db_inspect_command_provider.py
+++ b/tests/di/test_db_inspect_command_provider.py
@@ -1,10 +1,11 @@
 """Tests for get_db_inspect_command provider."""
 
-from local_newsifier.di.providers import get_db_inspect_command
 from local_newsifier.cli.commands.db import inspect_record
+from local_newsifier.di.providers import get_db_inspect_command
+from tests.fixtures.event_loop import event_loop_fixture  # noqa: F401
 
 
-def test_get_db_inspect_command_returns_inspect_record():
+def test_get_db_inspect_command_returns_inspect_record(event_loop_fixture):  # noqa: F811
     """Ensure provider returns the inspect_record function."""
     result = get_db_inspect_command()
     assert result is inspect_record


### PR DESCRIPTION
## Summary
- Fix RuntimeError: Event loop is closed in tests/di/test_db_inspect_command_provider.py
- Add event_loop_fixture parameter following the established pattern used in other DI provider tests
- This resolves the single failing test that was preventing PR #673 from passing

## Test plan
- [ ] Verify the specific failing test now passes
- [ ] Confirm all other tests continue to pass  
- [ ] Check that CI build completes successfully

## Background
This test was failing with event loop issues unrelated to the actual functionality being tested. The test simply verifies that a provider function returns the correct function reference, but was encountering asyncio event loop closure issues in CI environments.

The fix applies the standard event_loop_fixture pattern used throughout the test suite for handling async/event loop issues with fastapi-injectable.

🤖 Generated with [Claude Code](https://claude.ai/code)