### PR TITLE
Fix Python version requirement for Railway deployment (Issue #704)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "local_newsifier", from = "src"}]
 
 [tool.poetry.dependencies]
-python = "3.12.10"
+python = "~3.12"
 crewai = "^0.114.0"
 chromadb = "1.0.9"
 pydantic = "^2.11.3"


### PR DESCRIPTION
## Summary
- Changed Python version requirement from exact `3.12.10` to `~3.12` to fix Railway deployment failure
- This allows any Python 3.12.x version while preventing upgrades to 3.13

## Problem
Railway deployment was failing with:
```
ERROR: Package 'local-newsifier' requires a different Python: 3.12.7 not in '==3.12.10'
```

## Solution
Updated `pyproject.toml` to use `python = "~3.12"` which accepts versions >=3.12.0,<3.13.0

## Test plan
- [x] Updated pyproject.toml
- [x] Verified poetry lock succeeds
- [x] Tested local installation with `poetry install`
- [x] Verified CLI works with `nf --help`
- [ ] Railway deployment should succeed after merge

Fixes #704

🤖 Generated with [Claude Code](https://claude.ai/code)