### PR TITLE
CLI-to-HTTP migration phase 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ tabulate = "^0.9.0"
 apify-client = "1.10.0"
 fastapi-injectable = "0.7.0"
 greenlet = "^3.2.2"
-httpx = "^0.28.1"
+httpx = "^0.27.0"
 
 [tool.poetry.scripts]
 nf = "local_newsifier.cli.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,11 @@ tabulate = "^0.9.0"
 apify-client = "1.10.0"
 fastapi-injectable = "0.7.0"
 greenlet = "^3.2.2"
+httpx = "^0.28.1"
 
 [tool.poetry.scripts]
 nf = "local_newsifier.cli.main:main"
+nf-http = "local_newsifier.cli.main_http:main"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/src/local_newsifier/api/main.py
+++ b/src/local_newsifier/api/main.py
@@ -9,13 +9,12 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 from fastapi_injectable import register_app
-from sqlmodel import Session
 from starlette.middleware.sessions import SessionMiddleware
 
 # Import models to ensure they're registered with SQLModel.metadata before creating tables
-import local_newsifier.models
+import local_newsifier.models  # noqa: F401
 from local_newsifier.api.dependencies import get_templates
-from local_newsifier.api.routers import auth, system, tasks, webhooks
+from local_newsifier.api.routers import auth, db, feeds, system, tasks, webhooks
 from local_newsifier.config.settings import get_settings, settings
 from local_newsifier.database.engine import create_db_and_tables
 
