### PR TITLE
Convert Apify webhook route from async to sync (Issue #721)

### DIFF
--- a/GAMEPLAN.md
+++ b/GAMEPLAN.md
@@ -1,0 +1,128 @@
+# FastAPI Async to Sync Conversion Gameplan
+
+## Overview
+This document outlines the systematic approach to convert all FastAPI routes and dependencies from async to sync patterns. The conversion will be done in phases to ensure stability and testability at each step.
+
+## Phase 1: Remove Async Services and Dependencies
+
+### 1.1 Convert Async Service Classes
+- [ ] Convert `apify_webhook_service_async.py` to sync
+  - Remove all `async/await` keywords
+  - Replace `AsyncSession` with `Session`
+  - Update method signatures
+- [ ] Convert `apify_service_async.py` to sync (or remove if duplicate of sync version)
+- [ ] Remove/convert `async_article.py` CRUD module
+- [ ] Update `async_base.py` if still in use
+
+### 1.2 Update Async Providers
+- [ ] Check `di/async_providers.py` and convert any async providers to sync
+- [ ] Update provider functions to return sync instances
+
+### 1.3 Database Engine Updates
+- [ ] Review `database/async_engine.py` and ensure all async patterns are removed
+- [ ] Update any async session factories to sync
+
+## Phase 2: Convert Application Lifecycle
+
+### 2.1 Main Application File (`api/main.py`)
+- [ ] Convert `lifespan` context manager from async to sync
+  - Remove `async` keyword
+  - Update any startup/shutdown logic
+- [ ] Convert `register_app` function to sync
+- [ ] Update exception handler (`not_found_handler`) to sync
+
+## Phase 3: Convert Route Handlers
+
+### 3.1 Authentication Routes (`routers/auth.py`)
+- [ ] Convert `login_page()` to sync
+- [ ] Convert `login()` to sync
+- [ ] Convert `logout()` to sync
+
+### 3.2 System Routes (`routers/system.py`)
+- [ ] Convert `get_tables()` to sync
+- [ ] Convert `get_tables_api()` to sync
+- [ ] Convert `get_table_details()` to sync
+- [ ] Convert `get_table_details_api()` to sync
+
+### 3.3 Task Routes (`routers/tasks.py`)
+- [ ] Convert `tasks_dashboard()` to sync
+- [ ] Convert `process_article_endpoint()` to sync
+- [ ] Convert `fetch_rss_feeds_endpoint()` to sync
+- [ ] Convert `get_task_status()` to sync
+- [ ] Convert `cancel_task()` to sync
+
+### 3.4 Webhook Routes (`routers/webhooks.py`)
+- [x] Convert `apify_webhook()` to sync
+- [x] Replace `await request.body()` with `request.body`
+- [x] Update webhook service calls to use sync version
+
+### 3.5 Main Routes (`api/main.py`)
+- [ ] Convert `root()` to sync
+- [ ] Convert `health_check()` to sync
+- [ ] Convert `get_config()` to sync
+
+## Phase 4: Update Tests
+
+### 4.1 API Tests
+- [ ] Update `tests/api/test_auth.py` to remove async patterns
+- [ ] Update `tests/api/test_system.py` to remove async patterns
+- [ ] Update `tests/api/test_tasks.py` to remove async patterns
+- [ ] Update `tests/api/test_webhooks.py` to remove async patterns
+- [ ] Update `tests/api/test_main.py` to remove async patterns
+
+### 4.2 Service Tests
+- [ ] Update tests for converted async services
+- [ ] Remove any async test fixtures
+
+## Phase 5: Cleanup and Optimization
+
+### 5.1 Remove Async Dependencies
+- [ ] Remove `httpx` async client usage (switch to `requests`)
+- [ ] Remove `asyncio` imports
+- [ ] Update `requirements.txt` if needed
+
+### 5.2 Update Documentation
+- [ ] Update API documentation to reflect sync patterns
+- [ ] Update CLAUDE.md files in affected directories
+- [ ] Update any example code in docs
+
+## Implementation Order
+
+1. **Start with services** (Phase 1) - Convert underlying async services first
+2. **Update lifecycle** (Phase 2) - Convert app startup/shutdown
+3. **Convert routes bottom-up** (Phase 3) - Start with simple routes, move to complex
+4. **Update tests incrementally** (Phase 4) - Test each converted component
+5. **Final cleanup** (Phase 5) - Remove unused async code
+
+## Testing Strategy
+
+After each phase:
+1. Run the full test suite: `make test`
+2. Test the API manually with key endpoints
+3. Check for any deprecation warnings
+4. Verify no async runtime errors
+
+## Rollback Plan
+
+- Create a new branch for this work: `convert-fastapi-to-sync`
+- Commit after each successful phase
+- Tag stable points for easy rollback
+- Keep async versions temporarily with `_async` suffix until fully migrated
+
+## Success Criteria
+
+- [ ] All `async def` converted to `def` in API routes
+- [ ] No `await` keywords in API code
+- [ ] All tests passing
+- [ ] No async runtime warnings
+- [ ] API performance maintained or improved
+- [ ] Code coverage maintained at >90%
+
+## Notes
+
+- FastAPI supports both sync and async handlers natively
+- Sync handlers may be more performant for I/O-bound database operations
+- This aligns with the project's move away from async patterns
+- Celery tasks remain unaffected as they're already sync
+- During transition, duplicate sync services are created with "_sync" suffix to avoid conflicts:
+  - `apify_webhook_service_sync.py` (duplicate of `apify_webhook_service.py` for clarity)

--- a/src/local_newsifier/api/routers/webhooks.py
+++ b/src/local_newsifier/api/routers/webhooks.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
     summary="Receive Apify webhook notifications",
     description="Endpoint for receiving webhook notifications from Apify when runs complete",
 )
