### PR TITLE
Fix async webhook error (Issue #758)

### DIFF
--- a/src/local_newsifier/api/dependencies.py
+++ b/src/local_newsifier/api/dependencies.py
@@ -63,10 +63,10 @@ def get_session() -> Generator[Session, None, None]:
     Yields:
         Session: SQLModel session
     """
-    from local_newsifier.di.providers import get_session as get_injectable_session
+    from local_newsifier.database.engine import get_session as get_db_session
 
-    # Use injectable provider directly
-    yield from get_injectable_session()
+    # Use the database engine's get_session directly
+    yield from get_db_session()
 
 
 def get_article_service() -> ArticleService:

--- a/src/local_newsifier/di/providers.py
+++ b/src/local_newsifier/di/providers.py
@@ -68,7 +68,6 @@ def _make_simple_provider(obj_path: str):
 # Database providers
 
 
-@injectable(use_cache=False)
 def get_session() -> Generator[Session, None, None]:
     """Provide a database session.
 


### PR DESCRIPTION
## Summary
- Fixed the async webhook error that was preventing the `/webhooks/apify` endpoint from working correctly
- Removed the injectable decorator from the session provider to avoid event loop issues

## Problem
The `/webhooks/apify` endpoint was failing with:
```
RuntimeError: There is no current event loop in thread 'AnyIO worker thread'
```

This was happening despite all code being synchronous. The issue was caused by `fastapi-injectable` trying to resolve dependencies in a thread without an event loop.

## Solution
1. Removed `@injectable` decorator from `get_session` in `src/local_newsifier/di/providers.py`
2. Updated `src/local_newsifier/api/dependencies.py` to use the database engine's `get_session` directly
3. This provides a simpler session management approach for core dependencies

## Test Results
- ✅ Webhook endpoint now returns 202 Accepted for valid payloads
- ✅ Other API endpoints continue to work correctly
- ✅ The health check endpoint works
- ✅ Database connections are properly managed

## Example Test
```bash
curl -X POST http://localhost:8000/webhooks/apify \
  -H "Content-Type: application/json" \
  -d '{
    "createdAt": "2025-05-27T10:00:00.000Z",
    "eventType": "ACTOR.RUN.SUCCEEDED",
    "actorId": "test_actor",
    "actorRunId": "test_run_123",
    "status": "SUCCEEDED",
    "userId": "test_user",
    "defaultKeyValueStoreId": "store_123",
    "defaultDatasetId": "dataset_123",
    "startedAt": "2025-05-27T09:50:00.000Z",
    "finishedAt": "2025-05-27T10:00:00.000Z",
    "webhookId": "webhook_123"
}'
```

Response:
```json
{
  "status": "accepted",
  "message": "Webhook processed. Articles created: 0",
  "dataset_id": "dataset_123",
  "actor_id": "test_actor",
  "processing_status": "completed"
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)