@@ -30,7 +29,7 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan context manager for FastAPI application.
-    
+
     Handles startup and shutdown events.
     """
     # Startup logic
@@ -39,19 +38,19 @@ async def lifespan(app: FastAPI):
         # Initialize database tables
         create_db_and_tables()
         logger.info("Database initialization completed")
-        
+
         # Initialize fastapi-injectable
         logger.info("Initializing fastapi-injectable")
         await register_app(app)
-        
+
         logger.info("fastapi-injectable initialization completed")
     except Exception as e:
         logger.error(f"Startup error: {str(e)}")
-    
+
     logger.info("Application startup complete")
-    
+
     yield  # This is where FastAPI serves requests
-    
+
     # Shutdown logic
     logger.info("Application shutdown initiated")
     logger.info("Application shutdown complete")
@@ -70,40 +69,34 @@ app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
 
 # Include routers
 app.include_router(auth.router)
+app.include_router(db.router)
+app.include_router(feeds.router)
 app.include_router(system.router)
 app.include_router(tasks.router)
 app.include_router(webhooks.router)
 
+
 @app.get("/", response_class=HTMLResponse)
-async def root(
-    request: Request,
-    templates: Jinja2Templates = Depends(get_templates)
-):
+async def root(request: Request, templates: Jinja2Templates = Depends(get_templates)):
     """Root endpoint serving home page with recent headlines."""
     # Get recent articles from the last 30 days
     end_date = datetime.now()
     start_date = end_date - timedelta(days=30)
-    
+
     recent_articles_data = []
     try:
         # Use a synchronous session to avoid event loop issues
         from local_newsifier.crud.article import article as article_crud_instance
         from local_newsifier.database.engine import SessionManager
-        
+
         with SessionManager() as session:
             articles = article_crud_instance.get_by_date_range(
-                session, 
-                start_date=start_date, 
-                end_date=end_date
+                session, start_date=start_date, end_date=end_date
             )
-            
+
             # Order by published date (newest first) and limit to 20 articles
-            articles = sorted(
-                articles, 
-                key=lambda x: x.published_at, 
-                reverse=True
-            )[:20]
-            
+            articles = sorted(articles, key=lambda x: x.published_at, reverse=True)[:20]
+
             # Convert SQLModel objects to dictionaries to avoid detached instance errors
             for article in articles:
                 article_dict = {
@@ -112,19 +105,15 @@ async def root(
                     "url": article.url,
                     "source": article.source,
                     "published_at": article.published_at,
-                    "status": article.status
+                    "status": article.status,
                 }
                 recent_articles_data.append(article_dict)
     except Exception as e:
         logger.error(f"Error fetching recent articles: {str(e)}")
-    
+
     return templates.TemplateResponse(
         "index.html",
-        {
-            "request": request,
-            "title": "Local Newsifier",
-            "recent_articles": recent_articles_data
-        },
+        {"request": request, "title": "Local Newsifier", "recent_articles": recent_articles_data},
     )
 
 
@@ -149,10 +138,7 @@ async def get_config():
 
 
 @app.exception_handler(404)
-async def not_found_handler(
-    request: Request, 
-    exc: Exception
-) -> JSONResponse:
+async def not_found_handler(request: Request, exc: Exception) -> JSONResponse:
     """Handle 404 errors."""
     templates = get_templates()
     if request.url.path.startswith("/api"):

--- a/src/local_newsifier/api/routers/__init__.py
+++ b/src/local_newsifier/api/routers/__init__.py
@@ -1,1 +1,5 @@
 """API routers package."""
+
+from . import auth, db, feeds, system, tasks, webhooks
+
+__all__ = ["auth", "db", "feeds", "system", "tasks", "webhooks"]

--- a/src/local_newsifier/api/routers/db.py
+++ b/src/local_newsifier/api/routers/db.py
@@ -1,0 +1,361 @@
+"""Database inspection and management router."""
+
+from datetime import datetime
+from typing import Annotated, Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import func, text
+from sqlmodel import Session, select
+
+from local_newsifier.api.dependencies import get_session
+from local_newsifier.di.providers import (get_article_crud, get_entity_crud,
+                                          get_feed_processing_log_crud, get_rss_feed_crud)
+from local_newsifier.models.article import Article
+from local_newsifier.models.entity import Entity
+from local_newsifier.models.rss_feed import RSSFeed, RSSFeedProcessingLog
+
+router = APIRouter(
+    prefix="/db",
+    tags=["database"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+def format_datetime(dt) -> Optional[str]:
+    """Format a datetime object for display."""
+    if not dt:
+        return None
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+class PurgeDuplicatesRequest(BaseModel):
+    """Request model for purging duplicates."""
+
+    dry_run: bool = True
+
+
+@router.get("/stats")
+async def get_db_stats(session: Annotated[Session, Depends(get_session)]) -> Dict[str, Any]:
+    """Get database statistics for all major tables."""
+    stats = {}
+
+    # Article stats
+    article_count = session.exec(select(func.count()).select_from(Article)).one()
+    latest_article = session.exec(
+        select(Article).order_by(Article.created_at.desc()).limit(1)
+    ).first()
+    oldest_article = session.exec(select(Article).order_by(Article.created_at).limit(1)).first()
+
+    # RSS Feed stats
+    feed_count = session.exec(select(func.count()).select_from(RSSFeed)).one()
+    active_feed_count = session.exec(
+        select(func.count()).select_from(RSSFeed).where(RSSFeed.is_active)
+    ).one()
+
+    # RSSFeedProcessingLog stats
+    processing_log_count = session.exec(
+        select(func.count()).select_from(RSSFeedProcessingLog)
+    ).one()
+
+    # Entity stats
+    entity_count = session.exec(select(func.count()).select_from(Entity)).one()
+
+    stats["articles"] = {
+        "count": article_count,
+        "latest": format_datetime(latest_article.created_at) if latest_article else None,
+        "oldest": format_datetime(oldest_article.created_at) if oldest_article else None,
+    }
+
+    stats["rss_feeds"] = {
+        "count": feed_count,
+        "active": active_feed_count,
+        "inactive": feed_count - active_feed_count,
+    }
+
+    stats["feed_processing_logs"] = {
+        "count": processing_log_count,
+    }
+
+    stats["entities"] = {
+        "count": entity_count,
+    }
+
+    return stats
+
+
+@router.get("/duplicates")
+async def get_duplicates(
+    limit: int = 10, session: Annotated[Session, Depends(get_session)] = None
+) -> List[Dict[str, Any]]:
+    """Find duplicate articles (same URL) and show details."""
+    # Query to find duplicate URLs
+    duplicate_urls = session.exec(
+        select(Article.url, func.count(Article.id).label("count"))
+        .group_by(Article.url)
+        .having(func.count(Article.id) > 1)
+        .order_by(text("count DESC"))
+        .limit(limit)
+    ).all()
+
+    if not duplicate_urls:
+        return []
+
+    # Get detailed information about the duplicates
+    results = []
+    for url, count in duplicate_urls:
+        duplicates = session.exec(
+            select(Article).where(Article.url == url).order_by(Article.created_at)
+        ).all()
+
+        duplicate_info = {"url": url, "count": count, "articles": []}
+
+        for article in duplicates:
+            duplicate_info["articles"].append(
+                {
+                    "id": article.id,
+                    "title": (
+                        article.title[:50] + "..."
+                        if article.title and len(article.title) > 50
+                        else article.title
+                    ),
+                    "created_at": format_datetime(article.created_at),
+                    "status": article.status,
+                    "content_len": len(article.content) if article.content else 0,
+                }
+            )
+
+        results.append(duplicate_info)
+
+    return results
+
+
+@router.get("/articles")
+async def list_articles(
+    source: Optional[str] = None,
+    status: Optional[str] = None,
+    before: Optional[str] = None,
+    after: Optional[str] = None,
+    limit: int = 10,
+    session: Annotated[Session, Depends(get_session)] = None,
+) -> List[Dict[str, Any]]:
+    """List articles with filtering options."""
+    # Build the query with filters
+    query = select(Article)
+
+    if source:
+        query = query.where(Article.source == source)
+
+    if status:
+        query = query.where(Article.status == status)
+
+    if before:
+        try:
+            before_date = datetime.strptime(before, "%Y-%m-%d")
+            query = query.where(Article.created_at < before_date)
+        except ValueError:
+            raise HTTPException(
+                status_code=400, detail="Invalid date format for 'before'. Use YYYY-MM-DD"
+            )
+
+    if after:
+        try:
+            after_date = datetime.strptime(after, "%Y-%m-%d")
+            query = query.where(Article.created_at > after_date)
+        except ValueError:
+            raise HTTPException(
+                status_code=400, detail="Invalid date format for 'after'. Use YYYY-MM-DD"
+            )
+
+    # Order by most recent first and apply limit
+    query = query.order_by(Article.created_at.desc()).limit(limit)
+
+    # Execute query
+    articles = session.exec(query).all()
+
+    # Format the results
+    results = []
+    for article in articles:
+        results.append(
+            {
+                "id": article.id,
+                "title": article.title,
+                "url": article.url,
+                "source": article.source,
+                "status": article.status,
+                "created_at": format_datetime(article.created_at),
+                "content_len": len(article.content) if article.content else 0,
+            }
+        )
+
+    return results
+
+
+@router.get("/inspect/{table}/{id}")
+async def inspect_record(
+    table: str,
+    id: int,
+    session: Annotated[Session, Depends(get_session)] = None,
+    article_crud: Annotated[Any, Depends(get_article_crud)] = None,
+    rss_feed_crud: Annotated[Any, Depends(get_rss_feed_crud)] = None,
+    entity_crud: Annotated[Any, Depends(get_entity_crud)] = None,
+    feed_processing_log_crud: Annotated[Any, Depends(get_feed_processing_log_crud)] = None,
+) -> Dict[str, Any]:
+    """Inspect a specific database record in detail."""
+    if table not in ["article", "rss_feed", "feed_log", "entity"]:
+        raise HTTPException(status_code=400, detail=f"Invalid table: {table}")
+
+    result = None
+
+    if table == "article":
+        article = article_crud.get(session, id=id)
+        if not article:
+            raise HTTPException(status_code=404, detail=f"Article with ID {id} not found")
+
+        result = {
+            "id": article.id,
+            "title": article.title,
+            "url": article.url,
+            "source": article.source,
+            "status": article.status,
+            "created_at": format_datetime(article.created_at),
+            "updated_at": format_datetime(article.updated_at),
+            "published_at": format_datetime(article.published_at) if article.published_at else None,
+            "scraped_at": format_datetime(article.scraped_at) if article.scraped_at else None,
+            "content_len": len(article.content) if article.content else 0,
+            "content_preview": (
+                (article.content[:200] + "...")
+                if article.content and len(article.content) > 200
+                else article.content
+            ),
+        }
+
+    elif table == "rss_feed":
+        feed = rss_feed_crud.get(session, id=id)
+        if not feed:
+            raise HTTPException(status_code=404, detail=f"RSS Feed with ID {id} not found")
+
+        # Get processing logs for this feed
+        logs = session.exec(
+            select(RSSFeedProcessingLog)
+            .where(RSSFeedProcessingLog.feed_id == id)
+            .order_by(RSSFeedProcessingLog.started_at.desc())
+            .limit(5)
+        ).all()
+
+        log_data = []
+        for log in logs:
+            log_data.append(
+                {
+                    "id": log.id,
+                    "status": log.status,
+                    "started_at": format_datetime(log.started_at),
+                    "completed_at": format_datetime(log.completed_at) if log.completed_at else None,
+                    "articles_found": log.articles_found,
+                    "articles_added": log.articles_added,
+                    "error_message": log.error_message,
+                }
+            )
+
+        result = {
+            "id": feed.id,
+            "name": feed.name,
+            "url": feed.url,
+            "description": feed.description,
+            "is_active": feed.is_active,
+            "created_at": format_datetime(feed.created_at),
+            "updated_at": format_datetime(feed.updated_at),
+            "last_fetched_at": (
+                format_datetime(feed.last_fetched_at) if feed.last_fetched_at else None
+            ),
+            "recent_logs": log_data,
+        }
+
+    elif table == "feed_log":
+        log = feed_processing_log_crud.get(session, id=id)
+        if not log:
+            raise HTTPException(
+                status_code=404, detail=f"Feed Processing Log with ID {id} not found"
+            )
+
+        result = {
+            "id": log.id,
+            "feed_id": log.feed_id,
+            "status": log.status,
+            "started_at": format_datetime(log.started_at),
+            "completed_at": format_datetime(log.completed_at) if log.completed_at else None,
+            "articles_found": log.articles_found,
+            "articles_added": log.articles_added,
+            "error_message": log.error_message,
+        }
+
+    elif table == "entity":
+        entity = entity_crud.get(session, id=id)
+        if not entity:
+            raise HTTPException(status_code=404, detail=f"Entity with ID {id} not found")
+
+        result = {
+            "id": entity.id,
+            "name": entity.name,
+            "entity_type": entity.entity_type,
+            "created_at": format_datetime(entity.created_at),
+            "updated_at": format_datetime(entity.updated_at),
+        }
+
+    return result
+
+
+@router.post("/purge-duplicates")
+async def purge_duplicates(
+    request: PurgeDuplicatesRequest,
+    session: Annotated[Session, Depends(get_session)] = None,
+    article_crud: Annotated[Any, Depends(get_article_crud)] = None,
+) -> Dict[str, Any]:
+    """Remove duplicate articles, keeping the oldest version."""
+    # Query to find duplicate URLs
+    duplicate_urls = session.exec(
+        select(Article.url, func.count(Article.id).label("count"))
+        .group_by(Article.url)
+        .having(func.count(Article.id) > 1)
+    ).all()
+
+    if not duplicate_urls:
+        return {"total_urls": 0, "total_removed": 0, "dry_run": request.dry_run, "details": []}
+
+    # Process each set of duplicates
+    results = []
+    total_removed = 0
+
+    for url, count in duplicate_urls:
+        duplicates = session.exec(
+            select(Article).where(Article.url == url).order_by(Article.created_at)
+        ).all()
+
+        # Keep the oldest (first) article
+        to_keep = duplicates[0]
+        to_remove = duplicates[1:]
+
+        result = {
+            "url": url,
+            "kept_id": to_keep.id,
+            "removed_ids": [a.id for a in to_remove],
+            "removed_count": len(to_remove),
+        }
+        results.append(result)
+        total_removed += len(to_remove)
+
+        # Remove duplicates if not a dry run
+        if not request.dry_run:
+            for article in to_remove:
+                article_crud.remove(session, id=article.id)
+
+    # Commit changes if not a dry run
+    if not request.dry_run:
+        session.commit()
+
+    return {
+        "total_urls": len(results),
+        "total_removed": total_removed,
+        "dry_run": request.dry_run,
+        "details": results,
+    }

--- a/src/local_newsifier/api/routers/feeds.py
+++ b/src/local_newsifier/api/routers/feeds.py
@@ -1,0 +1,231 @@
+"""RSS Feeds API router."""
+
+import logging
+from typing import Annotated, Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlmodel import Session
+
+from local_newsifier.api.dependencies import get_session
+from local_newsifier.di.providers import get_rss_feed_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/feeds",
+    tags=["feeds"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+class FeedCreate(BaseModel):
+    """Request model for creating a feed."""
+
+    url: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
+class FeedUpdate(BaseModel):
+    """Request model for updating a feed."""
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    is_active: Optional[bool] = None
+
+
+class FeedResponse(BaseModel):
+    """Response model for a feed."""
+
+    id: int
+    name: str
+    url: str
+    description: Optional[str]
+    is_active: bool
+    created_at: str
+    updated_at: str
+    last_fetched_at: Optional[str]
+
+
+def format_datetime(dt) -> Optional[str]:
+    """Format a datetime object for display."""
+    if not dt:
+        return None
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+@router.get("/", response_model=List[Dict[str, Any]])
+async def list_feeds(
+    active_only: bool = Query(False, description="Show only active feeds"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum number of feeds to return"),
+    skip: int = Query(0, ge=0, description="Number of feeds to skip"),
+    session: Annotated[Session, Depends(get_session)] = None,
+    rss_feed_service: Annotated[Any, Depends(get_rss_feed_service)] = None,
+) -> List[Dict[str, Any]]:
+    """List RSS feeds with optional filtering."""
+    try:
+        feeds = rss_feed_service.list_feeds(skip=skip, limit=limit, active_only=active_only)
+        return feeds
+    except Exception as e:
+        logger.error(f"Error listing feeds: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/{feed_id}", response_model=Dict[str, Any])
+async def get_feed(
+    feed_id: int,
+    session: Annotated[Session, Depends(get_session)] = None,
+    rss_feed_service: Annotated[Any, Depends(get_rss_feed_service)] = None,
+) -> Dict[str, Any]:
+    """Get a specific RSS feed by ID."""
+    try:
+        feed = rss_feed_service.get_feed(feed_id)
+        if not feed:
+            raise HTTPException(status_code=404, detail=f"Feed with ID {feed_id} not found")
+
+        # Get processing logs
+        logs = rss_feed_service.get_feed_processing_logs(feed_id, limit=5)
+
+        # Format response
+        result = {
+            "id": feed["id"],
+            "name": feed["name"],
+            "url": feed["url"],
+            "description": feed.get("description"),
+            "is_active": feed["is_active"],
+            "created_at": feed["created_at"],
+            "updated_at": feed["updated_at"],
+            "last_fetched_at": feed.get("last_fetched_at"),
+            "recent_logs": logs,
+        }
+
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting feed {feed_id}: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/", response_model=Dict[str, Any])
+async def create_feed(
+    feed_data: FeedCreate,
+    session: Annotated[Session, Depends(get_session)] = None,
+    rss_feed_service: Annotated[Any, Depends(get_rss_feed_service)] = None,
+) -> Dict[str, Any]:
+    """Create a new RSS feed."""
+    try:
+        feed = rss_feed_service.create_feed(
+            url=feed_data.url,
+            name=feed_data.name or feed_data.url,  # Use URL as default name
+            description=feed_data.description,
+        )
+        return feed
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error creating feed: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.patch("/{feed_id}", response_model=Dict[str, Any])
+async def update_feed(
+    feed_id: int,
+    feed_update: FeedUpdate,
+    session: Annotated[Session, Depends(get_session)] = None,
+    rss_feed_service: Annotated[Any, Depends(get_rss_feed_service)] = None,
+) -> Dict[str, Any]:
+    """Update an existing RSS feed."""
+    try:
+        # Build update data
+        update_data = {}
+        if feed_update.name is not None:
+            update_data["name"] = feed_update.name
+        if feed_update.description is not None:
+            update_data["description"] = feed_update.description
+        if feed_update.is_active is not None:
+            update_data["is_active"] = feed_update.is_active
+
+        feed = rss_feed_service.update_feed(feed_id, **update_data)
+        if not feed:
+            raise HTTPException(status_code=404, detail=f"Feed with ID {feed_id} not found")
+
+        return feed
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating feed {feed_id}: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete("/{feed_id}")
+async def delete_feed(
+    feed_id: int,
+    session: Annotated[Session, Depends(get_session)] = None,
+    rss_feed_service: Annotated[Any, Depends(get_rss_feed_service)] = None,
+) -> Dict[str, str]:
+    """Delete an RSS feed."""
+    try:
+        success = rss_feed_service.remove_feed(feed_id)
+        if not success:
+            raise HTTPException(status_code=404, detail=f"Feed with ID {feed_id} not found")
+
+        return {"message": f"Feed {feed_id} deleted successfully"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting feed {feed_id}: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/{feed_id}/process")
+async def process_feed(
+    feed_id: int,
+    session: Annotated[Session, Depends(get_session)] = None,
+    rss_feed_service: Annotated[Any, Depends(get_rss_feed_service)] = None,
+) -> Dict[str, Any]:
+    """Process a specific RSS feed."""
+    try:
+        result = rss_feed_service.process_feed(feed_id)
+        if not result:
+            raise HTTPException(status_code=404, detail=f"Feed with ID {feed_id} not found")
+
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error processing feed {feed_id}: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/process-all")
+async def process_all_feeds(
+    session: Annotated[Session, Depends(get_session)] = None,
+    rss_feed_service: Annotated[Any, Depends(get_rss_feed_service)] = None,
+) -> Dict[str, Any]:
+    """Process all active RSS feeds."""
+    try:
+        # Get all active feeds
+        feeds = rss_feed_service.list_feeds(active_only=True)
+
+        results = []
+        for feed in feeds:
+            try:
+                result = rss_feed_service.process_feed(feed["id"])
+                results.append(result)
+            except Exception as e:
+                logger.error(f"Error processing feed {feed['id']}: {str(e)}")
+                results.append(
+                    {
+                        "status": "error",
+                        "feed_id": feed["id"],
+                        "feed_name": feed["name"],
+                        "error": str(e),
+                    }
+                )
+
+        return {"processed": len(results), "results": results}
+    except Exception as e:
+        logger.error(f"Error processing all feeds: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/local_newsifier/cli/commands/db_http.py
+++ b/src/local_newsifier/cli/commands/db_http.py
@@ -1,0 +1,311 @@
+"""
+Database diagnostics commands using HTTP client.
+
+This module provides commands for inspecting and managing database state through HTTP API:
+- Viewing table statistics
+- Checking for duplicate records
+- Analyzing data integrity
+- Showing detailed entity information
+"""
+
+import json
+import sys
+from typing import Optional
+
+import click
+from tabulate import tabulate
+
+from local_newsifier.cli.http_client import NewsifierAPIError, NewsifierClient
+
+
+@click.group(name="db")
+@click.pass_context
+def db_group(ctx):
+    """Inspect and manage database state."""
+    # Initialize HTTP client in context
+    ctx.ensure_object(dict)
+    api_url = ctx.obj.get("api_url")
+    ctx.obj["client"] = NewsifierClient(base_url=api_url)
+
+
+@db_group.command(name="stats")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def db_stats(ctx, json_output: bool):
+    """Show database statistics for all major tables."""
+    client = ctx.obj["client"]
+
+    try:
+        with client:
+            stats = client.get_db_stats()
+    except NewsifierAPIError as e:
+        click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    # Output stats
+    if json_output:
+        click.echo(json.dumps(stats, indent=2))
+        return
+
+    # Display stats in a human-readable format
+    click.echo(click.style("Database Statistics", fg="green", bold=True))
+
+    # Articles table
+    click.echo(click.style("\nArticles:", fg="cyan", bold=True))
+    click.echo(f"Total count: {stats['articles']['count']}")
+    if stats["articles"]["latest"]:
+        click.echo(f"Most recent: {stats['articles']['latest']}")
+    if stats["articles"]["oldest"]:
+        click.echo(f"Oldest: {stats['articles']['oldest']}")
+
+    # RSS Feeds table
+    click.echo(click.style("\nRSS Feeds:", fg="cyan", bold=True))
+    click.echo(f"Total count: {stats['rss_feeds']['count']}")
+    click.echo(f"Active: {stats['rss_feeds']['active']}")
+    click.echo(f"Inactive: {stats['rss_feeds']['inactive']}")
+
+    # Processing Logs table
+    click.echo(click.style("\nFeed Processing Logs:", fg="cyan", bold=True))
+    click.echo(f"Total count: {stats['feed_processing_logs']['count']}")
+
+    # Entities table
+    click.echo(click.style("\nEntities:", fg="cyan", bold=True))
+    click.echo(f"Total count: {stats['entities']['count']}")
+
+
+@db_group.command(name="duplicates")
+@click.option("--limit", type=int, default=10, help="Maximum number of duplicates to display")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def check_duplicates(ctx, limit: int, json_output: bool):
+    """Find duplicate articles (same URL) and show details."""
+    client = ctx.obj["client"]
+
+    try:
+        with client:
+            results = client.get_duplicates(limit=limit)
+    except NewsifierAPIError as e:
+        click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    if not results:
+        click.echo("No duplicate articles found.")
+        return
+
+    # Output results
+    if json_output:
+        click.echo(json.dumps(results, indent=2))
+        return
+
+    # Display in human-readable format
+    click.echo(
+        click.style(f"Found {len(results)} URLs with duplicate articles:", fg="yellow", bold=True)
+    )
+
+    for idx, result in enumerate(results):
+        click.echo(click.style(f"\n{idx + 1}. URL: {result['url']}", fg="cyan"))
+        click.echo(f"   Number of duplicates: {result['count']}")
+
+        table_data = []
+        for article in result["articles"]:
+            table_data.append(
+                [
+                    article["id"],
+                    article["title"] or "(No title)",
+                    article["created_at"],
+                    article["status"],
+                    article["content_len"],
+                ]
+            )
+
+        headers = ["ID", "Title", "Created At", "Status", "Content Length"]
+        click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
+
+
+@db_group.command(name="articles")
+@click.option("--source", help="Filter by article source")
+@click.option("--status", help="Filter by article status")
+@click.option("--before", help="Show articles created before date (YYYY-MM-DD)")
+@click.option("--after", help="Show articles created after date (YYYY-MM-DD)")
+@click.option("--limit", type=int, default=10, help="Maximum number of articles to display")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def list_articles(
+    ctx,
+    source: Optional[str],
+    status: Optional[str],
+    before: Optional[str],
+    after: Optional[str],
+    limit: int,
+    json_output: bool,
+):
+    """List articles with filtering options."""
+    client = ctx.obj["client"]
+
+    try:
+        with client:
+            results = client.list_articles(
+                source=source, status=status, before=before, after=after, limit=limit
+            )
+    except NewsifierAPIError as e:
+        if e.status_code == 400:
+            click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        else:
+            click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    if not results:
+        click.echo("No articles found matching the criteria.")
+        return
+
+    # Output results
+    if json_output:
+        click.echo(json.dumps(results, indent=2))
+        return
+
+    # Display in human-readable format
+    click.echo(click.style(f"Articles ({len(results)} results):", fg="green", bold=True))
+
+    table_data = []
+    for article in results:
+        title = article["title"]
+        if title and len(title) > 40:
+            title = title[:37] + "..."
+
+        url = article["url"]
+        if url and len(url) > 40:
+            url = url[:37] + "..."
+
+        table_data.append(
+            [
+                article["id"],
+                title or "(No title)",
+                url,
+                article["source"],
+                article["status"],
+                article["created_at"],
+                article["content_len"],
+            ]
+        )
+
+    headers = ["ID", "Title", "URL", "Source", "Status", "Created At", "Content Length"]
+    click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
+
+
+@db_group.command(name="inspect")
+@click.argument("table", type=click.Choice(["article", "rss_feed", "feed_log", "entity"]))
+@click.argument("id", type=int)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def inspect_record(ctx, table: str, id: int, json_output: bool):
+    """Inspect a specific database record in detail."""
+    client = ctx.obj["client"]
+
+    try:
+        with client:
+            result = client.inspect_record(table, id)
+    except NewsifierAPIError as e:
+        if e.status_code == 404:
+            click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        else:
+            click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    # Output results
+    if json_output:
+        click.echo(json.dumps(result, indent=2))
+        return
+
+    # Display in human-readable format
+    click.echo(click.style(f"{table.upper()} (ID: {id})", fg="green", bold=True))
+
+    # Display the data in a table format
+    table_data = []
+    for key, value in result.items():
+        if key == "recent_logs":
+            continue  # Handle logs separately
+        table_data.append([key, value])
+
+    click.echo(tabulate(table_data, headers=["Field", "Value"], tablefmt="simple"))
+
+    # Show logs if available
+    if table == "rss_feed" and result.get("recent_logs"):
+        click.echo(click.style("\nRecent Processing Logs:", fg="cyan", bold=True))
+
+        log_table = []
+        for log in result["recent_logs"]:
+            status_str = log["status"]
+
+            log_table.append(
+                [
+                    log["id"],
+                    log["started_at"],
+                    log["completed_at"] or "",
+                    status_str,
+                    log["articles_found"] or 0,
+                    log["articles_added"] or 0,
+                    log["error_message"] or "",
+                ]
+            )
+
+        log_headers = ["ID", "Started At", "Completed At", "Status", "Found", "Added", "Error"]
+        click.echo(tabulate(log_table, headers=log_headers, tablefmt="simple"))
+
+
+@db_group.command(name="purge-duplicates")
+@click.option(
+    "--dry-run", is_flag=True, help="Show what would be deleted without actually deleting"
+)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.confirmation_option(prompt="This will delete duplicate articles. Are you sure?")
+@click.pass_context
+def purge_duplicates(ctx, dry_run: bool, json_output: bool):
+    """Remove duplicate articles, keeping the oldest version."""
+    client = ctx.obj["client"]
+
+    try:
+        with client:
+            result = client.purge_duplicates(dry_run=dry_run)
+    except NewsifierAPIError as e:
+        click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    # Output results
+    if json_output:
+        click.echo(json.dumps(result, indent=2))
+        return
+
+    # Display in human-readable format
+    action_text = "Would remove" if dry_run else "Removed"
+    msg = f"{action_text} {result['total_removed']} duplicate articles "
+    msg += f"across {result['total_urls']} URLs"
+    click.echo(
+        click.style(
+            msg,
+            fg="green" if not dry_run else "yellow",
+            bold=True,
+        )
+    )
+
+    if dry_run:
+        click.echo(click.style("(DRY RUN - No changes were made)", fg="yellow"))
+
+    for detail in result["details"]:
+        click.echo(f"\nURL: {detail['url']}")
+        click.echo(f"  Kept article ID: {detail['kept_id']}")
+        click.echo(f"  Removed article IDs: {', '.join(map(str, detail['removed_ids']))}")

--- a/src/local_newsifier/cli/commands/feeds_http.py
+++ b/src/local_newsifier/cli/commands/feeds_http.py
@@ -1,0 +1,338 @@
+"""
+RSS Feeds management commands using HTTP client.
+
+This module provides commands for managing RSS feeds through HTTP API:
+- Listing feeds
+- Adding new feeds
+- Showing feed details
+- Removing feeds
+- Processing feeds
+- Fetching all active feeds
+- Updating feed properties
+"""
+
+import json
+import sys
+
+import click
+from tabulate import tabulate
+
+from local_newsifier.cli.http_client import NewsifierAPIError, NewsifierClient
+
+
+@click.group(name="feeds")
+@click.pass_context
+def feeds_group(ctx):
+    """Manage RSS feeds."""
+    # Initialize HTTP client in context
+    ctx.ensure_object(dict)
+    api_url = ctx.obj.get("api_url")
+    ctx.obj["client"] = NewsifierClient(base_url=api_url)
+
+
+@feeds_group.command(name="list")
+@click.option("--active-only", is_flag=True, help="Show only active feeds")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.option("--limit", type=int, default=100, help="Maximum number of feeds to display")
+@click.option("--skip", type=int, default=0, help="Number of feeds to skip")
+@click.pass_context
+def list_feeds(ctx, active_only, json_output, limit, skip):
+    """List all feeds with optional filtering."""
+    client = ctx.obj["client"]
+
+    try:
+        with client:
+            feeds = client.list_feeds(active_only=active_only, limit=limit, skip=skip)
+    except NewsifierAPIError as e:
+        click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps(feeds, indent=2))
+        return
+
+    if not feeds:
+        click.echo("No feeds found.")
+        return
+
+    # Format data for table
+    table_data = []
+    for feed in feeds:
+        table_data.append(
+            [
+                feed["id"],
+                feed["name"],
+                feed["url"][:50] + "..." if len(feed["url"]) > 50 else feed["url"],
+                "✓" if feed["is_active"] else "✗",
+                feed.get("last_fetched_at", "Never"),
+            ]
+        )
+
+    headers = ["ID", "Name", "URL", "Active", "Last Fetched"]
+    click.echo(tabulate(table_data, headers=headers, tablefmt="simple"))
+    click.echo(f"\nTotal feeds: {len(feeds)}")
+
+
+@feeds_group.command(name="add")
+@click.argument("url")
+@click.option("--name", help="Custom name for the feed")
+@click.option("--description", help="Description of the feed")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def add_feed(ctx, url, name, description, json_output):
+    """Add a new RSS feed."""
+    client = ctx.obj["client"]
+
+    try:
+        with client:
+            feed = client.add_feed(url=url, name=name, description=description)
+    except NewsifierAPIError as e:
+        if e.status_code == 400:
+            click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        else:
+            click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps(feed, indent=2))
+        return
+
+    click.echo(click.style(f"✓ Added feed: {feed['name']} (ID: {feed['id']})", fg="green"))
+
+
+@feeds_group.command(name="show")
+@click.argument("feed_id", type=int)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def show_feed(ctx, feed_id, json_output):
+    """Show details for a specific feed."""
+    client = ctx.obj["client"]
+
+    try:
+        with client:
+            feed = client.get_feed(feed_id)
+    except NewsifierAPIError as e:
+        if e.status_code == 404:
+            click.echo(click.style(f"Error: Feed with ID {feed_id} not found", fg="red"), err=True)
+        else:
+            click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps(feed, indent=2))
+        return
+
+    # Display feed details
+    click.echo(click.style(f"Feed Details (ID: {feed['id']})", fg="green", bold=True))
+    click.echo(f"Name: {feed['name']}")
+    click.echo(f"URL: {feed['url']}")
+    if feed.get("description"):
+        click.echo(f"Description: {feed['description']}")
+    click.echo(f"Active: {'Yes' if feed['is_active'] else 'No'}")
+    click.echo(f"Created: {feed['created_at']}")
+    click.echo(f"Updated: {feed['updated_at']}")
+    click.echo(f"Last Fetched: {feed.get('last_fetched_at', 'Never')}")
+
+    # Show recent logs if available
+    if feed.get("recent_logs"):
+        click.echo(click.style("\nRecent Processing Logs:", fg="cyan", bold=True))
+
+        log_table = []
+        for log in feed["recent_logs"]:
+            log_table.append(
+                [
+                    log["id"],
+                    log["started_at"],
+                    log["completed_at"] or "In Progress",
+                    log["status"],
+                    log["articles_found"] or 0,
+                    log["articles_added"] or 0,
+                ]
+            )
+
+        log_headers = ["ID", "Started At", "Completed At", "Status", "Found", "Added"]
+        click.echo(tabulate(log_table, headers=log_headers, tablefmt="simple"))
+
+
+@feeds_group.command(name="remove")
+@click.argument("feed_id", type=int)
+@click.confirmation_option(prompt="Are you sure you want to remove this feed?")
+@click.pass_context
+def remove_feed(ctx, feed_id):
+    """Remove a feed."""
+    client = ctx.obj["client"]
+
+    try:
+        with client:
+            result = client.delete_feed(feed_id)
+    except NewsifierAPIError as e:
+        if e.status_code == 404:
+            click.echo(click.style(f"Error: Feed with ID {feed_id} not found", fg="red"), err=True)
+        else:
+            click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    click.echo(click.style(f"✓ {result['message']}", fg="green"))
+
+
+@feeds_group.command(name="update")
+@click.argument("feed_id", type=int)
+@click.option("--name", help="New name for the feed")
+@click.option("--description", help="New description for the feed")
+@click.option("--active/--inactive", default=None, help="Set feed active status")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def update_feed(ctx, feed_id, name, description, active, json_output):
+    """Update feed properties."""
+    client = ctx.obj["client"]
+
+    # Check if any update was provided
+    if name is None and description is None and active is None:
+        click.echo(
+            click.style(
+                "Error: No updates provided. Use --name, --description, or --active/--inactive",
+                fg="red",
+            ),
+            err=True,
+        )
+        sys.exit(1)
+
+    try:
+        with client:
+            feed = client.update_feed(
+                feed_id=feed_id, name=name, description=description, is_active=active
+            )
+    except NewsifierAPIError as e:
+        if e.status_code == 404:
+            click.echo(click.style(f"Error: Feed with ID {feed_id} not found", fg="red"), err=True)
+        else:
+            click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps(feed, indent=2))
+        return
+
+    click.echo(click.style(f"✓ Updated feed: {feed['name']} (ID: {feed['id']})", fg="green"))
+    if name:
+        click.echo(f"  Name: {feed['name']}")
+    if description is not None:
+        click.echo(f"  Description: {feed['description'] or '(removed)'}")
+    if active is not None:
+        click.echo(f"  Active: {'Yes' if feed['is_active'] else 'No'}")
+
+
+@feeds_group.command(name="process")
+@click.argument("feed_id", type=int)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def process_feed(ctx, feed_id, json_output):
+    """Process a specific feed immediately."""
+    client = ctx.obj["client"]
+
+    click.echo(f"Processing feed {feed_id}...")
+
+    try:
+        with client:
+            result = client.process_feed(feed_id)
+    except NewsifierAPIError as e:
+        if e.status_code == 404:
+            click.echo(click.style(f"Error: Feed with ID {feed_id} not found", fg="red"), err=True)
+        else:
+            click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps(result, indent=2))
+        return
+
+    # Display processing results
+    status = result.get("status", "unknown")
+    if status == "success":
+        click.echo(click.style("✓ Feed processed successfully", fg="green"))
+        click.echo(f"  Articles found: {result.get('articles_found', 0)}")
+        click.echo(f"  Articles added: {result.get('articles_added', 0)}")
+        if result.get("message"):
+            click.echo(f"  Message: {result['message']}")
+    else:
+        click.echo(click.style(f"✗ Feed processing failed: {status}", fg="red"))
+        if result.get("error"):
+            click.echo(f"  Error: {result['error']}")
+
+
+@feeds_group.command(name="fetch-all")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def fetch_all_feeds(ctx, json_output):
+    """Process all active feeds."""
+    client = ctx.obj["client"]
+
+    click.echo("Processing all active feeds...")
+
+    try:
+        with client:
+            result = client.process_all_feeds()
+    except NewsifierAPIError as e:
+        click.echo(click.style(f"Error: {e.detail}", fg="red"), err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(click.style(f"Unexpected error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps(result, indent=2))
+        return
+
+    # Display summary
+    total_processed = result.get("processed", 0)
+    click.echo(click.style(f"\n✓ Processed {total_processed} feeds", fg="green", bold=True))
+
+    if result.get("results"):
+        # Show results table
+        table_data = []
+        total_found = 0
+        total_added = 0
+
+        for feed_result in result["results"]:
+            status = feed_result.get("status", "unknown")
+            found = feed_result.get("articles_found", 0)
+            added = feed_result.get("articles_added", 0)
+
+            table_data.append(
+                [
+                    feed_result.get("feed_id", "?"),
+                    feed_result.get("feed_name", "Unknown"),
+                    status,
+                    found,
+                    added,
+                    feed_result.get("error", "") if status != "success" else "",
+                ]
+            )
+
+            total_found += found
+            total_added += added
+
+        headers = ["Feed ID", "Name", "Status", "Found", "Added", "Error"]
+        click.echo("\n" + tabulate(table_data, headers=headers, tablefmt="simple"))
+
+        # Summary
+        click.echo(f"\nTotal articles found: {total_found}")
+        click.echo(f"Total articles added: {total_added}")

--- a/src/local_newsifier/cli/http_client.py
+++ b/src/local_newsifier/cli/http_client.py
@@ -1,0 +1,192 @@
+"""
+HTTP Client for CLI commands to communicate with FastAPI backend.
+
+This client provides a clean interface for CLI commands to communicate with
+the FastAPI backend, eliminating event loop conflicts and direct dependency injection.
+"""
+
+import os
+from typing import Any, Dict, List, Optional
+
+import httpx
+from httpx import ConnectError, HTTPStatusError, TimeoutException
+
+
+class NewsifierAPIError(Exception):
+    """Custom exception for API errors."""
+
+    def __init__(self, status_code: int, detail: str):
+        """Initialize the API error with status code and detail."""
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"API Error ({status_code}): {detail}")
+
+
+class NewsifierClient:
+    """Synchronous HTTP client for Local Newsifier API."""
+
+    def __init__(
+        self, base_url: Optional[str] = None, timeout: float = 30.0, local_mode: bool = False
+    ):
+        """Initialize the client.
+
+        Args:
+            base_url: Base URL for the API. Defaults to env var or localhost.
+            timeout: Request timeout in seconds.
+            local_mode: If True, use TestClient for local testing (not implemented yet).
+        """
+        self.base_url = base_url or os.getenv("NEWSIFIER_API_URL", "http://localhost:8000")
+        self.timeout = timeout
+        self.local_mode = local_mode
+        self._client = None
+
+    def __enter__(self):
+        """Context manager entry."""
+        self._client = httpx.Client(base_url=self.base_url, timeout=self.timeout)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        if self._client:
+            self._client.close()
+
+    @property
+    def client(self) -> httpx.Client:
+        """Get the HTTP client, creating one if needed."""
+        if not self._client:
+            self._client = httpx.Client(base_url=self.base_url, timeout=self.timeout)
+        return self._client
+
+    def _handle_response(self, response: httpx.Response) -> Dict[str, Any]:
+        """Handle API response and raise exceptions for errors."""
+        try:
+            response.raise_for_status()
+            return response.json()
+        except HTTPStatusError as e:
+            # Try to extract error detail from response
+            try:
+                error_detail = e.response.json().get("detail", str(e))
+            except Exception:
+                error_detail = str(e)
+            raise NewsifierAPIError(e.response.status_code, error_detail)
+        except Exception as e:
+            # Handle other errors
+            raise NewsifierAPIError(500, str(e))
+
+    # Database commands
+
+    def get_db_stats(self) -> Dict[str, Any]:
+        """Get database statistics."""
+        response = self.client.get("/db/stats")
+        return self._handle_response(response)
+
+    def get_duplicates(self, limit: int = 10) -> List[Dict[str, Any]]:
+        """Get duplicate articles."""
+        response = self.client.get("/db/duplicates", params={"limit": limit})
+        return self._handle_response(response)
+
+    def list_articles(
+        self,
+        source: Optional[str] = None,
+        status: Optional[str] = None,
+        before: Optional[str] = None,
+        after: Optional[str] = None,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """List articles with filtering options."""
+        params = {"limit": limit}
+        if source:
+            params["source"] = source
+        if status:
+            params["status"] = status
+        if before:
+            params["before"] = before
+        if after:
+            params["after"] = after
+
+        response = self.client.get("/db/articles", params=params)
+        return self._handle_response(response)
+
+    def inspect_record(self, table: str, id: int) -> Dict[str, Any]:
+        """Inspect a specific database record."""
+        response = self.client.get(f"/db/inspect/{table}/{id}")
+        return self._handle_response(response)
+
+    def purge_duplicates(self, dry_run: bool = True) -> Dict[str, Any]:
+        """Remove duplicate articles."""
+        response = self.client.post("/db/purge-duplicates", json={"dry_run": dry_run})
+        return self._handle_response(response)
+
+    # RSS Feed commands
+
+    def list_feeds(
+        self, active_only: bool = False, limit: int = 100, skip: int = 0
+    ) -> List[Dict[str, Any]]:
+        """List RSS feeds."""
+        params = {"limit": limit, "skip": skip, "active_only": active_only}
+        response = self.client.get("/feeds", params=params)
+        return self._handle_response(response)
+
+    def get_feed(self, feed_id: int) -> Dict[str, Any]:
+        """Get a specific RSS feed."""
+        response = self.client.get(f"/feeds/{feed_id}")
+        return self._handle_response(response)
+
+    def add_feed(
+        self, url: str, name: Optional[str] = None, description: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Add a new RSS feed."""
+        data = {"url": url}
+        if name:
+            data["name"] = name
+        if description:
+            data["description"] = description
+
+        response = self.client.post("/feeds", json=data)
+        return self._handle_response(response)
+
+    def update_feed(
+        self,
+        feed_id: int,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_active: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Update an RSS feed."""
+        data = {}
+        if name is not None:
+            data["name"] = name
+        if description is not None:
+            data["description"] = description
+        if is_active is not None:
+            data["is_active"] = is_active
+
+        response = self.client.patch(f"/feeds/{feed_id}", json=data)
+        return self._handle_response(response)
+
+    def delete_feed(self, feed_id: int) -> Dict[str, Any]:
+        """Delete an RSS feed."""
+        response = self.client.delete(f"/feeds/{feed_id}")
+        return self._handle_response(response)
+
+    def process_feed(self, feed_id: int) -> Dict[str, Any]:
+        """Process a specific RSS feed."""
+        response = self.client.post(f"/feeds/{feed_id}/process")
+        return self._handle_response(response)
+
+    def process_all_feeds(self) -> Dict[str, Any]:
+        """Process all active RSS feeds."""
+        response = self.client.post("/feeds/process-all")
+        return self._handle_response(response)
+
+    # Health check
+
+    def health_check(self) -> Dict[str, Any]:
+        """Check API health status."""
+        try:
+            response = self.client.get("/health")
+            return self._handle_response(response)
+        except ConnectError:
+            raise NewsifierAPIError(503, "Cannot connect to API server")
+        except TimeoutException:
+            raise NewsifierAPIError(504, "Request timed out")

--- a/src/local_newsifier/cli/main_http.py
+++ b/src/local_newsifier/cli/main_http.py
@@ -1,0 +1,80 @@
+"""
+Local Newsifier CLI - Main Entry Point with HTTP client support.
+
+The `nf` command is the entry point for the Local Newsifier CLI.
+This version uses HTTP client to communicate with the FastAPI backend,
+eliminating event loop conflicts.
+"""
+
+import sys
+
+import click
+
+
+@click.group()
+@click.version_option(version="0.1.0")
+@click.option("--api-url", envvar="NEWSIFIER_API_URL", help="API base URL")
+@click.pass_context
+def cli(ctx, api_url):
+    """
+    Local Newsifier CLI - A tool for managing local news data.
+
+    This CLI provides commands for managing RSS feeds, processing articles,
+    and analyzing news data through HTTP API.
+    """
+    # Store API URL in context for child commands
+    ctx.ensure_object(dict)
+    ctx.obj["api_url"] = api_url
+
+
+def is_apify_command():
+    """Check if the user is trying to run an apify command.
+
+    This helps us avoid loading dependencies that have SQLite requirements
+    when they're not needed.
+
+    Returns:
+        bool: True if the command is apify-related
+    """
+    # Check if 'apify' is in the command arguments
+    return len(sys.argv) > 1 and (sys.argv[1] == "apify" or sys.argv[1] == "apify-config")
+
+
+# Load HTTP-based command groups
+from local_newsifier.cli.commands.db_http import db_group
+from local_newsifier.cli.commands.feeds_http import feeds_group
+
+cli.add_command(feeds_group)
+cli.add_command(db_group)
+
+# TODO: Migrate apify commands to HTTP when ready
+if is_apify_command():
+    # Only load the apify command if it's being used
+    if sys.argv[1] == "apify":
+        from local_newsifier.cli.commands.apify import apify_group
+
+        cli.add_command(apify_group)
+    elif sys.argv[1] == "apify-config":
+        from local_newsifier.cli.commands.apify_config import apify_config_group
+
+        cli.add_command(apify_config_group)
+else:
+    # Load apify commands for help display
+    from local_newsifier.cli.commands.apify import apify_group
+    from local_newsifier.cli.commands.apify_config import apify_config_group
+
+    cli.add_command(apify_group)
+    cli.add_command(apify_config_group)
+
+
+def main():
+    """Run the CLI application."""
+    try:
+        cli()
+    except Exception as e:
+        click.echo(click.style(f"Error: {str(e)}", fg="red"), err=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cli/test_http_client.py
+++ b/tests/cli/test_http_client.py
@@ -1,0 +1,154 @@
+"""Tests for the NewsifierClient HTTP client."""
+
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+from local_newsifier.cli.http_client import NewsifierAPIError, NewsifierClient
+
+
+class TestNewsifierClient:
+    """Test cases for NewsifierClient."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a test client."""
+        return NewsifierClient(base_url="http://test.local")
+
+    def test_client_initialization(self):
+        """Test client initialization with different parameters."""
+        # Default initialization
+        client = NewsifierClient()
+        assert client.base_url == "http://localhost:8000"
+        assert client.timeout == 30.0
+        assert client.local_mode is False
+
+        # Custom initialization
+        client = NewsifierClient(base_url="http://custom.local", timeout=60.0, local_mode=True)
+        assert client.base_url == "http://custom.local"
+        assert client.timeout == 60.0
+        assert client.local_mode is True
+
+    def test_context_manager(self, client):
+        """Test context manager functionality."""
+        with client as c:
+            assert c._client is not None
+            assert isinstance(c._client, httpx.Client)
+        # Client should be closed after context
+        assert c._client.is_closed
+
+    @patch("httpx.Client.get")
+    def test_get_db_stats(self, mock_get, client):
+        """Test getting database statistics."""
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"articles": {"count": 100}, "rss_feeds": {"count": 10}}
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        with client:
+            stats = client.get_db_stats()
+
+        assert stats["articles"]["count"] == 100
+        assert stats["rss_feeds"]["count"] == 10
+        mock_get.assert_called_once_with("/db/stats")
+
+    @patch("httpx.Client.get")
+    def test_api_error_handling(self, mock_get, client):
+        """Test API error handling."""
+        # Mock error response
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.json.return_value = {"detail": "Not found"}
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404 Not Found", request=Mock(), response=mock_response
+        )
+        mock_get.return_value = mock_response
+
+        with client:
+            with pytest.raises(NewsifierAPIError) as exc_info:
+                client.get_db_stats()
+
+        assert exc_info.value.status_code == 404
+        assert "Not found" in str(exc_info.value)
+
+    @patch("httpx.Client.get")
+    def test_list_articles_with_filters(self, mock_get, client):
+        """Test listing articles with filters."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"id": 1, "title": "Article 1"},
+            {"id": 2, "title": "Article 2"},
+        ]
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        with client:
+            articles = client.list_articles(source="rss", status="processed", limit=5)
+
+        assert len(articles) == 2
+        assert articles[0]["title"] == "Article 1"
+
+        # Check that parameters were passed correctly
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        assert call_args[0][0] == "/db/articles"
+        assert call_args[1]["params"]["source"] == "rss"
+        assert call_args[1]["params"]["status"] == "processed"
+        assert call_args[1]["params"]["limit"] == 5
+
+    @patch("httpx.Client.post")
+    def test_add_feed(self, mock_post, client):
+        """Test adding a new RSS feed."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": 1,
+            "name": "Test Feed",
+            "url": "http://example.com/rss",
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        with client:
+            feed = client.add_feed(url="http://example.com/rss", name="Test Feed")
+
+        assert feed["id"] == 1
+        assert feed["name"] == "Test Feed"
+
+        # Check request
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert call_args[0][0] == "/feeds"
+        assert call_args[1]["json"]["url"] == "http://example.com/rss"
+        assert call_args[1]["json"]["name"] == "Test Feed"
+
+    @patch("httpx.Client.delete")
+    def test_delete_feed(self, mock_delete, client):
+        """Test deleting a feed."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"message": "Feed deleted successfully"}
+        mock_response.raise_for_status = Mock()
+        mock_delete.return_value = mock_response
+
+        with client:
+            result = client.delete_feed(1)
+
+        assert "Feed deleted successfully" in result["message"]
+        mock_delete.assert_called_once_with("/feeds/1")
+
+    @patch("httpx.Client.get")
+    def test_health_check_connection_error(self, mock_get, client):
+        """Test health check with connection error."""
+        mock_get.side_effect = httpx.ConnectError("Connection refused")
+
+        with client:
+            with pytest.raises(NewsifierAPIError) as exc_info:
+                client.health_check()
+
+        assert exc_info.value.status_code == 503
+        assert "Cannot connect" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- Implements the first phase of CLI-to-HTTP migration to eliminate event loop conflicts
- Creates HTTP client and API endpoints for database and RSS feed operations
- Adds new `nf-http` command for testing the HTTP-based CLI

## Changes
1. **HTTP Client**: Created `NewsifierClient` class for CLI commands to communicate with FastAPI backend
2. **API Endpoints**: 
   - Added database operation endpoints (stats, duplicates, articles, inspect, purge-duplicates)
   - Added RSS feed CRUD and processing endpoints
3. **CLI Commands**: 
   - Created HTTP-based versions of `db` and `feeds` commands
   - New entry point `nf-http` for testing (existing `nf` command remains unchanged)
4. **Tests**: Basic test coverage for the HTTP client

## Benefits
- Eliminates event loop conflicts between CLI and async code
- Clear separation between CLI and API layers
- Foundation for future remote CLI access and distributed deployment

## Test plan
- [ ] Run tests locally to ensure no regressions
- [ ] Test new `nf-http` commands work with a running API server
- [ ] Verify existing `nf` commands continue to work unchanged
- [ ] Check that pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)