-async def apify_webhook(
+def apify_webhook(
     request: Request,
     session: Annotated[Session, Depends(get_session)],
     apify_webhook_signature: Annotated[str | None, Header()] = None,
@@ -53,7 +53,7 @@ async def apify_webhook(
     """
     try:
         # Get raw payload for signature validation
-        raw_payload = await request.body()
+        raw_payload = request.body()
         raw_payload_str = raw_payload.decode("utf-8")
 
         # Parse payload

--- a/src/local_newsifier/services/apify_webhook_service_sync.py
+++ b/src/local_newsifier/services/apify_webhook_service_sync.py
@@ -1,0 +1,177 @@
+"""Sync Apify webhook service for handling webhook notifications.
+
+This is a duplicate of the existing sync ApifyWebhookService but renamed
+to clearly distinguish it from the async version during the transition.
+"""
+
+import hashlib
+import hmac
+import logging
+from datetime import UTC, datetime
+from typing import Dict, Optional
+
+from sqlmodel import Session, select
+
+from local_newsifier.crud.article import article
+from local_newsifier.models.apify import ApifyWebhookRaw
+from local_newsifier.models.article import Article
+from local_newsifier.services.apify_service import ApifyService
+
+logger = logging.getLogger(__name__)
+
+
+class ApifyWebhookServiceSync:
+    """Sync service for handling Apify webhooks."""
+
+    def __init__(self, session: Session, webhook_secret: Optional[str] = None):
+        """Initialize webhook service.
+
+        Args:
+            session: Database session
+            webhook_secret: Optional webhook secret for signature validation
+        """
+        self.session = session
+        self.webhook_secret = webhook_secret
+        self.apify_service = ApifyService()
+
+    def validate_signature(self, payload: str, signature: str) -> bool:
+        """Validate webhook signature.
+
+        Args:
+            payload: Raw webhook payload string
+            signature: Signature from Apify-Webhook-Signature header
+
+        Returns:
+            bool: True if signature is valid or no secret configured
+        """
+        if not self.webhook_secret:
+            return True
+
+        expected_signature = hmac.new(
+            self.webhook_secret.encode(), payload.encode(), hashlib.sha256
+        ).hexdigest()
+
+        return hmac.compare_digest(expected_signature, signature)
+
+    def handle_webhook(
+        self, payload: Dict[str, any], raw_payload: str, signature: Optional[str] = None
+    ) -> Dict[str, any]:
+        """Handle incoming webhook notification.
+
+        Args:
+            payload: Parsed webhook payload
+            raw_payload: Raw webhook payload string for signature validation
+            signature: Optional signature header value
+
+        Returns:
+            Dict with status and any error information
+        """
+        # Validate signature if provided
+        if signature and not self.validate_signature(raw_payload, signature):
+            logger.warning("Invalid webhook signature")
+            return {"status": "error", "message": "Invalid signature"}
+
+        # Extract key fields
+        run_id = payload.get("actorRunId", "")
+        actor_id = payload.get("actorId", "")
+        status = payload.get("status", "")
+
+        if not all([run_id, actor_id, status]):
+            logger.warning("Missing required webhook fields")
+            return {"status": "error", "message": "Missing required fields"}
+
+        # Check for duplicate
+        existing = self.session.exec(
+            select(ApifyWebhookRaw).where(ApifyWebhookRaw.run_id == run_id)
+        ).first()
+
+        if existing:
+            logger.info(f"Duplicate webhook for run_id: {run_id}")
+            return {"status": "ok", "message": "Duplicate webhook ignored"}
+
+        # Convert datetime strings to string format for JSON storage
+        # This avoids timezone issues when storing in JSONB
+        payload_copy = payload.copy()
+        for field in ["createdAt", "startedAt", "finishedAt"]:
+            if field in payload_copy and payload_copy[field]:
+                # Keep datetime strings as strings in the JSON field
+                # This preserves the original format and avoids timezone issues
+                pass
+
+        # Save raw webhook data
+        webhook_raw = ApifyWebhookRaw(
+            run_id=run_id, actor_id=actor_id, status=status, data=payload_copy
+        )
+        self.session.add(webhook_raw)
+
+        # If successful run, try to create articles
+        articles_created = 0
+        if status == "SUCCEEDED":
+            try:
+                dataset_id = payload.get("defaultDatasetId")
+                if dataset_id:
+                    articles_created = self._create_articles_from_dataset(dataset_id)
+            except Exception as e:
+                logger.error(f"Error creating articles from webhook: {e}")
+                # Don't fail the webhook - just log the error
+
+        self.session.commit()
+
+        return {
+            "status": "ok",
+            "message": f"Webhook processed. Articles created: {articles_created}",
+            "run_id": run_id,
+            "articles_created": articles_created,
+        }
+
+    def _create_articles_from_dataset(self, dataset_id: str) -> int:
+        """Create articles from Apify dataset.
+
+        Args:
+            dataset_id: Apify dataset ID
+
+        Returns:
+            Number of articles created
+        """
+        try:
+            # Fetch dataset items
+            dataset_items = self.apify_service.client.dataset(dataset_id).list_items().items
+
+            articles_created = 0
+            for item in dataset_items:
+                # Extract fields with fallbacks
+                url = item.get("url", "")
+                title = item.get("title", "")
+                content = item.get("content", "") or item.get("text", "") or item.get("body", "")
+
+                # Skip if missing required fields
+                if not all([url, title, content]):
+                    continue
+
+                # Skip if content too short
+                if len(content) < 100:
+                    continue
+
+                # Check if article already exists
+                existing = article.get_by_url(self.session, url=url)
+                if existing:
+                    continue
+
+                # Create article
+                new_article = Article(
+                    url=url,
+                    title=title,
+                    content=content,
+                    source=item.get("source", "apify"),
+                    published_at=datetime.now(UTC).replace(tzinfo=None),
+                    status="published",
+                    scraped_at=datetime.now(UTC).replace(tzinfo=None),
+                )
+                self.session.add(new_article)
+                articles_created += 1
+
+            return articles_created
+
+        except Exception as e:
+            logger.error(f"Error fetching dataset {dataset_id}: {e}")
+            return 0


### PR DESCRIPTION
## Summary
- Converted the Apify webhook route from async to sync pattern
- Created duplicate sync service for transition period

## Changes
1. **Webhook Route Conversion**:
   - Changed \ from \ to \
   - Replaced \ with \
   - The route was already using the sync \

2. **Service Duplication**:
   - Created \ as a duplicate of the existing sync service
   - This allows us to maintain both versions during the transition

3. **Documentation**:
   - Updated GAMEPLAN.md to track progress
   - Marked webhook conversion tasks as complete

## Test Plan
- [ ] Existing webhook tests should pass
- [ ] Manual testing with webhook endpoints
- [ ] Verify no async runtime warnings

Part of the async-to-sync migration effort to simplify the codebase as outlined in #721.